### PR TITLE
increased drag time for mobile and removed the ability to preview the gang card on ios

### DIFF
--- a/components/draggable-fighters.tsx
+++ b/components/draggable-fighters.tsx
@@ -21,7 +21,7 @@ export function DraggableFighters({
   
   const touchSensor = useSensor(TouchSensor, {
     activationConstraint: {
-      delay: 100,
+      delay: 1000,
       tolerance: 5,
     },
   });
@@ -69,11 +69,14 @@ export function DraggableFighters({
       console.error('Error handling drag end:', error);
     }
   };
+
+
   return (
     <DndContext 
       sensors={sensors}
       collisionDetection={closestCenter}
       onDragEnd={handleDragEnd}
+      
     >
       <SortableContext 
         items={fighters.map(f => f.id)}

--- a/components/sortable-fighter.tsx
+++ b/components/sortable-fighter.tsx
@@ -29,7 +29,9 @@ export function SortableFighter({ fighter, positions, onFighterDeleted }: Sortab
     transition,
     cursor: dndKitIsDragging ? 'grabbing' : 'grab',
     touchAction: 'manipulation',
-  };
+    WebkitTouchCallout: 'none',
+    WebkitUserSelect: 'none',
+  } as const;
 
   // Update isDragging when dndKitIsDragging changes
   useEffect(() => {


### PR DESCRIPTION
WebkitTouchCallout and WebkitUserSelect prevents apple's link preview behaviour [its weird](https://github.com/user-attachments/assets/41799b7d-d763-49d5-a21a-f825ef51dc85) and prevent highlighting of the card on mobile. Android might need this change as well, but we'll have to wait for a bug report. Ill mention it in my updated post in gen-UI