### PR TITLE
fix: surface PostgrestError messages in server action catch blocks

### DIFF
--- a/app/actions/add-fighter.ts
+++ b/app/actions/add-fighter.ts
@@ -1185,7 +1185,7 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
     console.error('Error in addFighterToGang server action:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 } 

--- a/app/actions/add-gang-vehicle.ts
+++ b/app/actions/add-gang-vehicle.ts
@@ -219,7 +219,7 @@ export async function addGangVehicle(params: AddGangVehicleParams): Promise<AddG
     console.error('Error in addGangVehicle server action:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 }
@@ -271,7 +271,7 @@ export async function getGangVehicleTypes(gangId: string) {
     console.error('Error fetching vehicle types:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 }

--- a/app/actions/assign-vehicle-to-fighter.ts
+++ b/app/actions/assign-vehicle-to-fighter.ts
@@ -208,7 +208,7 @@ export async function assignVehicleToFighter(params: AssignVehicleToFighterParam
     console.error('Error in assignVehicleToFighter server action:', error);
     return { 
       success: false, 
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 }

--- a/app/actions/chem-alchemy.ts
+++ b/app/actions/chem-alchemy.ts
@@ -155,7 +155,7 @@ export async function createChemAlchemy({
     console.error('Error in createChemAlchemy server action:', error);
     return { 
       success: false, 
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 } 

--- a/app/actions/copy-gang.ts
+++ b/app/actions/copy-gang.ts
@@ -616,7 +616,7 @@ export async function copyGang(params: CopyGangInput): Promise<CopyGangResult> {
     console.error('Error in copyGang server action:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 } 

--- a/app/actions/create-campaign.ts
+++ b/app/actions/create-campaign.ts
@@ -71,7 +71,7 @@ export async function createCampaign({ name, campaignTypeId, trading_posts }: Cr
     console.error('Error in createCampaign server action:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unknown error occurred',
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred',
     };
   }
 }

--- a/app/actions/create-gang.ts
+++ b/app/actions/create-gang.ts
@@ -99,7 +99,7 @@ export async function createGang({
     console.error('Error in createGang server action:', error);
     return { 
       success: false, 
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 } 

--- a/app/actions/delete-vehicle.ts
+++ b/app/actions/delete-vehicle.ts
@@ -169,7 +169,7 @@ export async function deleteVehicle(params: DeleteVehicleParams): Promise<Delete
     console.error('Error in deleteVehicle server action:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 } 

--- a/app/actions/edit-fighter.ts
+++ b/app/actions/edit-fighter.ts
@@ -1005,7 +1005,7 @@ export async function editFighterStatus(params: EditFighterStatusParams): Promis
     console.error('Error in editFighterStatus server action:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 }
@@ -1072,7 +1072,7 @@ export async function updateFighterXp(params: UpdateFighterXpParams): Promise<Ed
     console.error('Error updating fighter XP:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 }
@@ -1178,7 +1178,7 @@ export async function updateFighterXpWithOoa(params: UpdateFighterXpWithOoaParam
     console.error('Error updating fighter XP with OOA:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 }
@@ -1405,7 +1405,7 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
     console.error('Error updating fighter details:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 }

--- a/app/actions/equipment.ts
+++ b/app/actions/equipment.ts
@@ -916,7 +916,7 @@ export async function buyEquipmentForFighter(params: BuyEquipmentParams): Promis
     console.error('Error in buyEquipmentForFighter server action:', error);
     return { 
       success: false, 
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 }
@@ -1129,7 +1129,7 @@ export async function deleteEquipmentFromFighter(params: DeleteEquipmentParams):
     console.error('Error in deleteEquipmentFromFighter server action:', error);
     return { 
       success: false, 
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 }

--- a/app/actions/fighter-skill-access.ts
+++ b/app/actions/fighter-skill-access.ts
@@ -89,7 +89,7 @@ export async function saveFighterSkillAccessOverrides(params: {
     console.error('Error in saveFighterSkillAccessOverrides:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 }

--- a/app/actions/move-from-stash.ts
+++ b/app/actions/move-from-stash.ts
@@ -644,7 +644,7 @@ export async function moveEquipmentFromStash(params: MoveFromStashParams): Promi
     console.error('Error in moveEquipmentFromStash server action:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 }

--- a/app/actions/move-to-stash.ts
+++ b/app/actions/move-to-stash.ts
@@ -404,7 +404,7 @@ export async function moveEquipmentToStash(params: MoveToStashParams): Promise<M
     console.error('Error in moveEquipmentToStash server action:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 }

--- a/app/actions/sell-equipment.ts
+++ b/app/actions/sell-equipment.ts
@@ -360,7 +360,7 @@ export async function sellEquipmentFromFighter(params: SellEquipmentParams): Pro
     console.error('Error in sellEquipmentFromFighter server action:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 } 

--- a/app/actions/sell-vehicle.ts
+++ b/app/actions/sell-vehicle.ts
@@ -208,7 +208,7 @@ export async function sellVehicle(params: SellVehicleParams): Promise<SellVehicl
     console.error('Error in sellVehicle server action:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 }

--- a/app/actions/unassign-vehicle.ts
+++ b/app/actions/unassign-vehicle.ts
@@ -140,7 +140,7 @@ export async function unassignVehicle(params: UnassignVehicleParams): Promise<Un
     console.error('Error in unassignVehicle server action:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 }

--- a/app/actions/update-gang-positioning.ts
+++ b/app/actions/update-gang-positioning.ts
@@ -65,7 +65,7 @@ export async function updateGangPositioning(params: UpdateGangPositioningParams)
     console.error('Error in updateGangPositioning server action:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 }

--- a/app/actions/update-gang.ts
+++ b/app/actions/update-gang.ts
@@ -474,7 +474,7 @@ export async function updateGang(params: UpdateGangParams): Promise<UpdateGangRe
     console.error('Error in updateGang server action:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 }

--- a/app/actions/update-vehicle.ts
+++ b/app/actions/update-vehicle.ts
@@ -193,7 +193,7 @@ export async function updateVehicle(params: UpdateVehicleParams): Promise<Update
     console.error('Error in updateVehicle server action:', error);
     return {
       success: false,
-      error: error instanceof Error ? error.message : 'An unknown error occurred'
+      error: error instanceof Error ? error.message : (error as any)?.message || 'An unknown error occurred'
     };
   }
 } 


### PR DESCRIPTION
PostgrestError is a plain object with a .message property but does not extend Error, causing instanceof Error checks to return false and swallow real database error messages. Now falls back to (error as any)?.message before the generic unknown error string.

https://claude.ai/code/session_015e9UJUJLVfJiEw6HN37kyF