### PR TITLE
Fix FK violation when editing fighter to a custom fighter type

### DIFF
--- a/app/actions/edit-fighter.ts
+++ b/app/actions/edit-fighter.ts
@@ -53,7 +53,8 @@ export interface UpdateFighterDetailsParams {
   fighter_class?: string;
   fighter_class_id?: string;
   fighter_type?: string;
-  fighter_type_id?: string;
+  fighter_type_id?: string | null;
+  custom_fighter_type_id?: string | null;
   fighter_sub_type?: string | null;
   fighter_sub_type_id?: string | null;
   note?: string;
@@ -1221,6 +1222,7 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
     if (params.fighter_class_id !== undefined) updateData.fighter_class_id = params.fighter_class_id;
     if (params.fighter_type !== undefined) updateData.fighter_type = params.fighter_type;
     if (params.fighter_type_id !== undefined) updateData.fighter_type_id = params.fighter_type_id;
+    if (params.custom_fighter_type_id !== undefined) updateData.custom_fighter_type_id = params.custom_fighter_type_id;
     if (params.fighter_sub_type !== undefined) updateData.fighter_sub_type = params.fighter_sub_type;
     if (params.fighter_sub_type_id !== undefined) updateData.fighter_sub_type_id = params.fighter_sub_type_id;
     if (params.note !== undefined) updateData.note = params.note;

--- a/components/fighter/edit-fighter/fighter-edit-modal.tsx
+++ b/components/fighter/edit-fighter/fighter-edit-modal.tsx
@@ -142,6 +142,7 @@ export function EditFighterModal({
     fighter_sub_type?: string;
     fighter_sub_type_id?: string;
     available_legacies?: Array<{id: string; name: string}>;
+    is_custom_fighter?: boolean;
   }>>([]);
   const [isLoadingFighterTypes, setIsLoadingFighterTypes] = useState(false);
   const [fighterTypesError, setFighterTypesError] = useState<string | null>(null);
@@ -399,7 +400,8 @@ export function EditFighterModal({
           fighter_sub_type: type.sub_type?.sub_type_name || null,
           fighter_sub_type_id: type.sub_type?.id || null,
           // Include available legacies for each fighter type
-          available_legacies: type.available_legacies || []
+          available_legacies: type.available_legacies || [],
+          is_custom_fighter: type.is_custom_fighter || false
         }));
         setFighterTypes(transformedData);
 
@@ -453,7 +455,8 @@ export function EditFighterModal({
         fighter_sub_type: type.sub_type?.sub_type_name || null,
         fighter_sub_type_id: type.sub_type?.id || null,
         // Include available legacies for each fighter type
-        available_legacies: type.available_legacies || []
+        available_legacies: type.available_legacies || [],
+        is_custom_fighter: type.is_custom_fighter || false
       }));
       
       console.log('EditFighterModal: Fetched fighter types:', transformedData.length);
@@ -852,9 +855,18 @@ export function EditFighterModal({
         submitData.fighter_class = fighterTypeToUse.fighter_class;
         submitData.fighter_class_id = fighterTypeToUse.fighter_class_id;
         submitData.fighter_type = fighterTypeToUse.fighter_type;
-        submitData.fighter_type_id = fighterTypeToUse.id;
-        submitData.fighter_sub_type = selectedSubType && selectedSubType.fighter_sub_type !== 'Default' ? selectedSubType.fighter_sub_type : null;
-        submitData.fighter_sub_type_id = selectedSubType && selectedSubType.fighter_sub_type !== 'Default' ? selectedSubType.id : null;
+        if (fighterTypeToUse.is_custom_fighter) {
+          // Custom type IDs live in custom_fighter_types, not fighter_types — must not write to fighter_type_id
+          submitData.custom_fighter_type_id = fighterTypeToUse.id;
+          submitData.fighter_type_id = null;
+          submitData.fighter_sub_type = null;
+          submitData.fighter_sub_type_id = null;
+        } else {
+          submitData.fighter_type_id = fighterTypeToUse.id;
+          submitData.custom_fighter_type_id = null;
+          submitData.fighter_sub_type = selectedSubType && selectedSubType.fighter_sub_type !== 'Default' ? selectedSubType.fighter_sub_type : null;
+          submitData.fighter_sub_type_id = selectedSubType && selectedSubType.fighter_sub_type !== 'Default' ? selectedSubType.id : null;
+        }
       }
 
       // Apply the selected fighter class


### PR DESCRIPTION
## Summary

- When editing a fighter in a custom gang, the fighter type dropdown returns `custom_fighter_types` mixed with standard `fighter_types` from `/api/fighter-types`
- The edit modal was blindly writing the selected ID to `fighter_type_id`, which has a FK constraint to `fighter_types` — causing `fighters_fighter_type_id_fkey` violation when a custom type was chosen
- Fix preserves `is_custom_fighter` through both transformation paths in the modal, then branches in `handleConfirm` to write to `custom_fighter_type_id` vs `fighter_type_id` (nulling the other), mirroring the pattern already in `add-fighter.ts`
- The `updateFighterDetails` server action gains a `custom_fighter_type_id` param to support the write

**Regression introduced by a9f085a** (custom gang types feature, Apr 18 2026) — the API was updated to return custom types in the dropdown but the edit modal was never updated to handle them.

## Test plan

- [ ] Edit a fighter in a custom gang and change its type to a custom fighter type — save should succeed without FK error
- [ ] Edit a fighter in a custom gang and switch from a custom type back to a standard type — save should succeed and `custom_fighter_type_id` should be cleared
- [ ] Edit a fighter without changing its type — no regression, type fields unchanged

https://claude.ai/code/session_015e9UJUJLVfJiEw6HN37kyF

---
_Generated by [Claude Code](https://claude.ai/code/session_015e9UJUJLVfJiEw6HN37kyF)_