### PR TITLE
Fix: forward custom_fighter_type_id through mutation and fix optimistic update

### DIFF
--- a/components/fighter/edit-fighter/fighter-edit-modal.tsx
+++ b/components/fighter/edit-fighter/fighter-edit-modal.tsx
@@ -82,7 +82,8 @@ interface EditFighterModalProps {
     fighter_class?: string;
     fighter_class_id?: string;
     fighter_type?: string;
-    fighter_type_id?: string;
+    fighter_type_id?: string | null;
+    custom_fighter_type_id?: string | null;
     special_rules?: string[];
     stats?: Record<string, number>;
     fighter_sub_type?: string | null;
@@ -257,7 +258,8 @@ export function EditFighterModal({
       fighter_class?: string;
       fighter_class_id?: string;
       fighter_type?: string;
-      fighter_type_id?: string;
+      fighter_type_id?: string | null;
+      custom_fighter_type_id?: string | null;
       special_rules?: string[];
       fighter_sub_type?: string | null;
       fighter_sub_type_id?: string | null;
@@ -276,6 +278,7 @@ export function EditFighterModal({
         fighter_class_id: submit.fighter_class_id,
         fighter_type: submit.fighter_type,
         fighter_type_id: submit.fighter_type_id,
+        custom_fighter_type_id: submit.custom_fighter_type_id,
         fighter_sub_type: submit.fighter_sub_type,
         fighter_sub_type_id: submit.fighter_sub_type_id,
         fighter_gang_legacy_id: submit.fighter_gang_legacy_id,
@@ -319,8 +322,8 @@ export function EditFighterModal({
         kill_count: submit.kill_count,
         cost_adjustment: parseInt(submit.costAdjustment) || 0,
         ...(submit.fighter_class ? { fighter_class: submit.fighter_class } : {}),
-        ...(submit.fighter_type && submit.fighter_type_id
-          ? { fighter_type: { fighter_type: submit.fighter_type, fighter_type_id: submit.fighter_type_id } as any }
+        ...(submit.fighter_type && (submit.fighter_type_id || submit.custom_fighter_type_id)
+          ? { fighter_type: { fighter_type: submit.fighter_type, fighter_type_id: submit.fighter_type_id ?? null } as any }
           : {}),
         ...(submit.fighter_sub_type && submit.fighter_sub_type_id
           ? { fighter_sub_type: { fighter_sub_type: submit.fighter_sub_type, fighter_sub_type_id: submit.fighter_sub_type_id } as any }

--- a/components/fighter/edit-fighter/fighter-edit-modal.tsx
+++ b/components/fighter/edit-fighter/fighter-edit-modal.tsx
@@ -323,7 +323,11 @@ export function EditFighterModal({
         cost_adjustment: parseInt(submit.costAdjustment) || 0,
         ...(submit.fighter_class ? { fighter_class: submit.fighter_class } : {}),
         ...(submit.fighter_type && (submit.fighter_type_id || submit.custom_fighter_type_id)
-          ? { fighter_type: { fighter_type: submit.fighter_type, fighter_type_id: submit.fighter_type_id ?? null } as any }
+          ? {
+              fighter_type: { fighter_type: submit.fighter_type, fighter_type_id: submit.fighter_type_id ?? null } as any,
+              custom_fighter_type_id: submit.custom_fighter_type_id ?? null,
+              fighter_type_id: submit.fighter_type_id ?? null,
+            }
           : {}),
         ...(submit.fighter_sub_type && submit.fighter_sub_type_id
           ? { fighter_sub_type: { fighter_sub_type: submit.fighter_sub_type, fighter_sub_type_id: submit.fighter_sub_type_id } as any }


### PR DESCRIPTION
Follow-up to #1652, addressing three review findings that were missed in the original fix.

## Summary

- **HIGH** — `custom_fighter_type_id` was missing from the `mutationFn` parameter type (lines 251–266) and not forwarded into the `updateFighterDetails` call. The FK crash from #1652 was prevented, but the custom type was silently dropped — the DB write that was the whole point of the change never happened. Added the field to the param type and forwarded it.
- **MEDIUM** — Legacy `onSubmit` interface was also missing `custom_fighter_type_id`, making it incomplete for future callers.
- **LOW** — Optimistic update condition `submit.fighter_type && submit.fighter_type_id` failed for custom types because `fighter_type_id` is intentionally `null`. Now also checks `custom_fighter_type_id` as a signal so the displayed type updates immediately.

## Test plan

- [ ] Edit a fighter in a custom gang, change its type to a custom fighter type — save should succeed and the custom type should be persisted in the DB (`custom_fighter_type_id` set, `fighter_type_id` null)
- [ ] Edit a fighter in a custom gang, switch from a custom type back to a standard type — `fighter_type_id` set, `custom_fighter_type_id` null
- [ ] Confirm the displayed fighter type updates immediately on save (optimistic update) for both cases

https://claude.ai/code/session_015e9UJUJLVfJiEw6HN37kyF

---
_Generated by [Claude Code](https://claude.ai/code/session_015e9UJUJLVfJiEw6HN37kyF)_