### PR TITLE
Add trading post editing to admin campaign type management

### DIFF
--- a/app/api/admin/campaign-types/route.ts
+++ b/app/api/admin/campaign-types/route.ts
@@ -13,7 +13,7 @@ export async function GET() {
 
     const { data: campaignTypes, error } = await supabase
       .from('campaign_types')
-      .select('id, campaign_type_name, image_url')
+      .select('id, campaign_type_name, image_url, trading_posts')
       .order('campaign_type_name', { ascending: true });
 
     if (error) throw error;
@@ -37,7 +37,7 @@ export async function POST(request: Request) {
     }
 
     const body = await request.json();
-    const { campaign_type_name, image_url } = body;
+    const { campaign_type_name, image_url, trading_posts } = body;
 
     if (!campaign_type_name?.trim()) {
       return NextResponse.json(
@@ -65,11 +65,19 @@ export async function POST(request: Request) {
       }
     }
 
+    if (trading_posts !== undefined && trading_posts !== null && !Array.isArray(trading_posts)) {
+      return NextResponse.json(
+        { error: 'trading_posts must be an array or null' },
+        { status: 400 }
+      );
+    }
+
     const { data: campaignType, error } = await supabase
       .from('campaign_types')
       .insert([{
         campaign_type_name: campaign_type_name.trim(),
-        image_url: image_url?.trim() || null
+        image_url: image_url?.trim() || null,
+        trading_posts: trading_posts ?? null
       }])
       .select()
       .single();
@@ -95,7 +103,7 @@ export async function PATCH(request: Request) {
     }
 
     const body = await request.json();
-    const { id, campaign_type_name, image_url } = body;
+    const { id, campaign_type_name, image_url, trading_posts } = body;
 
     if (!id) {
       return NextResponse.json(
@@ -128,6 +136,15 @@ export async function PATCH(request: Request) {
         }
       }
       updateData.image_url = trimmedUrl;
+    }
+    if (trading_posts !== undefined) {
+      if (trading_posts !== null && !Array.isArray(trading_posts)) {
+        return NextResponse.json(
+          { error: 'trading_posts must be an array or null' },
+          { status: 400 }
+        );
+      }
+      updateData.trading_posts = trading_posts;
     }
 
     if (Object.keys(updateData).length === 0) {

--- a/components/admin/admin-campaign-management.tsx
+++ b/components/admin/admin-campaign-management.tsx
@@ -34,6 +34,11 @@ interface CampaignTriumph {
   updated_at?: string | null;
 }
 
+interface TradingPostType {
+  id: string;
+  trading_post_name: string;
+}
+
 interface AdminCampaignManagementModalProps {
   onClose: () => void;
   onSubmit?: () => void;
@@ -96,6 +101,16 @@ export function AdminCampaignManagementModal({
     staleTime: 5 * 60 * 1000,
   });
 
+  const { data: tradingPostTypes = [] } = useQuery<TradingPostType[]>({
+    queryKey: ['admin-trading-post-types'],
+    queryFn: async () => {
+      const response = await fetch('/api/admin/equipment/trading-post-types');
+      if (!response.ok) throw new Error('Failed to fetch trading post types');
+      return response.json();
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
   const isLoading = isLoadingCampaignTypes || isLoadingTerritories || isLoadingTriumphs || isSubmitting;
   
   // Campaign Types form state
@@ -107,10 +122,13 @@ export function AdminCampaignManagementModal({
   // Relationship management for campaign types
   const [relatedTerritories, setRelatedTerritories] = useState<Territory[]>([]);
   const [relatedTriumphs, setRelatedTriumphs] = useState<CampaignTriumph[]>([]);
+  const [relatedTradingPostIds, setRelatedTradingPostIds] = useState<string[]>([]);
   const [showAddTerritoryModal, setShowAddTerritoryModal] = useState(false);
   const [showAddTriumphModal, setShowAddTriumphModal] = useState(false);
+  const [showAddTradingPostModal, setShowAddTradingPostModal] = useState(false);
   const [selectedTerritoryToAdd, setSelectedTerritoryToAdd] = useState('');
   const [selectedTriumphToAdd, setSelectedTriumphToAdd] = useState('');
+  const [selectedTradingPostToAdd, setSelectedTradingPostToAdd] = useState('');
   
   // Territories form state
   const [selectedTerritoryId, setSelectedTerritoryId] = useState('');
@@ -135,6 +153,7 @@ export function AdminCampaignManagementModal({
     setIsCreateModeCampaignType(false);
     setRelatedTerritories([]);
     setRelatedTriumphs([]);
+    setRelatedTradingPostIds([]);
 
     setSelectedTerritoryId('');
     setTerritoryName('');
@@ -176,6 +195,7 @@ export function AdminCampaignManagementModal({
     if (selected) {
       setCampaignTypeName(selected.campaign_type_name);
       setImageUrl(selected.image_url || '');
+      setRelatedTradingPostIds(selected.trading_posts || []);
     }
   };
 
@@ -186,6 +206,7 @@ export function AdminCampaignManagementModal({
     setIsCreateModeCampaignType(true);
     setRelatedTerritories([]);
     setRelatedTriumphs([]);
+    setRelatedTradingPostIds([]);
   };
 
   const handleSubmitCampaignType = async (operation: OperationType) => {
@@ -205,7 +226,8 @@ export function AdminCampaignManagementModal({
           method = 'POST';
           body = JSON.stringify({
             campaign_type_name: campaignTypeName.trim(),
-            image_url: imageUrl.trim() || null
+            image_url: imageUrl.trim() || null,
+            trading_posts: relatedTradingPostIds.length > 0 ? relatedTradingPostIds : null
           });
           break;
         case OperationType.UPDATE:
@@ -213,7 +235,8 @@ export function AdminCampaignManagementModal({
           body = JSON.stringify({
             id: selectedCampaignTypeId,
             campaign_type_name: campaignTypeName.trim(),
-            image_url: imageUrl.trim() || null
+            image_url: imageUrl.trim() || null,
+            trading_posts: relatedTradingPostIds.length > 0 ? relatedTradingPostIds : null
           });
           break;
         default:
@@ -317,6 +340,7 @@ export function AdminCampaignManagementModal({
       setImageUrl('');
       setRelatedTerritories([]);
       setRelatedTriumphs([]);
+      setRelatedTradingPostIds([]);
       setIsCreateModeCampaignType(false);
 
       if (onSubmit) {
@@ -537,6 +561,16 @@ export function AdminCampaignManagementModal({
       }
       setShowAddTriumphModal(false);
       setSelectedTriumphToAdd('');
+      return true;
+    }
+    return false;
+  };
+
+  const handleAddTradingPost = () => {
+    if (selectedTradingPostToAdd) {
+      setRelatedTradingPostIds([...relatedTradingPostIds, selectedTradingPostToAdd]);
+      setShowAddTradingPostModal(false);
+      setSelectedTradingPostToAdd('');
       return true;
     }
     return false;
@@ -776,6 +810,45 @@ export function AdminCampaignManagementModal({
                             </button>
                           </div>
                         ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Default Trading Posts Section */}
+                {(isCreateModeCampaignType || (selectedCampaignTypeId && !isCreateModeCampaignType)) && (
+                  <div>
+                    <label className="block text-sm font-medium text-muted-foreground mb-1">
+                      Default Trading Posts
+                    </label>
+                    <Button
+                      onClick={() => setShowAddTradingPostModal(true)}
+                      variant="outline"
+                      size="sm"
+                      className="mb-2"
+                      disabled={tradingPostTypes.filter(tp => !relatedTradingPostIds.includes(tp.id)).length === 0}
+                    >
+                      Add Trading Post
+                    </Button>
+                    {relatedTradingPostIds.length > 0 && (
+                      <div className="flex flex-wrap gap-2">
+                        {relatedTradingPostIds.map((id) => {
+                          const tradingPost = tradingPostTypes.find(tp => tp.id === id);
+                          return (
+                            <div
+                              key={id}
+                              className="flex items-center gap-1 px-2 py-1 rounded-full text-sm bg-muted"
+                            >
+                              <span>{tradingPost?.trading_post_name ?? id}</span>
+                              <button
+                                onClick={() => setRelatedTradingPostIds(relatedTradingPostIds.filter(tid => tid !== id))}
+                                className="hover:text-red-500 focus:outline-none"
+                              >
+                                <HiX className="h-4 w-4" />
+                              </button>
+                            </div>
+                          );
+                        })}
                       </div>
                     )}
                   </div>
@@ -1042,6 +1115,41 @@ export function AdminCampaignManagementModal({
           onConfirm={handleAddTriumph}
           confirmText="Add Triumph"
           confirmDisabled={!selectedTriumphToAdd}
+        />
+      )}
+
+      {/* Add Trading Post Modal */}
+      {showAddTradingPostModal && (
+        <Modal
+          title="Add Trading Post"
+          content={
+            <div className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                Select a trading post to add as a default for this campaign type
+              </p>
+              <select
+                value={selectedTradingPostToAdd}
+                onChange={(e) => setSelectedTradingPostToAdd(e.target.value)}
+                className="w-full p-2 border rounded-md"
+              >
+                <option value="">Select a trading post</option>
+                {tradingPostTypes
+                  .filter(tp => !relatedTradingPostIds.includes(tp.id))
+                  .map((tp) => (
+                    <option key={tp.id} value={tp.id}>
+                      {tp.trading_post_name}
+                    </option>
+                  ))}
+              </select>
+            </div>
+          }
+          onClose={() => {
+            setShowAddTradingPostModal(false);
+            setSelectedTradingPostToAdd('');
+          }}
+          onConfirm={handleAddTradingPost}
+          confirmText="Add Trading Post"
+          confirmDisabled={!selectedTradingPostToAdd}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary

- Admins can now set default trading posts on campaign types from the Campaign Management modal, both when creating new types and editing existing ones
- `GET /api/admin/campaign-types` now returns the `trading_posts` field
- `POST` and `PATCH` endpoints accept and persist `trading_posts` (array of UUIDs or null)
- UI fetches trading post types and shows a **Default Trading Posts** section with add/remove chip controls, consistent with the existing territories and triumphs relationship UI

## Test plan

- [ ] Open Campaign Management modal as admin
- [ ] Select an existing campaign type — verify its current trading posts are pre-loaded as chips
- [ ] Add a trading post via the modal — verify it appears as a chip
- [ ] Remove a trading post chip — verify it's removed
- [ ] Save — verify the `trading_posts` field is persisted correctly in the database
- [ ] Create a new campaign type with trading posts selected — verify they are saved on creation
- [ ] Verify the Add Trading Post button is disabled when all trading post types are already selected

---
_Generated by [Claude Code](https://claude.ai/code/session_01F94uCmHHkvZdGWCcW2gVQE)_