### PR TITLE
Fix gang campaign tab not showing territories claimed via battle

### DIFF
--- a/app/actions/campaigns/[id]/battle-logs.ts
+++ b/app/actions/campaigns/[id]/battle-logs.ts
@@ -236,7 +236,7 @@ export async function createBattleLog(campaignId: string, params: BattleLogParam
     const { revalidateTag } = await import('next/cache');
     revalidateTag('campaign-battles');
     if (claimed_territories.length > 0 && winner_id) {
-      revalidateTag(`campaign-territories-${campaignId}`);
+      revalidateTag(CACHE_TAGS.BASE_CAMPAIGN_TERRITORIES(campaignId));
       revalidateTag(`campaign-${campaignId}`);
       revalidateTag(CACHE_TAGS.COMPOSITE_GANG_CAMPAIGNS(winner_id));
     }
@@ -394,7 +394,7 @@ export async function updateBattleLog(campaignId: string, battleId: string, para
     const { revalidateTag } = await import('next/cache');
     revalidateTag('campaign-battles');
     if (claimed_territories.length > 0 || existingBattle.campaign_territory_id) {
-      revalidateTag(`campaign-territories-${campaignId}`);
+      revalidateTag(CACHE_TAGS.BASE_CAMPAIGN_TERRITORIES(campaignId));
       revalidateTag(`campaign-${campaignId}`);
       if (winner_id && claimed_territories.length > 0) {
         revalidateTag(CACHE_TAGS.COMPOSITE_GANG_CAMPAIGNS(winner_id));
@@ -415,8 +415,6 @@ export async function updateBattleLog(campaignId: string, battleId: string, para
  * Delete a battle log using direct Supabase client
  */
 export async function deleteBattleLog(campaignId: string, battleId: string): Promise<void> {
-  'use server';
-
   try {
     const supabase = await createClient();
 
@@ -472,7 +470,7 @@ export async function deleteBattleLog(campaignId: string, battleId: string): Pro
     const { revalidateTag } = await import('next/cache');
     revalidateTag('campaign-battles');
     if (existingBattle.campaign_territory_id) {
-      revalidateTag(`campaign-territories-${campaignId}`);
+      revalidateTag(CACHE_TAGS.BASE_CAMPAIGN_TERRITORIES(campaignId));
       revalidateTag(`campaign-${campaignId}`);
       if (releasedTerritoryGangId) {
         revalidateTag(CACHE_TAGS.COMPOSITE_GANG_CAMPAIGNS(releasedTerritoryGangId));

--- a/app/actions/campaigns/[id]/battle-logs.ts
+++ b/app/actions/campaigns/[id]/battle-logs.ts
@@ -287,10 +287,11 @@ export async function updateBattleLog(campaignId: string, battleId: string, para
       throw new Error('Battle not found or access denied');
     }
 
-    // Look up the gang currently holding the old territory so we can invalidate their cache
+    // Look up the gang currently holding the old territory so we can invalidate their cache.
+    // This covers both cases: territory changes (old owner loses it) and same territory with
+    // a different winner (old owner is replaced without a release/re-claim cycle).
     let oldTerritoryGangId: string | null = null;
-    if (existingBattle.campaign_territory_id &&
-        existingBattle.campaign_territory_id !== newTerritoryId) {
+    if (existingBattle.campaign_territory_id) {
       const { data: oldTerritory } = await supabase
         .from('campaign_territories')
         .select('gang_id')

--- a/app/actions/campaigns/[id]/battle-logs.ts
+++ b/app/actions/campaigns/[id]/battle-logs.ts
@@ -4,6 +4,7 @@
 import { createClient } from "@/utils/supabase/server";
 import { cache } from 'react';
 import { logBattleResult, logTerritoryClaimed } from "../../logs/gang-campaign-logs";
+import { CACHE_TAGS } from "@/utils/cache-tags";
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 /**
@@ -234,9 +235,10 @@ export async function createBattleLog(campaignId: string, params: BattleLogParam
     // Invalidate cache - battles and territories if claimed
     const { revalidateTag } = await import('next/cache');
     revalidateTag('campaign-battles');
-    if (claimed_territories.length > 0) {
+    if (claimed_territories.length > 0 && winner_id) {
       revalidateTag(`campaign-territories-${campaignId}`);
       revalidateTag(`campaign-${campaignId}`);
+      revalidateTag(CACHE_TAGS.COMPOSITE_GANG_CAMPAIGNS(winner_id));
     }
 
     return transformedBattle;
@@ -283,6 +285,18 @@ export async function updateBattleLog(campaignId: string, battleId: string, para
 
     if (checkError || !existingBattle) {
       throw new Error('Battle not found or access denied');
+    }
+
+    // Look up the gang currently holding the old territory so we can invalidate their cache
+    let oldTerritoryGangId: string | null = null;
+    if (existingBattle.campaign_territory_id &&
+        existingBattle.campaign_territory_id !== newTerritoryId) {
+      const { data: oldTerritory } = await supabase
+        .from('campaign_territories')
+        .select('gang_id')
+        .eq('id', existingBattle.campaign_territory_id)
+        .single();
+      oldTerritoryGangId = oldTerritory?.gang_id ?? null;
     }
 
     // Release old territory if it was removed or changed
@@ -381,6 +395,12 @@ export async function updateBattleLog(campaignId: string, battleId: string, para
     if (claimed_territories.length > 0 || existingBattle.campaign_territory_id) {
       revalidateTag(`campaign-territories-${campaignId}`);
       revalidateTag(`campaign-${campaignId}`);
+      if (winner_id && claimed_territories.length > 0) {
+        revalidateTag(CACHE_TAGS.COMPOSITE_GANG_CAMPAIGNS(winner_id));
+      }
+      if (oldTerritoryGangId) {
+        revalidateTag(CACHE_TAGS.COMPOSITE_GANG_CAMPAIGNS(oldTerritoryGangId));
+      }
     }
 
     return transformedBattle;
@@ -410,6 +430,17 @@ export async function deleteBattleLog(campaignId: string, battleId: string): Pro
     if (checkError || !existingBattle) {
       console.error('Battle not found or access denied', checkError);
       throw new Error('Battle not found or access denied');
+    }
+
+    // Look up the gang currently holding the territory so we can invalidate their cache
+    let releasedTerritoryGangId: string | null = null;
+    if (existingBattle.campaign_territory_id) {
+      const { data: territory } = await supabase
+        .from('campaign_territories')
+        .select('gang_id')
+        .eq('id', existingBattle.campaign_territory_id)
+        .single();
+      releasedTerritoryGangId = territory?.gang_id ?? null;
     }
 
     // Release territory before deleting — if this fails, abort to avoid orphaning the territory
@@ -442,6 +473,9 @@ export async function deleteBattleLog(campaignId: string, battleId: string): Pro
     if (existingBattle.campaign_territory_id) {
       revalidateTag(`campaign-territories-${campaignId}`);
       revalidateTag(`campaign-${campaignId}`);
+      if (releasedTerritoryGangId) {
+        revalidateTag(CACHE_TAGS.COMPOSITE_GANG_CAMPAIGNS(releasedTerritoryGangId));
+      }
     }
   } catch (error) {
     console.error('Error deleting battle log:', error);


### PR DESCRIPTION
## Summary

- When a territory was claimed through a battle log, the campaign page correctly showed the new owner but the gang's **Campaign tab** stayed stale indefinitely
- Root cause: `createBattleLog`, `updateBattleLog`, and `deleteBattleLog` were not invalidating `COMPOSITE_GANG_CAMPAIGNS` — the cache tag for `getGangCampaigns()`, which drives the territory list on the gang page
- Added `revalidateTag(CACHE_TAGS.COMPOSITE_GANG_CAMPAIGNS(...))` in all three battle log mutations, including invalidating the previous owner's cache when a territory is released

## Test plan

- [ ] Claim a territory via a battle log and verify the gang's Campaign tab immediately shows the new territory without a hard refresh
- [ ] Update a battle log to change the claimed territory and verify both the old owner's and new owner's Campaign tabs update correctly
- [ ] Delete a battle log that had a territory claim and verify the previously owning gang's Campaign tab no longer shows that territory

---
_Generated by [Claude Code](https://claude.ai/code/session_01KWt9uZ74WqhxFiLhZD8v72)_