### PR TITLE
Add QoL navigation links between crew fighters and vehicles tab

### DIFF
--- a/components/fighter/fighter-details-card.tsx
+++ b/components/fighter/fighter-details-card.tsx
@@ -556,10 +556,22 @@ export const FighterDetailsCard = memo(function FighterDetailsCard({
           <div className="text-sm text-muted-foreground">
             Vehicle:{' '}
             {vehicles?.[0]
-              ? vehicles[0].vehicle_name
-                ? <Badge variant="secondary">{vehicles[0].vehicle_name} - {vehicles[0].vehicle_type}</Badge>
-                : <Badge variant="secondary">{vehicles[0].vehicle_type || 'None'}</Badge>
-              : <Badge variant="secondary">None</Badge>
+              ? gangId
+                ? <Link href={`/gang/${gangId}?tab=2`} prefetch={false}>
+                    <Badge variant="secondary" className="hover:bg-secondary/80 cursor-pointer">
+                      {vehicles[0].vehicle_name
+                        ? `${vehicles[0].vehicle_name} - ${vehicles[0].vehicle_type}`
+                        : vehicles[0].vehicle_type || 'None'}
+                    </Badge>
+                  </Link>
+                : <Badge variant="secondary">
+                    {vehicles[0].vehicle_name
+                      ? `${vehicles[0].vehicle_name} - ${vehicles[0].vehicle_type}`
+                      : vehicles[0].vehicle_type || 'None'}
+                  </Badge>
+              : gangId
+                ? <Link href={`/gang/${gangId}?tab=2`} prefetch={false}><Badge variant="secondary" className="hover:bg-secondary/80 cursor-pointer">None</Badge></Link>
+                : <Badge variant="secondary">None</Badge>
             }
           </div>
         )}

--- a/components/gang/gang-page-content.tsx
+++ b/components/gang/gang-page-content.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useCallback, useMemo } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { FighterProps } from "@/types/fighter";
 import { FighterType } from "@/types/fighter-type";
 import Gang from "@/components/gang/gang";
@@ -90,6 +91,12 @@ export default function GangPageContent({
   userId,
   userPermissions 
 }: GangPageContentProps) {
+  const searchParams = useSearchParams();
+  const initialTab = Math.min(
+    Number(searchParams.get('tab') ?? 0),
+    4 // max tab index
+  ) || 0;
+
   const [gangData, setGangData] = useState<GangDataState>({
     processedData: initialGangData,
     stash: initialGangData.stash || [],
@@ -842,7 +849,7 @@ export default function GangPageContent({
       })()}
 
       <div>
-      <Tabs tabTitles={['Gang', 'Stash', 'Vehicles', 'Campaign', 'Notes']}
+      <Tabs tabTitles={['Gang', 'Stash', 'Vehicles', 'Campaign', 'Notes']} initialTab={initialTab}
          tabIcons={[
            <FaUsers key="users" />,
            <FaBox key="box" />,

--- a/components/gang/vehicles-tab.tsx
+++ b/components/gang/vehicles-tab.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
+import Link from 'next/link';
 import { Button } from "@/components/ui/button";
 import { FighterProps } from '@/types/fighter';
 import { VehicleProps } from '@/types/vehicle';
@@ -732,8 +733,15 @@ export default function GangVehicles({
                       <span className="w-64 overflow-hidden text-ellipsis text-nowrap">
                         {vehicle.vehicle_type}
                       </span>
-                      <span className="w-64 overflow-hidden text-ellipsis text-muted-foreground">
-                        {vehicle.assigned_to || '-'}
+                      <span className="w-64 overflow-hidden text-ellipsis">
+                        {(() => {
+                          const fighter = vehicle.assigned_to
+                            ? fighters.find(f => f.fighter_name === vehicle.assigned_to)
+                            : null;
+                          return fighter
+                            ? <Link href={`/fighter/${fighter.id}`} prefetch={false} onClick={e => e.stopPropagation()}><span className="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold bg-secondary text-secondary-foreground hover:bg-secondary/80 cursor-pointer">{vehicle.assigned_to}</span></Link>
+                            : <span className="text-muted-foreground">{vehicle.assigned_to || '-'}</span>;
+                        })()}
                       </span>
                       <div className="flex-1" />
                       <div className="w-48 flex justify-end gap-1">

--- a/components/tabs.tsx
+++ b/components/tabs.tsx
@@ -5,12 +5,13 @@ import React, { useState, useEffect } from 'react';
 interface TabsProps {
   children: React.ReactNode[];
   tabTitles?: string[];
-  tabIcons?: React.ReactNode[]; // Accept icons for each tab
-  onTabChange?: (tabIndex: number) => void; // Callback for tab changes
+  tabIcons?: React.ReactNode[];
+  onTabChange?: (tabIndex: number) => void;
+  initialTab?: number;
 }
 
-const Tabs = ({ children, tabTitles, tabIcons, onTabChange }: TabsProps) => {
-  const [activeTab, setActiveTab] = useState(0);
+const Tabs = ({ children, tabTitles, tabIcons, onTabChange, initialTab = 0 }: TabsProps) => {
+  const [activeTab, setActiveTab] = useState(initialTab);
 
   const defaultTabTitles = ['Gang', 'Stash', 'Notes'];
   const titles = tabTitles || defaultTabTitles;


### PR DESCRIPTION
- Crew fighter's "None" vehicle badge links to the gang's Vehicles tab (?tab=2)
- Crew fighter's assigned vehicle badge also links to the gang's Vehicles tab
- Crew fighter name in the Vehicles tab links to the fighter's page
- Adds initialTab prop to Tabs component and reads ?tab= search param on the gang page