### PR TITLE
Fix page flash when navigating from home to gang/campaign

### DIFF
--- a/components/home/campaign-card.tsx
+++ b/components/home/campaign-card.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import type { Campaign } from '@/app/lib/get-user-campaigns'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
@@ -81,9 +82,9 @@ export function CampaignCardContent({ campaign, onToggleFavourite, dragListeners
           {innerContent}
         </div>
       ) : (
-        <a href={`/campaigns/${campaign.id}`} className="flex items-center grow min-w-0">
+        <Link href={`/campaigns/${campaign.id}`} prefetch={false} className="flex items-center grow min-w-0">
           {innerContent}
-        </a>
+        </Link>
       )}
       <button
         type="button"

--- a/components/home/gang-card.tsx
+++ b/components/home/gang-card.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import Image from 'next/image'
+import Link from 'next/link'
 import type { Gang } from '@/app/lib/get-user-gangs'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
@@ -93,9 +94,9 @@ export function GangCardContent({ gang, onToggleFavourite, dragListeners, dragAt
           {innerContent}
         </div>
       ) : (
-        <a href={`/gang/${gang.id}`} className="flex items-center grow min-w-0">
+        <Link href={`/gang/${gang.id}`} prefetch={false} className="flex items-center grow min-w-0">
           {innerContent}
-        </a>
+        </Link>
       )}
       <button
         type="button"


### PR DESCRIPTION
The home page gang and campaign cards used raw <a href> tags, which trigger a full-page browser reload instead of a client-side soft navigation. The reload tears down and re-fetches the persistent <BackgroundImage>, so the body's bg-background paints (white/black depending on theme) before the background image reloads — producing a visible flash.

Swap both cards to Next.js <Link prefetch={false}>, matching the rest of the app's gang/campaign links. This keeps the app shell (and the background image) mounted across navigation while preserving the no-prefetch behavior these expensive routes were relying on.