### PR TITLE
Optimize battle completion: defer logging, batch queries, suppress refetch

### DIFF
--- a/app/actions/battle-sessions.ts
+++ b/app/actions/battle-sessions.ts
@@ -1205,7 +1205,7 @@ export async function completeBattleSession(
 
     // Derive the effective winner set
     const flaggedWinnerIds: string[] =
-      (allParticipants ?? [])
+      allParticipants
         .filter((p) => p.is_winner === true)
         .map((p) => p.gang_id);
     const effectiveWinnerIds: string[] =
@@ -1216,7 +1216,7 @@ export async function completeBattleSession(
           : [];
     const winnerGangSet = new Set(effectiveWinnerIds);
     const claimerGangId: string | null =
-      (allParticipants ?? []).find((p) => p.claimed_territory === true)?.gang_id
+      allParticipants.find((p) => p.claimed_territory === true)?.gang_id
       ?? session.winner_gang_id
       ?? null;
     const legacyWinnerId: string | null =
@@ -1224,7 +1224,7 @@ export async function completeBattleSession(
 
     // --- Campaign battle log (inline insert, no createBattleLog call) ---
     let campaign_battle_id: string | undefined;
-    if (session.campaign_id && allParticipants) {
+    if (session.campaign_id) {
       const battleParticipants = allParticipants.map((p) => ({
         role: p.role,
         gang_id: p.gang_id,
@@ -1264,7 +1264,8 @@ export async function completeBattleSession(
           .eq('campaign_id', session.campaign_id);
 
         if (claimError) {
-          await supabase.from('campaign_battles').delete().eq('id', campaign_battle_id);
+          const { error: deleteError } = await supabase.from('campaign_battles').delete().eq('id', campaign_battle_id);
+          if (deleteError) console.error('Failed to rollback campaign battle after territory claim error:', deleteError);
           return { success: false, error: `Failed to claim territory: ${claimError.message}` };
         }
       }
@@ -1285,7 +1286,8 @@ export async function completeBattleSession(
 
     if (error || !updated || updated.length === 0) {
       if (campaign_battle_id) {
-        await supabase.from('campaign_battles').delete().eq('id', campaign_battle_id);
+        const { error: deleteError } = await supabase.from('campaign_battles').delete().eq('id', campaign_battle_id);
+        if (deleteError) console.error('Failed to rollback campaign battle after session update error:', deleteError);
       }
       return { success: false, error: error?.message || 'Session was already completed' };
     }
@@ -1296,8 +1298,6 @@ export async function completeBattleSession(
     // === Everything below runs AFTER the response is sent ===
     after(async () => {
       try {
-        if (!allParticipants) return;
-
         // Fetch gang names + owner IDs for logging (one query)
         const gangIds = allParticipants.map((p) => p.gang_id);
         const { data: gangs } = await supabase
@@ -1308,9 +1308,7 @@ export async function completeBattleSession(
           gangs?.map((g) => [g.id, g]) || []
         );
 
-        // Batch gang logs — one insert instead of N sequential calls
-        const campaignName = session.campaign_id ? undefined : 'Standalone Battle';
-        let resolvedCampaignName = campaignName;
+        let resolvedCampaignName = 'Standalone Battle';
         if (session.campaign_id) {
           const { data: campaign } = await supabase
             .from('campaigns')
@@ -1320,55 +1318,52 @@ export async function completeBattleSession(
           resolvedCampaignName = campaign?.campaign_name || 'Campaign';
         }
 
-        const logs = allParticipants
-          .map((p) => {
-            const gang = gangMap.get(p.gang_id);
-            if (!gang) return null;
+        // Build all gang logs in one batch
+        const logs: { gang_id: string; user_id: string; action_type: string; description: string; created_at: string }[] = [];
 
-            let result: 'won' | 'lost' | 'draw';
-            if (winnerGangSet.size === 0) {
-              result = 'draw';
-            } else if (winnerGangSet.has(p.gang_id)) {
-              result = 'won';
-            } else {
-              result = 'lost';
-            }
+        for (const p of allParticipants) {
+          const gang = gangMap.get(p.gang_id);
+          if (!gang) continue;
 
-            const opponents = allParticipants
-              .filter((op) => op.gang_id !== p.gang_id)
-              .map((op) => gangMap.get(op.gang_id)?.name)
-              .filter(Boolean)
-              .join(', ');
+          let result: 'won' | 'lost' | 'draw';
+          if (winnerGangSet.size === 0) {
+            result = 'draw';
+          } else if (winnerGangSet.has(p.gang_id)) {
+            result = 'won';
+          } else {
+            result = 'lost';
+          }
 
-            const roleText =
-              p.role === 'attacker'
-                ? 'attacked'
-                : p.role === 'defender'
-                  ? 'defended against'
-                  : 'fought';
-            const resultText =
-              result === 'won' ? 'Victory!' : result === 'lost' ? 'Defeat' : 'Draw';
+          const opponents = allParticipants
+            .filter((op) => op.gang_id !== p.gang_id)
+            .map((op) => gangMap.get(op.gang_id)?.name)
+            .filter(Boolean)
+            .join(', ');
 
-            return {
-              gang_id: p.gang_id,
-              user_id: gang.user_id,
-              action_type: `battle_${result}`,
-              description: `Gang "${gang.name}" ${roleText} "${opponents || 'Unknown'}" in "${session.scenario || 'Unknown Scenario'}" (Campaign: ${resolvedCampaignName}). Result: ${resultText}`,
-              created_at: new Date().toISOString(),
-            };
-          })
-          .filter((log): log is NonNullable<typeof log> => log !== null);
+          const roleText =
+            p.role === 'attacker'
+              ? 'attacked'
+              : p.role === 'defender'
+                ? 'defended against'
+                : 'fought';
+          const resultText =
+            result === 'won' ? 'Victory!' : result === 'lost' ? 'Defeat' : 'Draw';
 
-        if (logs.length > 0) {
-          await supabase.from('gang_logs').insert(logs);
+          logs.push({
+            gang_id: p.gang_id,
+            user_id: gang.user_id,
+            action_type: `battle_${result}`,
+            description: `Gang "${gang.name}" ${roleText} "${opponents || 'Unknown'}" in "${session.scenario || 'Unknown Scenario'}" (Campaign: ${resolvedCampaignName}). Result: ${resultText}`,
+            created_at: new Date().toISOString(),
+          });
         }
 
-        // Territory claim log
+        // Territory claim log — added to same batch
         if (options?.campaign_territory_id && claimerGangId && claimed_territory) {
           const claimer = gangMap.get(claimerGangId);
           if (claimer) {
             const territoryType = territoryIsCustom ? 'custom territory' : 'territory';
-            await supabase.from('gang_logs').insert({
+            logs.push({
               gang_id: claimerGangId,
               user_id: claimer.user_id,
               action_type: 'territory_claimed',
@@ -1376,6 +1371,10 @@ export async function completeBattleSession(
               created_at: new Date().toISOString(),
             });
           }
+        }
+
+        if (logs.length > 0) {
+          await supabase.from('gang_logs').insert(logs);
         }
 
         // Notifications — one insert

--- a/app/actions/battle-sessions.ts
+++ b/app/actions/battle-sessions.ts
@@ -1170,7 +1170,7 @@ export async function completeBattleSession(
     // Parallel fetch: session, participants, profile, and territory name (if applicable)
     const [
       { data: session },
-      { data: allParticipants },
+      { data: allParticipants, error: participantsError },
       { data: userProfile },
       territoryResult,
     ] = await Promise.all([
@@ -1187,7 +1187,7 @@ export async function completeBattleSession(
       options?.campaign_territory_id
         ? supabase
             .from('campaign_territories')
-            .select('territory_name')
+            .select('territory_name, territory_id')
             .eq('id', options.campaign_territory_id)
             .single()
         : Promise.resolve({ data: null }),
@@ -1196,9 +1196,12 @@ export async function completeBattleSession(
     if (!session) return { success: false, error: 'Session not found' };
     if (session.status !== 'post_battle')
       return { success: false, error: 'Session must be in post-battle to complete' };
+    if (participantsError || !allParticipants)
+      return { success: false, error: 'Failed to load session participants' };
 
     const senderName = userProfile?.username || 'Someone';
     const claimed_territory = territoryResult?.data?.territory_name ?? null;
+    const territoryIsCustom = territoryResult?.data ? !territoryResult.data.territory_id : false;
 
     // Derive the effective winner set
     const flaggedWinnerIds: string[] =
@@ -1254,11 +1257,16 @@ export async function completeBattleSession(
 
       // Claim territory in same flow
       if (options?.campaign_territory_id && claimerGangId) {
-        await supabase
+        const { error: claimError } = await supabase
           .from('campaign_territories')
           .update({ gang_id: claimerGangId })
           .eq('id', options.campaign_territory_id)
           .eq('campaign_id', session.campaign_id);
+
+        if (claimError) {
+          await supabase.from('campaign_battles').delete().eq('id', campaign_battle_id);
+          return { success: false, error: `Failed to claim territory: ${claimError.message}` };
+        }
       }
     }
 
@@ -1359,11 +1367,12 @@ export async function completeBattleSession(
         if (options?.campaign_territory_id && claimerGangId && claimed_territory) {
           const claimer = gangMap.get(claimerGangId);
           if (claimer) {
+            const territoryType = territoryIsCustom ? 'custom territory' : 'territory';
             await supabase.from('gang_logs').insert({
               gang_id: claimerGangId,
               user_id: claimer.user_id,
               action_type: 'territory_claimed',
-              description: `Gang "${claimer.name}" claimed territory "${claimed_territory}" in campaign "${resolvedCampaignName}"`,
+              description: `Gang "${claimer.name}" claimed ${territoryType} "${claimed_territory}" in campaign "${resolvedCampaignName}"`,
               created_at: new Date().toISOString(),
             });
           }

--- a/app/actions/battle-sessions.ts
+++ b/app/actions/battle-sessions.ts
@@ -6,8 +6,7 @@ import { revalidateTag } from 'next/cache';
 import {
   CACHE_TAGS,
 } from '@/utils/cache-tags';
-import { logBattleResult } from '@/app/actions/logs/gang-campaign-logs';
-import { createBattleLog } from '@/app/actions/campaigns/[id]/battle-logs';
+import { after } from 'next/server';
 import { updateGang } from '@/app/actions/update-gang';
 import type {
   BattleSessionFull,
@@ -22,7 +21,6 @@ import { getBattleSessionCached } from '@/app/lib/battle-sessions/get-battle-ses
 // =============================================================================
 
 export async function fetchBattleSession(sessionId: string): Promise<BattleSessionFull | null> {
-  revalidateTag(CACHE_TAGS.BASE_BATTLE_SESSION(sessionId));
   const supabase = await createClient();
   return getBattleSessionCached(sessionId, supabase);
 }
@@ -1166,37 +1164,43 @@ export async function completeBattleSession(
     const supabase = await createClient();
     const user = await getAuthenticatedUser(supabase);
 
-    const { data: userProfile } = await supabase
-      .from('profiles')
-      .select('username')
-      .eq('id', user.id)
-      .single();
-    const senderName = userProfile?.username || 'Someone';
-
     const auth = await verifySessionCreator(supabase, sessionId, user.id);
     if (!auth.authorized) return { success: false, error: auth.error };
 
-    const { data: session } = await supabase
-      .from('battle_sessions')
-      .select('status, campaign_id, scenario, winner_gang_id, created_at')
-      .eq('id', sessionId)
-      .single();
+    // Parallel fetch: session, participants, profile, and territory name (if applicable)
+    const [
+      { data: session },
+      { data: allParticipants },
+      { data: userProfile },
+      territoryResult,
+    ] = await Promise.all([
+      supabase
+        .from('battle_sessions')
+        .select('status, campaign_id, scenario, winner_gang_id, created_at')
+        .eq('id', sessionId)
+        .single(),
+      supabase
+        .from('battle_session_participants')
+        .select('id, gang_id, user_id, role, is_winner, claimed_territory')
+        .eq('battle_session_id', sessionId),
+      supabase.from('profiles').select('username').eq('id', user.id).single(),
+      options?.campaign_territory_id
+        ? supabase
+            .from('campaign_territories')
+            .select('territory_name')
+            .eq('id', options.campaign_territory_id)
+            .single()
+        : Promise.resolve({ data: null }),
+    ]);
 
     if (!session) return { success: false, error: 'Session not found' };
     if (session.status !== 'post_battle')
       return { success: false, error: 'Session must be in post-battle to complete' };
 
-    let campaign_battle_id: string | undefined;
+    const senderName = userProfile?.username || 'Someone';
+    const claimed_territory = territoryResult?.data?.territory_name ?? null;
 
-    // Pull the multi-winner flags so we can forward them to the campaign
-    // battle log and the per-gang logger below.
-    const { data: allParticipants } = await supabase
-      .from('battle_session_participants')
-      .select('id, gang_id, user_id, role, is_winner, claimed_territory')
-      .eq('battle_session_id', sessionId);
-
-    // Derive the effective winner set: prefer participant flags, fall back to
-    // the legacy winner_gang_id so historical sessions still produce a sane log.
+    // Derive the effective winner set
     const flaggedWinnerIds: string[] =
       (allParticipants ?? [])
         .filter((p) => p.is_winner === true)
@@ -1212,46 +1216,53 @@ export async function completeBattleSession(
       (allParticipants ?? []).find((p) => p.claimed_territory === true)?.gang_id
       ?? session.winner_gang_id
       ?? null;
+    const legacyWinnerId: string | null =
+      claimerGangId ?? effectiveWinnerIds[0] ?? null;
 
+    // --- Campaign battle log (inline insert, no createBattleLog call) ---
+    let campaign_battle_id: string | undefined;
     if (session.campaign_id && allParticipants) {
-      try {
-        const battleLog = await createBattleLog(session.campaign_id, {
-          scenario: session.scenario || '',
-          // The server action derives `winner_id` from participants[].is_winner /
-          // claimed_territory, but we still pass it as a defensive fallback for
-          // sessions that never received the new flags.
-          winner_id: claimerGangId ?? effectiveWinnerIds[0] ?? null,
-          note: options?.note || null,
-          participants: allParticipants.map((p) => ({
-            gang_id: p.gang_id,
-            role: p.role as 'attacker' | 'defender' | 'none',
-            is_winner: winnerGangSet.has(p.gang_id),
-            claimed_territory: claimerGangId !== null && p.gang_id === claimerGangId,
-          })),
-          claimed_territories: options?.campaign_territory_id
-            ? [{ campaign_territory_id: options.campaign_territory_id }]
-            : [],
-          territory_claimed_by_gang_id: claimerGangId,
-          created_at: session.created_at,
-          cycle: options?.cycle ?? null,
-        });
-        campaign_battle_id = battleLog?.id;
-      } catch (err) {
-        console.error('Error creating campaign battle log:', err);
+      const battleParticipants = allParticipants.map((p) => ({
+        role: p.role,
+        gang_id: p.gang_id,
+        is_winner: winnerGangSet.has(p.gang_id),
+        claimed_territory: claimerGangId !== null && p.gang_id === claimerGangId,
+      }));
+
+      const { data: battle, error: battleError } = await supabase
+        .from('campaign_battles')
+        .insert([
+          {
+            campaign_id: session.campaign_id,
+            scenario: session.scenario || '',
+            winner_id: legacyWinnerId,
+            note: options?.note || null,
+            participants: JSON.stringify(battleParticipants),
+            created_at: session.created_at ?? new Date().toISOString(),
+            campaign_territory_id: options?.campaign_territory_id || null,
+            cycle: options?.cycle ?? null,
+          },
+        ])
+        .select('id')
+        .single();
+
+      if (battleError) {
+        console.error('Error creating campaign battle log:', battleError);
         return { success: false, error: 'Failed to create campaign battle log' };
+      }
+      campaign_battle_id = battle.id;
+
+      // Claim territory in same flow
+      if (options?.campaign_territory_id && claimerGangId) {
+        await supabase
+          .from('campaign_territories')
+          .update({ gang_id: claimerGangId })
+          .eq('id', options.campaign_territory_id)
+          .eq('campaign_id', session.campaign_id);
       }
     }
 
-    let claimed_territory: string | null = null;
-    if (options?.campaign_territory_id) {
-      const { data: territory } = await supabase
-        .from('campaign_territories')
-        .select('territory_name')
-        .eq('id', options.campaign_territory_id)
-        .single();
-      claimed_territory = territory?.territory_name ?? null;
-    }
-
+    // --- Core state change ---
     const { data: updated, error } = await supabase
       .from('battle_sessions')
       .update({
@@ -1271,72 +1282,123 @@ export async function completeBattleSession(
       return { success: false, error: error?.message || 'Session was already completed' };
     }
 
+    // Invalidate session cache so the client renders the completed state
     revalidateTag(CACHE_TAGS.BASE_BATTLE_SESSION(sessionId));
 
-    if (allParticipants) {
-      for (const p of allParticipants) {
-        revalidateTag(CACHE_TAGS.GANG_BATTLE_SESSIONS(p.gang_id));
-      }
+    // === Everything below runs AFTER the response is sent ===
+    after(async () => {
+      try {
+        if (!allParticipants) return;
 
-      // Log battle results for non-campaign sessions (campaign logging handled by createBattleLog)
-      if (!session.campaign_id) {
+        // Fetch gang names + owner IDs for logging (one query)
         const gangIds = allParticipants.map((p) => p.gang_id);
-        const { data: gangNames } = await supabase
+        const { data: gangs } = await supabase
           .from('gangs')
-          .select('id, name')
+          .select('id, name, user_id')
           .in('id', gangIds);
-        const gangNameMap = new Map(gangNames?.map((g) => [g.id, g.name]) || []);
+        const gangMap = new Map<string, { id: string; name: string; user_id: string }>(
+          gangs?.map((g) => [g.id, g]) || []
+        );
 
-        for (const p of allParticipants) {
-          const gangName = gangNameMap.get(p.gang_id);
-          if (!gangName) continue;
+        // Batch gang logs — one insert instead of N sequential calls
+        const campaignName = session.campaign_id ? undefined : 'Standalone Battle';
+        let resolvedCampaignName = campaignName;
+        if (session.campaign_id) {
+          const { data: campaign } = await supabase
+            .from('campaigns')
+            .select('campaign_name')
+            .eq('id', session.campaign_id)
+            .single();
+          resolvedCampaignName = campaign?.campaign_name || 'Campaign';
+        }
 
-          // Multi-winner aware: every flagged winner is logged as 'won'.
-          let battleResult: 'won' | 'lost' | 'draw';
-          if (winnerGangSet.size === 0) {
-            battleResult = 'draw';
-          } else if (winnerGangSet.has(p.gang_id)) {
-            battleResult = 'won';
-          } else {
-            battleResult = 'lost';
-          }
+        const logs = allParticipants
+          .map((p) => {
+            const gang = gangMap.get(p.gang_id);
+            if (!gang) return null;
 
-          const opponents = allParticipants
-            .filter((op) => op.gang_id !== p.gang_id)
-            .map((op) => gangNameMap.get(op.gang_id))
-            .filter(Boolean)
-            .join(', ');
+            let result: 'won' | 'lost' | 'draw';
+            if (winnerGangSet.size === 0) {
+              result = 'draw';
+            } else if (winnerGangSet.has(p.gang_id)) {
+              result = 'won';
+            } else {
+              result = 'lost';
+            }
 
-          try {
-            await logBattleResult({
+            const opponents = allParticipants
+              .filter((op) => op.gang_id !== p.gang_id)
+              .map((op) => gangMap.get(op.gang_id)?.name)
+              .filter(Boolean)
+              .join(', ');
+
+            const roleText =
+              p.role === 'attacker'
+                ? 'attacked'
+                : p.role === 'defender'
+                  ? 'defended against'
+                  : 'fought';
+            const resultText =
+              result === 'won' ? 'Victory!' : result === 'lost' ? 'Defeat' : 'Draw';
+
+            return {
               gang_id: p.gang_id,
-              gang_name: gangName,
-              campaign_name: 'Standalone Battle',
-              opponent_name: opponents || 'Unknown',
-              scenario: session.scenario || 'Unknown Scenario',
-              result: battleResult,
+              user_id: gang.user_id,
+              action_type: `battle_${result}`,
+              description: `Gang "${gang.name}" ${roleText} "${opponents || 'Unknown'}" in "${session.scenario || 'Unknown Scenario'}" (Campaign: ${resolvedCampaignName}). Result: ${resultText}`,
+              created_at: new Date().toISOString(),
+            };
+          })
+          .filter((log): log is NonNullable<typeof log> => log !== null);
+
+        if (logs.length > 0) {
+          await supabase.from('gang_logs').insert(logs);
+        }
+
+        // Territory claim log
+        if (options?.campaign_territory_id && claimerGangId && claimed_territory) {
+          const claimer = gangMap.get(claimerGangId);
+          if (claimer) {
+            await supabase.from('gang_logs').insert({
+              gang_id: claimerGangId,
+              user_id: claimer.user_id,
+              action_type: 'territory_claimed',
+              description: `Gang "${claimer.name}" claimed territory "${claimed_territory}" in campaign "${resolvedCampaignName}"`,
+              created_at: new Date().toISOString(),
             });
-          } catch (logErr) {
-            console.error('Error logging battle result:', logErr);
           }
         }
-      }
 
-      // Notify participants
-      const notifications = allParticipants
-        .filter((p) => p.user_id !== user.id)
-        .map((p) => ({
-          receiver_id: p.user_id,
-          sender_id: user.id,
-          type: 'info',
-          text: `${senderName} completed a battle session.`,
-          link: `/gang/${p.gang_id}/battle-session/${sessionId}`,
-          dismissed: false,
-        }));
-      if (notifications.length > 0) {
-        await supabase.from('notifications').insert(notifications);
+        // Notifications — one insert
+        const notifications = allParticipants
+          .filter((p) => p.user_id !== user.id)
+          .map((p) => ({
+            receiver_id: p.user_id,
+            sender_id: user.id,
+            type: 'info',
+            text: `${senderName} completed a battle session.`,
+            link: `/gang/${p.gang_id}/battle-session/${sessionId}`,
+            dismissed: false,
+          }));
+        if (notifications.length > 0) {
+          await supabase.from('notifications').insert(notifications);
+        }
+
+        // Deferred cache invalidation
+        for (const p of allParticipants) {
+          revalidateTag(CACHE_TAGS.GANG_BATTLE_SESSIONS(p.gang_id));
+        }
+        if (session.campaign_id) {
+          revalidateTag('campaign-battles');
+          revalidateTag(CACHE_TAGS.BASE_CAMPAIGN_TERRITORIES(session.campaign_id));
+          for (const wid of effectiveWinnerIds) {
+            revalidateTag(CACHE_TAGS.COMPOSITE_GANG_CAMPAIGNS(wid));
+          }
+        }
+      } catch (afterErr) {
+        console.error('Error in deferred battle completion work:', afterErr);
       }
-    }
+    });
 
     return { success: true, campaign_battle_id };
   } catch (err) {

--- a/components/battle-session/active-session.tsx
+++ b/components/battle-session/active-session.tsx
@@ -54,7 +54,7 @@ export default function ActiveSession({
     staleTime: Infinity,
     refetchOnWindowFocus: false,
   });
-  const broadcast = useBattleSessionRealtime(session.id);
+  const { broadcast, suppressRefetch } = useBattleSessionRealtime(session.id);
 
   if (session.status === 'completed') {
     return <CompletedSession session={session} userId={userId} />;
@@ -431,6 +431,7 @@ export default function ActiveSession({
           gangFightersMap={gangFightersMap}
           territories={territories}
           onClose={() => setShowCompleteBattleModal(false)}
+          onSuppressRefetch={suppressRefetch}
         />
       )}
     </>

--- a/components/battle-session/complete-battle-modal.tsx
+++ b/components/battle-session/complete-battle-modal.tsx
@@ -81,8 +81,6 @@ export default function CompleteBattleModal({
   });
 
   const handleConfirm = async () => {
-    onSuppressRefetch?.();
-
     if (!hasAnyWinnerSelected) {
       toast.error('Please select a winner or draw');
       return false;
@@ -103,6 +101,7 @@ export default function CompleteBattleModal({
     }
 
     setSubmitting(true);
+    onSuppressRefetch?.();
 
     const winnerPayload = isDraw
       ? []

--- a/components/battle-session/complete-battle-modal.tsx
+++ b/components/battle-session/complete-battle-modal.tsx
@@ -33,6 +33,7 @@ interface CompleteBattleModalProps {
   gangFightersMap: Record<string, GangFighter[]>;
   territories?: CompleteBattleTerritory[];
   onClose: () => void;
+  onSuppressRefetch?: () => void;
 }
 
 export default function CompleteBattleModal({
@@ -40,6 +41,7 @@ export default function CompleteBattleModal({
   gangFightersMap,
   territories = [],
   onClose,
+  onSuppressRefetch,
 }: CompleteBattleModalProps) {
   // Multi-winner state. Prefill from the persisted is_winner / claimed_territory
   // flags (with fallback to the legacy winner_gang_id for older sessions).
@@ -79,6 +81,8 @@ export default function CompleteBattleModal({
   });
 
   const handleConfirm = async () => {
+    onSuppressRefetch?.();
+
     if (!hasAnyWinnerSelected) {
       toast.error('Please select a winner or draw');
       return false;

--- a/hooks/use-battle-session-realtime.ts
+++ b/hooks/use-battle-session-realtime.ts
@@ -9,11 +9,14 @@ export function useBattleSessionRealtime(sessionId: string) {
   const queryClient = useQueryClient();
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const broadcastChannelRef = useRef<RealtimeChannel | null>(null);
+  const suppressedRef = useRef(false);
+  const suppressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const supabase = createClient();
 
     const debouncedRefresh = () => {
+      if (suppressedRef.current) return;
       if (debounceRef.current) clearTimeout(debounceRef.current);
       debounceRef.current = setTimeout(() => {
         queryClient.invalidateQueries({ queryKey: ['battle-session', sessionId] });
@@ -63,6 +66,7 @@ export function useBattleSessionRealtime(sessionId: string) {
 
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (suppressTimerRef.current) clearTimeout(suppressTimerRef.current);
       broadcastChannelRef.current = null;
       supabase.removeChannel(dbChannel);
       supabase.removeChannel(broadcastChannel);
@@ -77,5 +81,13 @@ export function useBattleSessionRealtime(sessionId: string) {
     });
   }, []);
 
-  return broadcast;
+  const suppressRefetch = useCallback(() => {
+    suppressedRef.current = true;
+    if (suppressTimerRef.current) clearTimeout(suppressTimerRef.current);
+    suppressTimerRef.current = setTimeout(() => {
+      suppressedRef.current = false;
+    }, 2000);
+  }, []);
+
+  return { broadcast, suppressRefetch };
 }


### PR DESCRIPTION
## Summary
Refactored the `completeBattleSession` action to improve performance and user experience by deferring non-critical work, batching database queries, and suppressing unnecessary refetches during completion.

## Key Changes

### Server-side optimizations (`app/actions/battle-sessions.ts`)
- **Deferred work with `after()`**: Moved all logging, notifications, and cache invalidation to run after the response is sent using Next.js `after()` API, ensuring the user sees the completion result immediately
- **Parallel queries**: Consolidated multiple sequential Supabase queries into a single `Promise.all()` call for session, participants, profile, and territory data
- **Inline campaign battle log**: Replaced `createBattleLog()` server action call with direct Supabase insert, eliminating function call overhead
- **Batch gang logs**: Changed from N sequential `logBattleResult()` calls to a single batch insert of all gang logs
- **Territory claim in same flow**: Moved territory update into the campaign battle creation block to reduce round trips
- **Removed unnecessary revalidation**: Deleted `revalidateTag()` call from `fetchBattleSession()` that was invalidating cache on every read

### Client-side improvements (`hooks/use-battle-session-realtime.ts` & `components/battle-session/`)
- **Refetch suppression**: Added `suppressRefetch()` callback to prevent unnecessary query invalidations for 2 seconds after completion
- **Suppress state tracking**: Implemented `suppressedRef` and `suppressTimerRef` to track and enforce suppression window
- **Updated hook return**: Changed `useBattleSessionRealtime()` to return object with `broadcast` and `suppressRefetch` instead of just broadcast
- **Integrated suppression**: Connected `suppressRefetch` callback to `CompleteBattleModal` completion handler

## Implementation Details
- All deferred work is wrapped in error handling to prevent silent failures
- Gang logs now include user_id for proper attribution
- Campaign name resolution is cached within the deferred block to avoid redundant queries
- Territory claim logging is conditional on successful territory update
- Refetch suppression uses a 2-second window to cover typical network latency

https://claude.ai/code/session_01DpZfBBVjrSDP7mdHfA4T4t