### PR TITLE
perf: configure TanStack QueryClient defaults to prevent refetch storms

### DIFF
--- a/app/providers/query-client-provider.tsx
+++ b/app/providers/query-client-provider.tsx
@@ -5,7 +5,20 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 
 export function QueryClientProviderWrapper({ children }: { children: React.ReactNode }) {
-  const [queryClient] = React.useState(() => new QueryClient())
+  const [queryClient] = React.useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            // Without a default staleTime, every mounted query refetches on
+            // window focus/remount, multiplying API and Supabase load.
+            staleTime: 5 * 60 * 1000,
+            gcTime: 10 * 60 * 1000,
+            refetchOnWindowFocus: false,
+          },
+        },
+      })
+  )
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/components/battle-session/create-battle-modal.tsx
+++ b/components/battle-session/create-battle-modal.tsx
@@ -80,6 +80,8 @@ export default function CreateBattleModal({
       return res.json() as Promise<CampaignGang[]>;
     },
     enabled: !!campaignId,
+    // Other players join/leave campaigns; refetch on every modal open
+    staleTime: 0,
   });
 
   const { data: selectedUserGangs, isLoading: loadingGangs } = useQuery({
@@ -91,6 +93,8 @@ export default function CreateBattleModal({
       return (data.gangs || []) as { id: string; name: string; rating: number }[];
     },
     enabled: !!selectedUser,
+    // Opponents' gang lists change outside this client; refetch on every modal open
+    staleTime: 0,
   });
 
   const scenarios = battleData?.scenarios ?? [];


### PR DESCRIPTION
## Problem

The global `QueryClient` in `app/providers/query-client-provider.tsx` was created with no options, so TanStack Query's most aggressive defaults applied app-wide:

- `staleTime: 0` — every mounted query refetches on remount and window focus
- `refetchOnWindowFocus: true` — every tab switch re-fires all mounted queries

With ~240 `useQuery`/`useMutation` instances across the app, every window-focus event triggered a burst of API-route invocations and Supabase reads, directly inflating Vercel and Supabase costs.

## Change

Set sensible global defaults matching the per-query values already used throughout the codebase:

- `staleTime: 5 min`
- `gcTime: 10 min`
- `refetchOnWindowFocus: false`

Per-query options still override these defaults, so the many queries that already set explicit `staleTime` (5–10 min) are unaffected.

## Review finding addressed before pushing

A code review of the diff found one real regression: the create-battle modal's `campaign-gangs` and `user-gangs` queries had no explicit `staleTime` and relied on the old refetch-on-focus behavior to pick up gangs added by other players (a multiplayer-sensitive flow). These now set `staleTime: 0` explicitly so each modal open refetches. The scenarios list (`battle-data`) is admin-curated reference data and keeps the 5-minute default. The battle session itself stays fresh via the existing realtime subscription.

## Verification

- `tsc --noEmit` passes
- `next build` passes

https://claude.ai/code/session_01NZVCbMTmo2hiE4QpSBTLYf

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZVCbMTmo2hiE4QpSBTLYf)_