### PR TITLE
Remove unnecessary fighterName check in equipment purchase

### DIFF
--- a/app/actions/equipment.ts
+++ b/app/actions/equipment.ts
@@ -642,7 +642,7 @@ export async function buyEquipmentForFighter(params: BuyEquipmentParams): Promis
     let createdBeasts: any[] = [];
     let createdBeastsRatingDelta = 0;
 
-    if (params.fighter_id && !params.buy_for_gang_stash && !params.custom_equipment_id && params.equipment_id && fighterName) {
+    if (params.fighter_id && !params.buy_for_gang_stash && !params.custom_equipment_id && params.equipment_id) {
       try {
         const beastResult = await createExoticBeastsForEquipment({
           equipmentId: params.equipment_id,


### PR DESCRIPTION
## Summary
Removed an unnecessary `fighterName` validation check from the equipment purchase condition for exotic beasts creation.

## Key Changes
- Removed `&& fighterName` from the conditional check in `buyEquipmentForFighter` function
- This simplifies the condition while maintaining all other necessary validations (`fighter_id`, `buy_for_gang_stash`, `custom_equipment_id`, and `equipment_id`)

## Implementation Details
The `fighterName` variable was being checked but is not actually required for the exotic beasts creation logic. The other parameters in the condition are sufficient to ensure the operation can proceed safely. This change reduces unnecessary validation overhead without affecting functionality.

https://claude.ai/code/session_012ZYKcxgbFFaTgQGuz5f7go