### PR TITLE
Remove redundant equipment source label for fighters tradingpost

### DIFF
--- a/components/equipment/equipment-tooltip.tsx
+++ b/components/equipment/equipment-tooltip.tsx
@@ -40,9 +40,6 @@ export function getEquipmentTooltipHtml(
     if (item.equipment_tradingpost && (item.trading_post_names || []).length > 0) {
       sourceParts.push((item.trading_post_names || []).join(', '));
     }
-    if (equipmentListType === 'fighters-tradingpost' && item.equipment_tradingpost && (item.trading_post_names || []).length === 0 && !(item.fighter_type_equipment || item.from_fighters_list)) {
-      sourceParts.push(isVehicleEquipment ? "Vehicle's List" : "Fighter's List");
-    }
     if (equipmentListType === 'unrestricted' && sourceParts.length === 0) {
       sourceParts.push('Exclusive');
     }


### PR DESCRIPTION
## Summary
Removed a redundant code block that was adding "Fighter's List" or "Vehicle's List" labels to equipment items in the fighters tradingpost view when no trading post names were available.

## Changes
- Removed the conditional logic that appended "Fighter's List" or "Vehicle's List" source labels for items in the `fighters-tradingpost` equipment list type when they had no trading post names and weren't fighter-type equipment

## Details
This code block was checking a specific combination of conditions (`equipmentListType === 'fighters-tradingpost'` with no trading post names and not fighter-type equipment) to display a fallback source label. The removal suggests this fallback behavior was either:
- Redundant with other source labeling logic
- No longer needed based on updated equipment data structure
- Causing incorrect or unwanted labels in the UI

https://claude.ai/code/session_0175sVi7du2Yr277kK9d9tp1