### PR TITLE
Allow campaign owners/arbitrators to edit battle sessions

### DIFF
--- a/app/actions/battle-sessions.ts
+++ b/app/actions/battle-sessions.ts
@@ -15,6 +15,7 @@ import type {
   SessionRecord,
 } from '@/types/battle-session';
 import { getBattleSessionCached } from '@/app/lib/battle-sessions/get-battle-session-data';
+import { PermissionService } from '@/app/lib/user-permissions';
 
 // =============================================================================
 // Data Fetching
@@ -29,21 +30,61 @@ export async function fetchBattleSession(sessionId: string): Promise<BattleSessi
 // Authorization Helpers
 // =============================================================================
 
-async function verifySessionCreator(
+// Site admins and campaign OWNERs/ARBITRATORs can act on any session in their
+// campaign. Mirrors the RLS policies on the battle session tables
+// (private.is_admin() OR private.is_arb(campaign_id)) and the gang page
+// permission model.
+async function isSessionArbitrator(
+  userId: string,
+  campaignId: string | null
+): Promise<boolean> {
+  const permissionService = new PermissionService();
+  const profile = await permissionService.getUserProfile(userId);
+  if (profile?.user_role === 'admin') return true;
+  if (!campaignId) return false;
+  const role = await permissionService.getCampaignRole(userId, campaignId);
+  return role === 'OWNER' || role === 'ARBITRATOR';
+}
+
+async function canManageSession(
+  userId: string,
+  session: { created_by: string; campaign_id: string | null }
+): Promise<boolean> {
+  if (session.created_by === userId) return true;
+  return isSessionArbitrator(userId, session.campaign_id);
+}
+
+async function verifySessionManager(
   supabase: Awaited<ReturnType<typeof createClient>>,
   sessionId: string,
   userId: string
 ): Promise<{ authorized: boolean; error?: string }> {
   const { data: session } = await supabase
     .from('battle_sessions')
-    .select('created_by')
+    .select('created_by, campaign_id')
     .eq('id', sessionId)
     .single();
 
   if (!session) return { authorized: false, error: 'Session not found' };
-  if (session.created_by !== userId)
-    return { authorized: false, error: 'Only the session creator can perform this action' };
+  if (!(await canManageSession(userId, session)))
+    return { authorized: false, error: 'Only the session creator or an arbitrator can perform this action' };
   return { authorized: true };
+}
+
+// Arbitrators (not the session creator) may act on another player's
+// participant slot — same rights they have over that player's gang page.
+async function isArbitratorForSession(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  sessionId: string,
+  userId: string
+): Promise<boolean> {
+  const { data: session } = await supabase
+    .from('battle_sessions')
+    .select('campaign_id')
+    .eq('id', sessionId)
+    .single();
+  if (!session) return false;
+  return isSessionArbitrator(userId, session.campaign_id);
 }
 
 async function verifySessionParticipant(
@@ -55,13 +96,14 @@ async function verifySessionParticipant(
   if (participantId) {
     const { data: participant } = await supabase
       .from('battle_session_participants')
-      .select('id')
+      .select('id, user_id')
       .eq('id', participantId)
       .eq('battle_session_id', sessionId)
-      .eq('user_id', userId)
       .maybeSingle();
 
     if (!participant)
+      return { authorized: false, error: 'You are not a participant in this session' };
+    if (participant.user_id !== userId && !(await isArbitratorForSession(supabase, sessionId, userId)))
       return { authorized: false, error: 'You are not a participant in this session' };
     return { authorized: true, participantId: participant.id };
   }
@@ -74,9 +116,11 @@ async function verifySessionParticipant(
     .limit(1);
 
   const participant = participants?.[0];
-  if (!participant)
-    return { authorized: false, error: 'You are not a participant in this battle session' };
-  return { authorized: true, participantId: participant.id };
+  if (participant) return { authorized: true, participantId: participant.id };
+
+  if (await isArbitratorForSession(supabase, sessionId, userId))
+    return { authorized: true };
+  return { authorized: false, error: 'You are not a participant in this battle session' };
 }
 
 // =============================================================================
@@ -169,13 +213,13 @@ export async function cancelBattleSession(
 
     const { data: session } = await supabase
       .from('battle_sessions')
-      .select('created_by, status')
+      .select('created_by, campaign_id, status')
       .eq('id', sessionId)
       .single();
 
     if (!session) return { success: false, error: 'Session not found' };
-    if (session.created_by !== user.id)
-      return { success: false, error: 'Only the session creator can cancel' };
+    if (!(await canManageSession(user.id, session)))
+      return { success: false, error: 'Only the session creator or an arbitrator can cancel' };
     if (session.status === 'completed')
       return { success: false, error: 'Cannot cancel a completed session' };
 
@@ -205,7 +249,7 @@ export async function cancelBattleSession(
   }
 }
 
-async function updateSessionAsCreator(
+async function updateSessionAsManager(
   sessionId: string,
   updateFields: Record<string, unknown>,
   options?: { requireStatus?: string; statusError?: string }
@@ -215,13 +259,13 @@ async function updateSessionAsCreator(
 
   const { data: session } = await supabase
     .from('battle_sessions')
-    .select('created_by, status')
+    .select('created_by, campaign_id, status')
     .eq('id', sessionId)
     .single();
 
   if (!session) return { success: false, error: 'Session not found' };
-  if (session.created_by !== user.id)
-    return { success: false, error: 'Only the session creator can perform this action' };
+  if (!(await canManageSession(user.id, session)))
+    return { success: false, error: 'Only the session creator or an arbitrator can perform this action' };
   if (options?.requireStatus && session.status !== options.requireStatus)
     return { success: false, error: options.statusError || 'Invalid session status' };
 
@@ -241,7 +285,7 @@ export async function setSessionScenario(
   scenario: string
 ): Promise<{ success: boolean; error?: string }> {
   try {
-    return await updateSessionAsCreator(sessionId, { scenario });
+    return await updateSessionAsManager(sessionId, { scenario });
   } catch (err) {
     console.error('Error setting scenario:', err);
     return { success: false, error: 'Failed to set scenario' };
@@ -264,7 +308,7 @@ export async function setSessionWinners(
     const supabase = await createClient();
     const user = await getAuthenticatedUser(supabase);
 
-    const auth = await verifySessionCreator(supabase, sessionId, user.id);
+    const auth = await verifySessionManager(supabase, sessionId, user.id);
     if (!auth.authorized) return { success: false, error: auth.error };
 
     const claimers = winners.filter((w) => w.claimed_territory === true);
@@ -452,7 +496,6 @@ export async function toggleParticipantReady(
       .from('battle_session_participants')
       .select('id, ready')
       .eq('id', participantId)
-      .eq('user_id', user.id)
       .single();
     if (!myParticipant) return { success: false, error: 'Participant not found' };
 
@@ -501,7 +544,7 @@ export async function changeSessionPhase(
     const supabase = await createClient();
     const user = await getAuthenticatedUser(supabase);
 
-    const auth = await verifySessionCreator(supabase, sessionId, user.id);
+    const auth = await verifySessionManager(supabase, sessionId, user.id);
     if (!auth.authorized) return { success: false, error: auth.error };
 
     const { data: session } = await supabase
@@ -567,8 +610,8 @@ export async function addParticipant(params: {
     if (!session) return { success: false, error: 'Session not found' };
     if (session.status !== 'pre_battle')
       return { success: false, error: 'Can only add players during pre-battle' };
-    if (session.created_by !== currentUser.id)
-      return { success: false, error: 'Only the session creator can add participants' };
+    if (!(await canManageSession(currentUser.id, session)))
+      return { success: false, error: 'Only the session creator or an arbitrator can add participants' };
 
     // Validate gang belongs to the specified user
     const { data: gangOwner } = await supabase
@@ -662,8 +705,8 @@ export async function removeParticipant(
 
     const isSelfRemoval = participant.user_id === user.id;
     if (!isSelfRemoval) {
-      const auth = await verifySessionCreator(supabase, sessionId, user.id);
-      if (!auth.authorized) return { success: false, error: 'Only the session creator can remove other participants' };
+      const auth = await verifySessionManager(supabase, sessionId, user.id);
+      if (!auth.authorized) return { success: false, error: 'Only the session creator or an arbitrator can remove other participants' };
     }
 
     const { error } = await supabase
@@ -694,7 +737,7 @@ export async function updateParticipantRole(
 
     const { data: session } = await supabase
       .from('battle_sessions')
-      .select('id, status, created_by')
+      .select('id, status, created_by, campaign_id')
       .eq('id', sessionId)
       .single();
 
@@ -711,7 +754,7 @@ export async function updateParticipantRole(
 
     if (!participant) return { success: false, error: 'Participant not found' };
 
-    if (participant.user_id !== user.id && session.created_by !== user.id)
+    if (participant.user_id !== user.id && !(await canManageSession(user.id, session)))
       return { success: false, error: 'Not authorized to change this role' };
 
     const { error } = await supabase
@@ -1164,7 +1207,7 @@ export async function completeBattleSession(
     const supabase = await createClient();
     const user = await getAuthenticatedUser(supabase);
 
-    const auth = await verifySessionCreator(supabase, sessionId, user.id);
+    const auth = await verifySessionManager(supabase, sessionId, user.id);
     if (!auth.authorized) return { success: false, error: auth.error };
 
     // Parallel fetch: session, participants, profile, and territory name (if applicable)

--- a/app/actions/battle-sessions.ts
+++ b/app/actions/battle-sessions.ts
@@ -38,12 +38,7 @@ async function isSessionArbitrator(
   userId: string,
   campaignId: string | null
 ): Promise<boolean> {
-  const permissionService = new PermissionService();
-  const profile = await permissionService.getUserProfile(userId);
-  if (profile?.user_role === 'admin') return true;
-  if (!campaignId) return false;
-  const role = await permissionService.getCampaignRole(userId, campaignId);
-  return role === 'OWNER' || role === 'ARBITRATOR';
+  return new PermissionService().isCampaignArbitrator(userId, campaignId);
 }
 
 async function canManageSession(

--- a/app/actions/battle-sessions.ts
+++ b/app/actions/battle-sessions.ts
@@ -82,6 +82,10 @@ async function isArbitratorForSession(
   return isSessionArbitrator(userId, session.campaign_id);
 }
 
+// Authorizes the user's own participant slot, or any slot for arbitrators.
+// NOTE: callers that need a participant row MUST pass `participantId` — the
+// no-participantId form authorizes session-wide actions and returns no
+// participantId when the caller is an arbitrator without a gang in the session.
 async function verifySessionParticipant(
   supabase: Awaited<ReturnType<typeof createClient>>,
   sessionId: string,
@@ -91,15 +95,20 @@ async function verifySessionParticipant(
   if (participantId) {
     const { data: participant } = await supabase
       .from('battle_session_participants')
-      .select('id, user_id')
+      .select('id, user_id, battle_sessions(campaign_id)')
       .eq('id', participantId)
       .eq('battle_session_id', sessionId)
       .maybeSingle();
 
     if (!participant)
       return { authorized: false, error: 'You are not a participant in this session' };
-    if (participant.user_id !== userId && !(await isArbitratorForSession(supabase, sessionId, userId)))
-      return { authorized: false, error: 'You are not a participant in this session' };
+    if (participant.user_id !== userId) {
+      const session = Array.isArray(participant.battle_sessions)
+        ? participant.battle_sessions[0]
+        : participant.battle_sessions;
+      if (!(await isSessionArbitrator(userId, session?.campaign_id ?? null)))
+        return { authorized: false, error: 'You are not a participant in this session' };
+    }
     return { authorized: true, participantId: participant.id };
   }
 
@@ -491,6 +500,7 @@ export async function toggleParticipantReady(
       .from('battle_session_participants')
       .select('id, ready')
       .eq('id', participantId)
+      .eq('battle_session_id', sessionId)
       .single();
     if (!myParticipant) return { success: false, error: 'Participant not found' };
 

--- a/app/actions/update-gang.ts
+++ b/app/actions/update-gang.ts
@@ -67,8 +67,8 @@ export async function updateGang(params: UpdateGangParams): Promise<UpdateGangRe
   try {
     const supabase = await createClient();
     
-    // Get the current user with optimized getClaims()
-    const user = await getAuthenticatedUser(supabase);
+    // Ensure the caller is authenticated (RLS handles write permissions)
+    await getAuthenticatedUser(supabase);
 
     // Get gang information (RLS will handle permissions)
     const { data: gang, error: gangError } = await supabase
@@ -431,11 +431,13 @@ export async function updateGang(params: UpdateGangParams): Promise<UpdateGangRe
 
       // Only log if something changed
       if (Object.keys(oldResourceStates).length > 0 || creditsChanged || (params.reputation !== undefined && params.reputation_operation)) {
+        // Use gang owner's user_id so logs are attributed to the owner even
+        // when an arbitrator edits on their behalf (matches gang-campaign-logs)
         await logGangResourceChanges({
           gang_id: params.gang_id,
           oldState,
           newState,
-          user_id: user.id
+          user_id: gang.user_id
         });
       }
     } catch (logError) {

--- a/app/actions/update-gang.ts
+++ b/app/actions/update-gang.ts
@@ -432,12 +432,13 @@ export async function updateGang(params: UpdateGangParams): Promise<UpdateGangRe
       // Only log if something changed
       if (Object.keys(oldResourceStates).length > 0 || creditsChanged || (params.reputation !== undefined && params.reputation_operation)) {
         // Use gang owner's user_id so logs are attributed to the owner even
-        // when an arbitrator edits on their behalf (matches gang-campaign-logs)
+        // when an arbitrator edits on their behalf (matches gang-campaign-logs).
+        // Ownerless gangs fall back to the caller inside createGangLog.
         await logGangResourceChanges({
           gang_id: params.gang_id,
           oldState,
           newState,
-          user_id: gang.user_id
+          user_id: gang.user_id ?? undefined
         });
       }
     } catch (logError) {

--- a/app/gang/[id]/battle-session/[sessionId]/page.tsx
+++ b/app/gang/[id]/battle-session/[sessionId]/page.tsx
@@ -34,15 +34,10 @@ export async function renderBattleSessionPage(sessionId: string) {
 
   // Site admins and campaign OWNERs/ARBITRATORs can manage the session like
   // the creator and edit participants like the gang owners (gang page model)
-  let isArbitrator = false;
-  const permissionService = new PermissionService();
-  const profile = await permissionService.getUserProfile(user.id);
-  if (profile?.user_role === 'admin') {
-    isArbitrator = true;
-  } else if (session.campaign_id) {
-    const role = await permissionService.getCampaignRole(user.id, session.campaign_id);
-    isArbitrator = role === 'OWNER' || role === 'ARBITRATOR';
-  }
+  const isArbitrator = await new PermissionService().isCampaignArbitrator(
+    user.id,
+    session.campaign_id
+  );
 
   const uniqueGangIds = Array.from(
     new Set(session.participants.map((p) => p.gang_id))

--- a/app/gang/[id]/battle-session/[sessionId]/page.tsx
+++ b/app/gang/[id]/battle-session/[sessionId]/page.tsx
@@ -4,6 +4,7 @@ import { getAuthenticatedUser } from '@/utils/auth';
 import { getBattleSessionCached } from '@/app/lib/battle-sessions/get-battle-session-data';
 import { getGangFightersList, getGangPositioning, type GangFighter } from '@/app/lib/shared/gang-data';
 import { getCampaignTerritories } from '@/app/lib/campaigns/[id]/get-campaign-data';
+import { PermissionService } from '@/app/lib/user-permissions';
 import ActiveSession from '@/components/battle-session/active-session';
 import CompletedSession from '@/components/battle-session/completed-session';
 
@@ -29,6 +30,18 @@ export async function renderBattleSessionPage(sessionId: string) {
         <CompletedSession session={session} userId={user.id} />
       </div>
     );
+  }
+
+  // Site admins and campaign OWNERs/ARBITRATORs can manage the session like
+  // the creator and edit participants like the gang owners (gang page model)
+  let isArbitrator = false;
+  const permissionService = new PermissionService();
+  const profile = await permissionService.getUserProfile(user.id);
+  if (profile?.user_role === 'admin') {
+    isArbitrator = true;
+  } else if (session.campaign_id) {
+    const role = await permissionService.getCampaignRole(user.id, session.campaign_id);
+    isArbitrator = role === 'OWNER' || role === 'ARBITRATOR';
   }
 
   const uniqueGangIds = Array.from(
@@ -57,6 +70,7 @@ export async function renderBattleSessionPage(sessionId: string) {
       <ActiveSession
         session={session}
         userId={user.id}
+        isArbitrator={isArbitrator}
         scenarios={scenarios || []}
         gangFightersMap={gangFightersMap}
         gangPositioningMap={gangPositioningMap}

--- a/app/lib/user-permissions.ts
+++ b/app/lib/user-permissions.ts
@@ -120,6 +120,24 @@ export class PermissionService {
   }
 
   /**
+   * Check if a user has arbitrator-level rights over a campaign: site admin,
+   * or campaign OWNER/ARBITRATOR. Pass null campaignId for content with no
+   * campaign (only site admins qualify there).
+   *
+   * @param userId - The current user's ID
+   * @param campaignId - The campaign's ID, or null
+   * @returns boolean indicating arbitrator-level access
+   */
+  async isCampaignArbitrator(userId: string, campaignId: string | null): Promise<boolean> {
+    const [profile, role] = await Promise.all([
+      this.getUserProfile(userId),
+      campaignId ? this.getCampaignRole(userId, campaignId) : Promise.resolve(null),
+    ]);
+    if (profile?.user_role === 'admin') return true;
+    return role === 'OWNER' || role === 'ARBITRATOR';
+  }
+
+  /**
    * Check if a user can view a hidden gang
    *
    * Permission Logic:

--- a/components/battle-session/active-session.tsx
+++ b/components/battle-session/active-session.tsx
@@ -323,7 +323,7 @@ export default function ActiveSession({
               participant={participant}
               session={session}
               userId={userId}
-              isOwner={canManage}
+              canManage={canManage}
               isArbitrator={isArbitrator}
               editable={isPreBattle || isPostBattle}
               battleActive={battleActive}

--- a/components/battle-session/active-session.tsx
+++ b/components/battle-session/active-session.tsx
@@ -27,6 +27,7 @@ import type { GangFighter } from '@/app/lib/shared/gang-data';
 interface ActiveSessionProps {
   session: BattleSessionFull;
   userId: string;
+  isArbitrator?: boolean;
   scenarios: Scenario[];
   gangFightersMap: Record<string, GangFighter[]>;
   gangPositioningMap: Record<string, Record<string, any> | null>;
@@ -36,6 +37,7 @@ interface ActiveSessionProps {
 export default function ActiveSession({
   session: initialSession,
   userId,
+  isArbitrator = false,
   scenarios,
   gangFightersMap,
   gangPositioningMap,
@@ -66,6 +68,7 @@ export default function ActiveSession({
   const [showReturnToSetupModal, setShowReturnToSetupModal] = useState(false);
   const [showCompleteBattleModal, setShowCompleteBattleModal] = useState(false);
   const isOwner = session.created_by === userId;
+  const canManage = isOwner || isArbitrator;
   const isPreBattle = session.status === 'pre_battle';
   const isPostBattle = session.status === 'post_battle';
   const battleActive = session.status === 'active';
@@ -101,7 +104,15 @@ export default function ActiveSession({
         setShowCancelModal(false);
         toast.success('Battle cancelled');
         broadcast();
-        router.push(`/gang/${session.participants.find(p => p.user_id === userId)?.gang_id}`);
+        const ownGangId = session.participants.find(p => p.user_id === userId)?.gang_id;
+        // Arbitrators may have no gang in the session; send them to the campaign
+        router.push(
+          ownGangId
+            ? `/gang/${ownGangId}`
+            : session.campaign_id
+              ? `/campaigns/${session.campaign_id}`
+              : '/'
+        );
       } else {
         toast.error(result.error);
       }
@@ -166,7 +177,7 @@ export default function ActiveSession({
             )}
           </div>
           <div className="flex items-center gap-2">
-            {isOwner && (
+            {canManage && (
               <>
                 {isPreBattle && (
                   <Button onClick={() => setShowAddPlayerModal(true)}>
@@ -312,7 +323,8 @@ export default function ActiveSession({
               participant={participant}
               session={session}
               userId={userId}
-              isOwner={isOwner}
+              isOwner={canManage}
+              isArbitrator={isArbitrator}
               editable={isPreBattle || isPostBattle}
               battleActive={battleActive}
               gangFightersList={gangFightersMap[participant.gang_id] || []}
@@ -325,7 +337,7 @@ export default function ActiveSession({
           ))}
         </div>
 
-        {battleActive && isOwner && (
+        {battleActive && canManage && (
           <div className="mt-4 flex justify-end gap-2">
             <Button
               onClick={() => changePhaseMutation.mutate('forward')}
@@ -336,7 +348,7 @@ export default function ActiveSession({
           </div>
         )}
 
-        {isPostBattle && isOwner && (
+        {isPostBattle && canManage && (
           <div className="mt-4 flex justify-end gap-2">
             <Button
               onClick={() => setShowCompleteBattleModal(true)}
@@ -415,12 +427,13 @@ export default function ActiveSession({
         document.body
       )}
 
-      {showAddPlayerModal && userGangInSession && (
+      {showAddPlayerModal && (userGangInSession || canManage) && (
         <CreateBattleModal
-          gangId={userGangInSession.gang_id}
-          gangName={userGangInSession.gang?.name ?? 'Your Gang'}
+          gangId={userGangInSession?.gang_id}
+          gangName={userGangInSession?.gang?.name ?? 'Your Gang'}
           campaignId={session.campaign_id ?? undefined}
           existingSessionId={session.id}
+          existingGangIds={session.participants.map((p) => p.gang_id)}
           onClose={() => setShowAddPlayerModal(false)}
         />
       )}

--- a/components/battle-session/create-battle-modal.tsx
+++ b/components/battle-session/create-battle-modal.tsx
@@ -13,10 +13,12 @@ import { Button } from '@/components/ui/button';
 import type { Scenario } from '@/types/campaign';
 
 interface CreateBattleModalProps {
-  gangId: string;
-  gangName: string;
+  // Optional: arbitrators can add players to a session without having a gang in it
+  gangId?: string;
+  gangName?: string;
   campaignId?: string;
   existingSessionId?: string;
+  existingGangIds?: string[];
   onClose: () => void;
 }
 
@@ -39,6 +41,7 @@ export default function CreateBattleModal({
   gangName,
   campaignId,
   existingSessionId,
+  existingGangIds = [],
   onClose,
 }: CreateBattleModalProps) {
   const router = useRouter();
@@ -105,7 +108,10 @@ export default function CreateBattleModal({
   });
 
   const opponentCampaignGangs = (campaignGangs ?? []).filter(
-    (g) => g.id !== gangId && !selectedCampaignGangIds.includes(g.id)
+    (g) =>
+      g.id !== gangId &&
+      !selectedCampaignGangIds.includes(g.id) &&
+      !existingGangIds.includes(g.id)
   );
 
   // User search (non-campaign, debounced)
@@ -170,9 +176,12 @@ export default function CreateBattleModal({
     setSelectedCampaignGangIds((prev) => prev.filter((id) => id !== campaignGangId));
   };
 
-  // Filter out gangs already added as opponents
+  // Filter out gangs already added as opponents or already in the session
   const availableUserGangs = (selectedUserGangs ?? []).filter(
-    (g) => g.id !== gangId && !opponents.some((o) => o.gangId === g.id)
+    (g) =>
+      g.id !== gangId &&
+      !opponents.some((o) => o.gangId === g.id) &&
+      !existingGangIds.includes(g.id)
   );
 
   const createMutation = useMutation({
@@ -214,11 +223,11 @@ export default function CreateBattleModal({
         return { success: true };
       }
 
-      // Create mode
+      // Create mode (always launched from a gang page, so gangId is set)
       const scenarioName = selectedScenario === 'custom'
         ? customScenario.trim()
         : sortedScenarios.find((s) => s.id === selectedScenario)?.scenario_name;
-      const allGangIds = [gangId];
+      const allGangIds = gangId ? [gangId] : [];
 
       if (campaignId) {
         allGangIds.push(...selectedCampaignGangIds);
@@ -269,15 +278,17 @@ export default function CreateBattleModal({
       width="md"
     >
       <div className="space-y-4">
-        {/* Your Gang */}
-        <div>
-          <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
-            Your Gang
-          </label>
-          <div className="rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800">
-            {gangName}
+        {/* Your Gang (hidden for arbitrators without a gang in the session) */}
+        {gangId && (
+          <div>
+            <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+              Your Gang
+            </label>
+            <div className="rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm dark:border-neutral-700 dark:bg-neutral-800">
+              {gangName}
+            </div>
           </div>
-        </div>
+        )}
 
         {/* Opponent selection */}
         {campaignId ? (

--- a/components/battle-session/create-battle-modal.tsx
+++ b/components/battle-session/create-battle-modal.tsx
@@ -223,7 +223,8 @@ export default function CreateBattleModal({
         return { success: true };
       }
 
-      // Create mode (always launched from a gang page, so gangId is set)
+      // Create mode — gangId may only be absent in add mode (arbitrators),
+      // but guard anyway so a session is never created with an undefined gang
       const scenarioName = selectedScenario === 'custom'
         ? customScenario.trim()
         : sortedScenarios.find((s) => s.id === selectedScenario)?.scenario_name;

--- a/components/battle-session/participant-card.tsx
+++ b/components/battle-session/participant-card.tsx
@@ -841,7 +841,8 @@ interface ParticipantCardProps {
   participant: BattleSessionParticipant & { fighters: BattleSessionFighter[] };
   session: BattleSessionFull;
   userId: string;
-  isOwner: boolean;
+  // Session creator or arbitrator: may manage participants (remove, set roles)
+  canManage: boolean;
   // Campaign OWNER/ARBITRATOR (or site admin): may edit any participant's data,
   // unlike the session creator who only manages the session itself
   isArbitrator?: boolean;
@@ -856,7 +857,7 @@ export default function ParticipantCard({
   participant,
   session,
   userId,
-  isOwner,
+  canManage,
   isArbitrator = false,
   editable = false,
   battleActive = false,
@@ -888,7 +889,7 @@ export default function ParticipantCard({
   const canEdit = editable && (isMyGang || isArbitrator) && !isPostBattle;
   const canInteract = battleActive && (isMyGang || isArbitrator);
   const canPostBattle = isPostBattle && (isMyGang || isArbitrator);
-  const canEditRole = editable && (isOwner || isMyGang) && !isPostBattle;
+  const canEditRole = editable && (canManage || isMyGang) && !isPostBattle;
 
   const handleRoleChange = (role: 'attacker' | 'defender' | 'none') => {
     setLocalRole(role);
@@ -1313,7 +1314,7 @@ export default function ParticipantCard({
               )}
             </div>
           </div>
-          {(canEdit || canPostBattle || ((isOwner || isMyGang) && editable && !isPostBattle)) && (
+          {(canEdit || canPostBattle || ((canManage || isMyGang) && editable && !isPostBattle)) && (
             <div className="flex gap-2 self-end sm:self-auto">
               {(canEdit || canPostBattle) && (
                 <>
@@ -1343,7 +1344,7 @@ export default function ParticipantCard({
                   )}
                 </>
               )}
-              {(isOwner || isMyGang) && editable && !isPostBattle && (
+              {(canManage || isMyGang) && editable && !isPostBattle && (
                 <Button
                   variant="destructive"
                   onClick={() => removeMutation.mutate()}

--- a/components/battle-session/participant-card.tsx
+++ b/components/battle-session/participant-card.tsx
@@ -842,6 +842,9 @@ interface ParticipantCardProps {
   session: BattleSessionFull;
   userId: string;
   isOwner: boolean;
+  // Campaign OWNER/ARBITRATOR (or site admin): may edit any participant's data,
+  // unlike the session creator who only manages the session itself
+  isArbitrator?: boolean;
   editable?: boolean;
   battleActive?: boolean;
   gangFightersList?: GangFighter[];
@@ -854,6 +857,7 @@ export default function ParticipantCard({
   session,
   userId,
   isOwner,
+  isArbitrator = false,
   editable = false,
   battleActive = false,
   gangFightersList = [],
@@ -881,9 +885,9 @@ export default function ParticipantCard({
   const localReady = readyOverride ?? participant.ready;
   const isMyGang = participant.user_id === userId;
   const isPostBattle = session.status === 'post_battle';
-  const canEdit = editable && isMyGang && !isPostBattle;
-  const canInteract = battleActive && isMyGang;
-  const canPostBattle = isPostBattle && isMyGang;
+  const canEdit = editable && (isMyGang || isArbitrator) && !isPostBattle;
+  const canInteract = battleActive && (isMyGang || isArbitrator);
+  const canPostBattle = isPostBattle && (isMyGang || isArbitrator);
   const canEditRole = editable && (isOwner || isMyGang) && !isPostBattle;
 
   const handleRoleChange = (role: 'attacker' | 'defender' | 'none') => {
@@ -1633,7 +1637,7 @@ export default function ParticipantCard({
             </div>
           )}
 
-          {isPostBattle && !isMyGang && (localRepChange !== 0 || localCreditsEarned !== 0 || localResourceChanges.some((r) => r.quantity_delta !== 0)) && (
+          {isPostBattle && !isMyGang && !isArbitrator && (localRepChange !== 0 || localCreditsEarned !== 0 || localResourceChanges.some((r) => r.quantity_delta !== 0)) && (
             <div className="border-t border-neutral-100 pt-3 text-sm dark:border-neutral-700 flex gap-4 flex-wrap">
               {localRepChange !== 0 && (
                 <span>Reputation: {localRepChange > 0 ? '+' : ''}{localRepChange}</span>


### PR DESCRIPTION
## Summary

Campaign **OWNERs/ARBITRATORs** (and site admins) can now edit battle sessions belonging to their campaign — the same model as the gang page, where arbitrators have full edit rights over gangs in their campaign.

The RLS policies on `battle_sessions` / `battle_session_participants` / `battle_session_fighters` already permitted this (`private.is_admin() OR private.is_arb(campaign_id)`); this PR wires it through the TypeScript server actions and the UI. **No DB migration.**

### What arbitrators can now do
- **Session management** (previously creator-only): cancel, change scenario, phase transitions, add/remove players, set winners, complete battle, advance/revert rounds.
- **Participant data** (previously the player only): crew selection, loadouts, XP/injuries/conditions, ready toggle, roles, credits/reputation/resource outcomes.

Sessions without a `campaign_id` grant arbitrators nothing, and a session *creator* gains no new rights over other players' data.

### Owner attribution
Writes made on a player's behalf carry the **gang owner's** `user_id`, following the existing arbitrator-equipment-purchase pattern. The one gap found was `updateGang`'s resource-change logs, which were attributed to the caller — now attributed to the gang owner (also fixes arbitrator edits from the gang page).

### Changes
- `app/actions/battle-sessions.ts` — `canManageSession`/`isSessionArbitrator` helpers; creator-only checks accept arbitrators; `verifySessionParticipant` falls back to arbitrator rights
- `app/lib/user-permissions.ts` — new `PermissionService.isCampaignArbitrator()` shared by actions and page
- `app/actions/update-gang.ts` — log attribution fix
- `app/gang/[id]/battle-session/[sessionId]/page.tsx` — computes `isArbitrator` server-side
- `components/battle-session/active-session.tsx` / `participant-card.tsx` — arbitrator gating; `ParticipantCard` prop renamed `isOwner` → `canManage`; cancel-redirect fallback for arbitrators without a gang in the session
- `components/battle-session/create-battle-modal.tsx` — `gangId`/`gangName` optional so arbitrators can add players; opponent list excludes gangs already in the session

### Review & verification
- Pre-push code review ran 7 analysis angles; confirmed cleanups were applied (shared permission helper, prop rename). Notably verified: the `gang_logs` INSERT policy only constrains `gang_id` (arbitrators qualify via campaign membership), so owner-attributed log rows pass RLS.
- `npx tsc --noEmit` passes.

https://claude.ai/code/session_01Af9JaAhWR98Hp2VXzjeMmH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Af9JaAhWR98Hp2VXzjeMmH)_