### PR TITLE
Don't refresh activations for injured fighters on round change

### DIFF
--- a/app/actions/battle-sessions.ts
+++ b/app/actions/battle-sessions.ts
@@ -450,12 +450,15 @@ export async function advanceRound(
         fighters.map((f) => {
           const rules = rulesMap.get(f.fighter_id);
           const isDual = rules?.some((r) => DUAL_ACTIVATION_RULES.includes(r)) ?? false;
+          // Injured fighters are out of action and get no fresh activation;
+          // players can still grant one manually via updateActivations
+          const isInjured = (f.session_record?.injuries?.length ?? 0) > 0;
           const record: SessionRecord = {
             xp_earned: f.session_record?.xp_earned ?? 0,
             injuries: f.session_record?.injuries ?? [],
             conditions: f.session_record?.conditions ?? [],
             note: f.session_record?.note,
-            activations: isDual ? 2 : 1,
+            activations: isInjured ? 0 : isDual ? 2 : 1,
           };
           return supabase
             .from('battle_session_fighters')


### PR DESCRIPTION
## Summary

When a round is completed (or reverted) in a battle session, `advanceRound` resets every fighter's `activations` — including fighters who took an injury during the session. Injured fighters are out of action and shouldn't be handed a fresh activation each round.

## Change

Server action only (`app/actions/battle-sessions.ts`, `advanceRound`): the per-round reset now gives fighters with any recorded session injury **0** activations instead of 1 (or 2 for dual-activation special rules). Applies to both Complete Round and Revert Round, which share the reset.

Players can still toggle activations manually — `updateActivations` is untouched — so a fighter can be given an activation by hand when needed.

## Verification

- `npx tsc --noEmit` passes.
- Manual: in an active session, record an injury on fighter A, complete the round → uninjured fighters reset to 1 (2 with dual-activation rules), fighter A stays at 0; manually toggling A's activation still works.

https://claude.ai/code/session_01Af9JaAhWR98Hp2VXzjeMmH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Af9JaAhWR98Hp2VXzjeMmH)_