### PR TITLE
Equipment attachment tooltip updates

### DIFF
--- a/app/actions/equipment.ts
+++ b/app/actions/equipment.ts
@@ -965,6 +965,22 @@ export async function buyEquipmentForFighter(params: BuyEquipmentParams): Promis
             try {
               invalidateFighterDataWithFinancials(params.fighter_id, params.gang_id);
             } catch {}
+
+            // Include the applied effect's modifiers in the response so the client can
+            // update the target weapon's profiles immediately without a page refresh
+            if (result.effect_data) {
+              responseData.attachment_effect = {
+                id: result.effect_id,
+                effect_name: result.effect_data.effect_name,
+                type_specific_data: result.effect_data.type_specific_data || {},
+                fighter_effect_modifiers: (result.effect_data.fighter_effect_type_modifiers || []).map((m: any) => ({
+                  stat_name: m.stat_name,
+                  numeric_value: m.default_numeric_value,
+                  operation: m.operation || 'add'
+                })),
+                target_equipment_id: chosenTargetId
+              };
+            }
           }
         } catch (e) {
           console.error('Failed to attach equipment upgrade during purchase:', e);

--- a/app/lib/shared/fighter-data.ts
+++ b/app/lib/shared/fighter-data.ts
@@ -462,12 +462,13 @@ export const getFighterEquipment = async (fighterId: string, supabase: any): Pro
           }
 
           // If we have profiles, apply equipment-targeted effects from fighter_effects targeting this equipment
+          let baseWeaponProfiles: any[] | null = null;
           if (weaponProfiles.length > 0) {
             // Lookup targeting effects from Map (O(1) instead of query)
             const targetingEffects = targetingEffectsMap.get(fighterEquipmentId) || [];
 
             if (targetingEffects.length > 0) {
-              // Use shared utility function to apply weapon modifiers
+              baseWeaponProfiles = weaponProfiles;
               weaponProfiles = applyWeaponModifiers(weaponProfiles, targetingEffects);
             }
           }
@@ -490,6 +491,7 @@ export const getFighterEquipment = async (fighterId: string, supabase: any): Pro
             is_master_crafted: item.is_master_crafted || false,
             is_editable: item.is_editable || false,
             weapon_profiles: weaponProfiles,
+            base_weapon_profiles: baseWeaponProfiles,
             target_equipment_id: targetEquipmentId,
             effect_names: effectNames.length > 0 ? effectNames : undefined,
             loadout_ids: loadoutIds.length > 0 ? loadoutIds : undefined,

--- a/app/lib/shared/fighter-data.ts
+++ b/app/lib/shared/fighter-data.ts
@@ -332,7 +332,11 @@ export const getFighterEquipment = async (fighterId: string, supabase: any): Pro
               .order('profile_name')
           : Promise.resolve({ data: [] }),
 
-        // Batch fetch targeting effects (effects that target equipment)
+        // Batch fetch targeting effects (effects that modify weapon profiles).
+        // Two cases mirror the gang-data.ts approach:
+        // 1. Equipment-to-equipment upgrades: fighter_equipment_id = source attachment,
+        //    target_equipment_id = target weapon
+        // 2. Rig glitches: fighter_equipment_id = target weapon, target_equipment_id = NULL
         fighterEquipmentIds.length > 0
           ? supabase
               .from('fighter_effects')
@@ -342,11 +346,13 @@ export const getFighterEquipment = async (fighterId: string, supabase: any): Pro
                 effect_name,
                 type_specific_data,
                 sort_order,
+                fighter_equipment_id,
                 target_equipment_id,
                 fighter_effect_type:fighter_effect_type_id ( sort_order ),
                 fighter_effect_modifiers ( stat_name, numeric_value, operation )
               `)
-              .in('target_equipment_id', fighterEquipmentIds)
+              .eq('fighter_id', fighterId)
+              .not('fighter_equipment_id', 'is', null)
           : Promise.resolve({ data: [] }),
 
         // Batch fetch loadout assignments (which loadouts each equipment belongs to)
@@ -392,10 +398,12 @@ export const getFighterEquipment = async (fighterId: string, supabase: any): Pro
 
       const targetingEffectsMap = new Map<string, any[]>();
       (targetingEffectsData.data || []).forEach((effect: any) => {
-        if (!targetingEffectsMap.has(effect.target_equipment_id)) {
-          targetingEffectsMap.set(effect.target_equipment_id, []);
+        const targetId = effect.target_equipment_id || effect.fighter_equipment_id;
+        if (!targetId) return;
+        if (!targetingEffectsMap.has(targetId)) {
+          targetingEffectsMap.set(targetId, []);
         }
-        targetingEffectsMap.get(effect.target_equipment_id)!.push(effect);
+        targetingEffectsMap.get(targetId)!.push(effect);
       });
       // Sort effects by sort_order (type as default, instance as override) and build names map
       const targetingEffectNamesMap = new Map<string, string[]>();

--- a/components/equipment/equipment-tooltip.tsx
+++ b/components/equipment/equipment-tooltip.tsx
@@ -11,6 +11,12 @@ export interface EquipmentTooltipOptions {
   isVehicleEquipment?: boolean;
 }
 
+function formatRange(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) return '-';
+  const strValue = value.toString();
+  return /\d$/.test(strValue) ? `${strValue}"` : strValue;
+}
+
 function hasProfileData(profile: WeaponProfile): boolean {
   return !!(
     profile.range_short || profile.range_long ||
@@ -106,8 +112,8 @@ export function getEquipmentTooltipHtml(
         html += '<tr style="border-bottom: 1px solid #555;">';
         html += `<td style="padding: 2px; vertical-align: top; font-weight: 500; text-overflow: ellipsis; max-width: 10vw;">${profile.profile_name || '-'}</td>`;
         if (profileHasData) {
-          html += `<td style="padding: 3px; vertical-align: top; text-align: center; border-left: 1px solid #555;">${profile.range_short ?? '-'}</td>`;
-          html += `<td style="padding: 3px; vertical-align: top; text-align: center;">${profile.range_long ?? '-'}</td>`;
+          html += `<td style="padding: 3px; vertical-align: top; text-align: center; border-left: 1px solid #555;">${formatRange(profile.range_short)}</td>`;
+          html += `<td style="padding: 3px; vertical-align: top; text-align: center;">${formatRange(profile.range_long)}</td>`;
           html += `<td style="padding: 3px; vertical-align: top; text-align: center; border-left: 1px solid #555;">${profile.acc_short ?? '-'}</td>`;
           html += `<td style="padding: 3px; vertical-align: top; text-align: center;">${profile.acc_long ?? '-'}</td>`;
           html += `<td style="padding: 3px; vertical-align: top; text-align: center; border-left: 1px solid #555;">${profile.strength ?? '-'}</td>`;

--- a/components/fighter/fighter-equipment-list.tsx
+++ b/components/fighter/fighter-equipment-list.tsx
@@ -187,7 +187,8 @@ export function WeaponList({
           updated = updated.map(eq => {
             if (eq.fighter_equipment_id !== attachmentEffect.target_equipment_id) return eq;
             const baseProfiles = eq.base_weapon_profiles || eq.weapon_profiles || [];
-            const modifiedProfiles = applyWeaponModifiers(baseProfiles, [attachmentEffect]);
+            const currentProfiles = eq.weapon_profiles || [];
+            const modifiedProfiles = applyWeaponModifiers(currentProfiles, [attachmentEffect]);
             return { ...eq, base_weapon_profiles: baseProfiles, weapon_profiles: modifiedProfiles };
           });
         }

--- a/components/fighter/fighter-equipment-list.tsx
+++ b/components/fighter/fighter-equipment-list.tsx
@@ -24,6 +24,7 @@ import FighterLoadoutsModal from '@/components/fighter/fighter-loadouts-modal';
 import { Badge } from '@/components/ui/badge';
 import { setActiveLoadout } from '@/app/actions/loadouts';
 import { EquipmentTooltipTrigger, EquipmentTooltip } from '@/components/equipment/equipment-tooltip';
+import { applyWeaponModifiers } from '@/utils/effect-modifiers';
 import { Tooltip } from 'react-tooltip';
 
 // Escape untrusted strings before inlining into tooltip HTML
@@ -158,13 +159,28 @@ export function WeaponList({
         const newEquipmentId = data?.insertIntofighter_equipmentCollection?.records?.[0]?.id;
 
         // Replace temp with real item and reconcile credits
-        const updated = [...previousEquipment, {
+        const newItem: Equipment = {
           ...item,
           fighter_equipment_id: newEquipmentId || tempId,
           cost: serverRatingCost,
           is_master_crafted: Boolean(data?.insertIntofighter_equipmentCollection?.records?.[0]?.is_master_crafted) || isMaster,
           target_equipment_id: params?.equipment_target?.target_equipment_id || params?.target_equipment_id || item.target_equipment_id,
-        } as Equipment];
+        } as Equipment;
+
+        let updated: Equipment[] = [...previousEquipment, newItem];
+
+        // If the purchase attached an effect to another weapon (e.g. a weapon upgrade tier),
+        // apply the modifiers to that weapon's profiles in state so tooltips reflect the
+        // change immediately without requiring a page refresh.
+        const attachmentEffect = data?.attachment_effect;
+        if (attachmentEffect?.target_equipment_id) {
+          updated = updated.map(eq => {
+            if (eq.fighter_equipment_id !== attachmentEffect.target_equipment_id) return eq;
+            const baseProfiles = eq.base_weapon_profiles || eq.weapon_profiles || [];
+            const modifiedProfiles = applyWeaponModifiers(baseProfiles, [attachmentEffect]);
+            return { ...eq, base_weapon_profiles: baseProfiles, weapon_profiles: modifiedProfiles };
+          });
+        }
 
         onEquipmentUpdate(updated, previousFighterCredits + serverRatingCost, newGangCredits);
 

--- a/components/fighter/fighter-equipment-list.tsx
+++ b/components/fighter/fighter-equipment-list.tsx
@@ -27,6 +27,19 @@ import { EquipmentTooltipTrigger, EquipmentTooltip } from '@/components/equipmen
 import { applyWeaponModifiers } from '@/utils/effect-modifiers';
 import { Tooltip } from 'react-tooltip';
 
+// When a weapon attachment is removed, revert the target weapon's profiles to base
+function revertWeaponProfilesAfterRemoval(filteredEquipment: Equipment[], removedItem: Equipment): Equipment[] {
+  if (!removedItem.target_equipment_id) return filteredEquipment;
+  return filteredEquipment.map(eq => {
+    if (eq.fighter_equipment_id !== removedItem.target_equipment_id) return eq;
+    const stillTargeted = filteredEquipment.some(r => r.target_equipment_id === eq.fighter_equipment_id);
+    if (!stillTargeted && eq.base_weapon_profiles) {
+      return { ...eq, weapon_profiles: eq.base_weapon_profiles, base_weapon_profiles: null };
+    }
+    return eq;
+  });
+}
+
 // Escape untrusted strings before inlining into tooltip HTML
 const escapeHtml = (unsafe: string): string =>
   unsafe
@@ -169,9 +182,6 @@ export function WeaponList({
 
         let updated: Equipment[] = [...previousEquipment, newItem];
 
-        // If the purchase attached an effect to another weapon (e.g. a weapon upgrade tier),
-        // apply the modifiers to that weapon's profiles in state so tooltips reflect the
-        // change immediately without requiring a page refresh.
         const attachmentEffect = data?.attachment_effect;
         if (attachmentEffect?.target_equipment_id) {
           updated = updated.map(eq => {
@@ -219,7 +229,8 @@ export function WeaponList({
       }
 
       // Optimistic UI: remove item and adjust fighter credits
-      const optimisticEquipment = equipment.filter(e => e.fighter_equipment_id !== fighterEquipmentId);
+      const filtered = equipment.filter(e => e.fighter_equipment_id !== fighterEquipmentId);
+      const optimisticEquipment = revertWeaponProfilesAfterRemoval(filtered, equipmentToDelete);
       const optimisticFighterCredits = previousFighterCredits - (equipmentToDelete.cost ?? 0);
       onEquipmentUpdate(optimisticEquipment, optimisticFighterCredits, previousGangCredits);
 
@@ -265,9 +276,8 @@ export function WeaponList({
       if (!equipmentToSell) throw new Error('Equipment not found');
 
       // Optimistic UI: remove item, adjust fighter and gang credits
-      const optimisticEquipment = equipment.filter(
-        item => item.fighter_equipment_id !== fighterEquipmentId
-      );
+      const filtered = equipment.filter(item => item.fighter_equipment_id !== fighterEquipmentId);
+      const optimisticEquipment = revertWeaponProfilesAfterRemoval(filtered, equipmentToSell);
       const optimisticFighterCredits = previousFighterCredits - (equipmentToSell.cost ?? 0);
       const optimisticGangCredits = previousGangCredits + (manualCost || 0);
       onEquipmentUpdate(optimisticEquipment, optimisticFighterCredits, optimisticGangCredits);
@@ -313,9 +323,8 @@ export function WeaponList({
       }
 
       // Optimistic UI: remove item and adjust fighter credits (gang credits unchanged)
-      const optimisticEquipment = equipment.filter(
-        item => item.fighter_equipment_id !== fighterEquipmentId
-      );
+      const filtered = equipment.filter(item => item.fighter_equipment_id !== fighterEquipmentId);
+      const optimisticEquipment = revertWeaponProfilesAfterRemoval(filtered, equipmentToStash);
       const optimisticFighterCredits = previousFighterCredits - (equipmentToStash.cost ?? 0);
       onEquipmentUpdate(optimisticEquipment, optimisticFighterCredits, previousGangCredits);
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",
+    "dev:fresh": "npx next clean && npx next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "clean": "next clean"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",
-    "dev:fresh": "npx next clean && npx next dev --turbopack",
+    "dev:fresh": "next clean && next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "clean": "next clean"


### PR DESCRIPTION
## Summary

- Weapon attachment tooltips on the fighter page were showing base (unmodified) weapon profiles even when attachments (e.g. Tier 1 upgrade) had modifiers applied
- Range values in tooltips were missing the inch symbol (`24` instead of `24"`)
- Removing an attachment didn't revert the parent weapon's profiles in client state

## Changes

- **`fighter-data.ts`**: Fixed targeting effects query to mirror `gang-data.ts` — previously used `.in('target_equipment_id', ...)` which missed effects where `target_equipment_id` is null (rig-glitch style). Now fetches all effects with `fighter_equipment_id` set for the fighter and resolves the target as `target_equipment_id || fighter_equipment_id`. Also populates `base_weapon_profiles` alongside modified profiles to enable client-side revert.
- **`equipment.ts`**: Returns `attachment_effect` with modifiers in the server response so the client can update the target weapon's tooltip immediately after purchase without a page refresh.
- **`fighter-equipment-list.tsx`**: Applies `attachment_effect` modifiers to the target weapon optimistically after purchase; reverts profiles to `base_weapon_profiles` when an attachment is removed.
- **`equipment-tooltip.tsx`**: Appends `"` to numeric range values to match the fighter card display.
- **`package.json`**: Adds `dev:fresh` script for a clean dev server restart that clears the data cache.

## Test plan

- [ ] Fighter with an attachment (e.g. Yeld missile gauntlet + Tier 1) — tooltip shows modified profiles (AP, range etc.)
- [ ] Range values display with inch symbol (`24"` not `24`)
- [ ] Purchasing a new attachment updates the target weapon's tooltip immediately without a page refresh
- [ ] Removing an attachment reverts the target weapon's tooltip to base profiles immediately
- [ ] Page refresh after any of the above shows correct data