### PR TITLE
Fix React 19 script tag warning with next-themes: Remove the mounted …

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -133,7 +133,7 @@ export default async function RootLayout({
               (function() {
                 try {
                   const theme = localStorage.getItem('mundamanager-theme');
-                  const isDark = theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches);
+                  const isDark = theme === 'dark' || ((theme === 'system' || !theme) && window.matchMedia('(prefers-color-scheme: dark)').matches);
                   const currentClass = document.documentElement.className;
                   document.documentElement.className = currentClass + (isDark ? ' dark' : '');
                 } catch (_) {}

--- a/components/client-theme-provider.tsx
+++ b/components/client-theme-provider.tsx
@@ -2,18 +2,23 @@
 
 import { ThemeProvider as NextThemesProvider } from 'next-themes';
 import type { ThemeProviderProps } from 'next-themes';
-import { useEffect, useState } from 'react';
+
+// next-themes injects an inline <script> during SSR to prevent theme flicker.
+// React 19 warns about script tags inside client components — a false positive
+// because the script is in the server HTML and runs before hydration.
+if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
+  const originalConsoleError = console.error;
+  console.error = (...args: unknown[]) => {
+    if (
+      typeof args[0] === 'string' &&
+      args[0].includes('Encountered a script tag')
+    ) {
+      return;
+    }
+    originalConsoleError.apply(console, args);
+  };
+}
 
 export function ClientThemeProvider({ children, ...props }: ThemeProviderProps) {
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  if (!mounted) {
-    return <>{children}</>;
-  }
-
   return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
 }


### PR DESCRIPTION
…guard from ClientThemeProvider so next-themes renders its SSR script during the initial render instead of only after client mount. Suppress the known React 19 false positive in development. Also fix the head theme script so system preference is respected when the stored theme is system