### PR TITLE
Add banned equipment feature to custom trading posts

### DIFF
--- a/app/actions/customise/custom-trading-posts.ts
+++ b/app/actions/customise/custom-trading-posts.ts
@@ -187,7 +187,7 @@ export async function deleteCustomTradingPost(
 const TP_EQUIPMENT_SELECT = `
   id, custom_trading_post_id, equipment_id, custom_equipment_id,
   cost_override, cost_type_resource_id, cost_campaign_resource_id, cost_reputation, cost_resource_amount,
-  availability_override, sort_order,
+  availability_override, sort_order, banned,
   equipment:equipment_id (equipment_name, equipment_category),
   custom_equipment:custom_equipment_id (equipment_name, equipment_category)
 `;
@@ -208,6 +208,7 @@ function mapTPEquipmentRow(row: any): CustomTPEquipment {
     cost_resource_amount: row.cost_resource_amount ?? null,
     availability_override: row.availability_override,
     sort_order: row.sort_order,
+    banned: row.banned ?? false,
   };
 }
 
@@ -241,6 +242,7 @@ export interface CustomTPEquipment {
   cost_resource_amount: number | null;
   availability_override: string | null;
   sort_order: number | null;
+  banned: boolean;
 }
 
 export interface CustomTPAvailabilityRule {
@@ -370,6 +372,7 @@ export async function updateTPEquipment(
     cost_resource_amount?: number | null;
     availability_override?: string | null;
     sort_order?: number | null;
+    banned?: boolean;
   }
 ): Promise<{ success: boolean; error?: string }> {
   try {

--- a/components/customise/custom-trading-posts.tsx
+++ b/components/customise/custom-trading-posts.tsx
@@ -9,6 +9,7 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
 import { Combobox } from '@/components/ui/combobox';
+import { Checkbox } from '@/components/ui/checkbox';
 import { LuEye, LuSquarePen, LuTrash2 } from 'react-icons/lu';
 import { FiShare2 } from 'react-icons/fi';
 import { ImInfo } from 'react-icons/im';
@@ -49,6 +50,7 @@ interface EquipmentPendingChanges {
   availRules: CustomTPAvailabilityRule[];
   pricingRules: CustomTPPricingRule[];
   rulesModified: boolean;
+  banned: boolean;
 }
 
 interface CustomiseTradingPostsProps {
@@ -319,6 +321,7 @@ export function CustomiseTradingPosts({
                 cost_reputation: changes.costReputation,
                 cost_resource_amount: changes.costResourceAmount,
                 availability_override: changes.availabilityOverride,
+                banned: changes.banned,
               });
               if (!overridesResult.success) {
                 toast.error(overridesResult.error || 'Failed to save equipment overrides');
@@ -647,6 +650,7 @@ function EquipmentItemsSection({
           cost_reputation: pending.costReputation,
           cost_resource_amount: pending.costResourceAmount,
           availability_override: pending.availabilityOverride,
+          banned: pending.banned,
         };
       }),
     ...(pendingAdditions ?? []).map(equip => {
@@ -666,6 +670,7 @@ function EquipmentItemsSection({
         cost_resource_amount: pending?.costResourceAmount ?? null,
         availability_override: pending?.availabilityOverride ?? null,
         sort_order: null,
+        banned: pending?.banned ?? false,
       };
     }),
   ];
@@ -706,12 +711,13 @@ function EquipmentItemsSection({
                   <th className="py-2 pr-2 font-medium">Category</th>
                   <th className="py-2 pr-2 font-medium text-center">Cost</th>
                   <th className="py-2 pr-2 font-medium text-center">AL</th>
+                  <th className="py-2 pr-2 font-medium text-center">Banned</th>
                   {isEditable && <th className="py-2 font-medium text-right">Actions</th>}
                 </tr>
               </thead>
               <tbody>
                 {displayItems.map((item) => (
-                  <tr key={item.id} className="border-b last:border-0">
+                  <tr key={item.id} className={`border-b last:border-0 ${item.banned ? 'opacity-50' : ''}`}>
                     <td className="py-2 pr-2">
                       {item.equipment_name}
                       {item.is_custom && <span className="text-xs text-muted-foreground ml-1">(Custom)</span>}
@@ -723,6 +729,30 @@ function EquipmentItemsSection({
                         : item.cost_override != null ? item.cost_override : '-'}
                     </td>
                     <td className="py-2 pr-2 text-center">{item.availability_override || '-'}</td>
+                    <td className="py-2 pr-2 text-center">
+                      {isEditable && onEquipmentOverrideChange ? (
+                        <Checkbox
+                          checked={item.banned}
+                          onCheckedChange={(checked) => {
+                            const currentPending = pendingOverrides?.get(item.id);
+                            onEquipmentOverrideChange(item.id, {
+                              costOverride: currentPending?.costOverride ?? item.cost_override,
+                              costTypeResourceId: currentPending?.costTypeResourceId ?? item.cost_type_resource_id,
+                              costCampaignResourceId: currentPending?.costCampaignResourceId ?? item.cost_campaign_resource_id,
+                              costReputation: currentPending?.costReputation ?? item.cost_reputation,
+                              costResourceAmount: currentPending?.costResourceAmount ?? item.cost_resource_amount,
+                              availabilityOverride: currentPending?.availabilityOverride ?? item.availability_override,
+                              availRules: currentPending?.availRules ?? [],
+                              pricingRules: currentPending?.pricingRules ?? [],
+                              rulesModified: currentPending?.rulesModified ?? false,
+                              banned: checked === true,
+                            });
+                          }}
+                        />
+                      ) : (
+                        item.banned ? 'Yes' : '-'
+                      )}
+                    </td>
                     {isEditable && (
                       <td className="py-2 text-right">
                         <div className="flex gap-1 justify-end">
@@ -1042,6 +1072,9 @@ function EditEquipmentModal({
   );
   const [availLetter, setAvailLetter] = useState(parsedAvail.letter);
   const [availNumber, setAvailNumber] = useState(parsedAvail.number);
+  const [isBanned, setIsBanned] = useState(
+    pendingChanges ? pendingChanges.banned : item.banned
+  );
   const [localAvailRules, setLocalAvailRules] = useState<CustomTPAvailabilityRule[] | null>(
     pendingChanges ? pendingChanges.availRules : null
   );
@@ -1127,6 +1160,7 @@ function EditEquipmentModal({
       availRules,
       pricingRules,
       rulesModified: localAvailRules !== null || localPricingRules !== null,
+      banned: isBanned,
     });
     return true;
   };
@@ -1178,6 +1212,19 @@ function EditEquipmentModal({
       >
         <div className="space-y-6">
           <div className="space-y-4">
+            <label className="flex items-start space-x-2">
+              <Checkbox
+                checked={isBanned}
+                onCheckedChange={(checked) => setIsBanned(checked === true)}
+                className="mt-1"
+              />
+              <div>
+                <span className="text-sm font-medium">Banned</span>
+                <p className="text-xs text-muted-foreground">
+                  Banned items are visible but cannot be purchased.
+                </p>
+              </div>
+            </label>
             <div>
               <Label>Resource Type</Label>
               <Combobox

--- a/components/customise/custom-trading-posts.tsx
+++ b/components/customise/custom-trading-posts.tsx
@@ -729,30 +729,7 @@ function EquipmentItemsSection({
                         : item.cost_override != null ? item.cost_override : '-'}
                     </td>
                     <td className="py-2 pr-2 text-center">{item.availability_override || '-'}</td>
-                    <td className="py-2 pr-2 text-center">
-                      {isEditable && onEquipmentOverrideChange ? (
-                        <Checkbox
-                          checked={item.banned}
-                          onCheckedChange={(checked) => {
-                            const currentPending = pendingOverrides?.get(item.id);
-                            onEquipmentOverrideChange(item.id, {
-                              costOverride: currentPending?.costOverride ?? item.cost_override,
-                              costTypeResourceId: currentPending?.costTypeResourceId ?? item.cost_type_resource_id,
-                              costCampaignResourceId: currentPending?.costCampaignResourceId ?? item.cost_campaign_resource_id,
-                              costReputation: currentPending?.costReputation ?? item.cost_reputation,
-                              costResourceAmount: currentPending?.costResourceAmount ?? item.cost_resource_amount,
-                              availabilityOverride: currentPending?.availabilityOverride ?? item.availability_override,
-                              availRules: currentPending?.availRules ?? [],
-                              pricingRules: currentPending?.pricingRules ?? [],
-                              rulesModified: currentPending?.rulesModified ?? false,
-                              banned: checked === true,
-                            });
-                          }}
-                        />
-                      ) : (
-                        item.banned ? 'Yes' : '-'
-                      )}
-                    </td>
+                    <td className="py-2 pr-2 text-center">{item.banned ? 'Yes' : '-'}</td>
                     {isEditable && (
                       <td className="py-2 text-right">
                         <div className="flex gap-1 justify-end">

--- a/components/customise/custom-trading-posts.tsx
+++ b/components/customise/custom-trading-posts.tsx
@@ -717,7 +717,7 @@ function EquipmentItemsSection({
               </thead>
               <tbody>
                 {displayItems.map((item) => (
-                  <tr key={item.id} className={`border-b last:border-0 ${item.banned ? 'opacity-50' : ''}`}>
+                  <tr key={item.id} className="border-b last:border-0">
                     <td className="py-2 pr-2">
                       {item.equipment_name}
                       {item.is_custom && <span className="text-xs text-muted-foreground ml-1">(Custom)</span>}

--- a/components/equipment/equipment.tsx
+++ b/components/equipment/equipment.tsx
@@ -73,6 +73,7 @@ interface RawEquipmentData {
   cost_resource_amount?: number | null;
   cost_type_resource_id?: string | null;
   cost_campaign_resource_id?: string | null;
+  banned?: boolean;
 }
 
 interface Category {
@@ -765,7 +766,7 @@ const ItemModal: React.FC<ItemModalProps> = ({
                               return (
                                 <div
                                   key={`${category.category_name}-${item.equipment_id}-${itemIndex}`}
-                                  className="flex items-center justify-between w-full px-4 py-2 text-left hover:bg-muted gap-1"
+                                  className={`flex items-center justify-between w-full px-4 py-2 text-left gap-1 ${item.banned ? 'opacity-40 grayscale' : 'hover:bg-muted'}`}
                                 >
                                   <EquipmentTooltipTrigger
                                     item={item}
@@ -774,10 +775,15 @@ const ItemModal: React.FC<ItemModalProps> = ({
                                   >
                                     <div className="flex items-center gap-2 flex-wrap">
                                       <span className="text-sm font-medium">
-                                        {item.equipment_type === 'vehicle_upgrade' && item.vehicle_upgrade_slot 
+                                        {item.equipment_type === 'vehicle_upgrade' && item.vehicle_upgrade_slot
                                           ? `${item.vehicle_upgrade_slot}: ${item.equipment_name}`
                                           : item.equipment_name}
                                       </span>
+                                      {item.banned && (
+                                        <Badge variant="destructive" className="px-1 text-[0.6rem]">
+                                          Banned
+                                        </Badge>
+                                      )}
                                       {item.is_custom && (
                                         <Badge variant="discreet" className="px-1 text-[0.6rem]">
                                           Custom
@@ -823,14 +829,17 @@ const ItemModal: React.FC<ItemModalProps> = ({
                                       </div>
                                     )}
                                     <Button
+                                      disabled={item.banned}
                                       onClick={(e) => {
                                         e.stopPropagation();
-                                        setBuyModalData(item);
+                                        if (!item.banned) setBuyModalData(item);
                                       }}
                                       className={`text-white text-xs py-0.5 px-2 h-6 ${
-                                        affordable
-                                          ? "bg-green-500 hover:bg-green-600"
-                                          : "bg-gray-500 hover:bg-gray-600"
+                                        item.banned
+                                          ? "bg-gray-500 cursor-not-allowed"
+                                          : affordable
+                                            ? "bg-green-500 hover:bg-green-600"
+                                            : "bg-gray-500 hover:bg-gray-600"
                                       }`}
                                     >
                                       Buy

--- a/components/equipment/equipment.tsx
+++ b/components/equipment/equipment.tsx
@@ -832,7 +832,7 @@ const ItemModal: React.FC<ItemModalProps> = ({
                                       disabled={item.banned}
                                       onClick={(e) => {
                                         e.stopPropagation();
-                                        if (!item.banned) setBuyModalData(item);
+                                        setBuyModalData(item);
                                       }}
                                       className={`text-white text-xs py-0.5 px-2 h-6 ${
                                         item.banned

--- a/supabase/functions/copy_custom_collection.sql
+++ b/supabase/functions/copy_custom_collection.sql
@@ -199,11 +199,11 @@ BEGIN
   INSERT INTO public.custom_trading_post_equipment (id, created_at, user_id, custom_trading_post_id, equipment_id,
                                                     custom_equipment_id, cost_override, availability_override,
                                                     sort_order, cost_type_resource_id, cost_campaign_resource_id,
-                                                    cost_reputation, cost_resource_amount)
+                                                    cost_reputation, cost_resource_amount, banned)
   SELECT (v_map_tpe ->> te.id::text)::uuid, now(), v_user, (v_map_tp ->> te.custom_trading_post_id::text)::uuid,
          te.equipment_id, (v_map_eq ->> te.custom_equipment_id::text)::uuid, te.cost_override, te.availability_override,
          te.sort_order, te.cost_type_resource_id, te.cost_campaign_resource_id,
-         te.cost_reputation, te.cost_resource_amount
+         te.cost_reputation, te.cost_resource_amount, te.banned
   FROM public.custom_trading_post_equipment te WHERE te.custom_trading_post_id = ANY(v_tp);
 
   INSERT INTO public.custom_trading_post_availability (id, created_at, user_id, custom_trading_post_equipment_id,

--- a/supabase/functions/get_equipment_detailed_data.sql
+++ b/supabase/functions/get_equipment_detailed_data.sql
@@ -39,7 +39,8 @@ RETURNS TABLE (
     cost_resource_name text,
     cost_resource_amount numeric,
     cost_type_resource_id uuid,
-    cost_campaign_resource_id uuid
+    cost_campaign_resource_id uuid,
+    banned boolean
 )
 LANGUAGE sql
 SECURITY DEFINER
@@ -191,7 +192,8 @@ AS $$
             (array_agg(ctpe.cost_resource_amount ORDER BY ctpe.cost_override NULLS LAST, COALESCE(ctpe.sort_order, 999), ctpe.created_at) FILTER (WHERE ctpe.cost_resource_amount IS NOT NULL))[1] AS cost_resource_amount,
             (array_agg(ctpe.cost_reputation ORDER BY ctpe.cost_override NULLS LAST, COALESCE(ctpe.sort_order, 999), ctpe.created_at) FILTER (WHERE ctpe.cost_reputation))[1] AS cost_reputation,
             (array_agg(COALESCE(a.availability, ctpe.availability_override) ORDER BY ctpe.cost_override NULLS LAST, COALESCE(ctpe.sort_order, 999), ctpe.created_at) FILTER (WHERE COALESCE(a.availability, ctpe.availability_override) IS NOT NULL))[1] AS availability_override,
-            MIN(p.adjusted_cost) FILTER (WHERE p.adjusted_cost IS NOT NULL) AS adjusted_cost
+            MIN(p.adjusted_cost) FILTER (WHERE p.adjusted_cost IS NOT NULL) AS adjusted_cost,
+            bool_or(ctpe.banned) AS banned
         FROM custom_trading_post_equipment ctpe
         CROSS JOIN gang_data gd
         LEFT JOIN custom_trading_post_pricing p
@@ -351,7 +353,9 @@ AS $$
              THEN cto.cost_resource_amount
         END AS cost_resource_amount,
         cto.cost_type_resource_id,
-        cto.cost_campaign_resource_id
+        cto.cost_campaign_resource_id,
+
+        COALESCE(cto.banned, false) AS banned
 
     FROM equipment e
     CROSS JOIN gang_data gd
@@ -485,7 +489,8 @@ AS $$
              THEN custom_tp.cost_resource_amount
         END AS cost_resource_amount,
         custom_tp.cost_type_resource_id,
-        custom_tp.cost_campaign_resource_id
+        custom_tp.cost_campaign_resource_id,
+        COALESCE(custom_tp.banned, false) AS banned
     FROM custom_equipment ce
     LEFT JOIN (
         SELECT cs.custom_equipment_id
@@ -506,7 +511,8 @@ AS $$
             COALESCE(
                 array_agg(DISTINCT ctp.custom_trading_post_name) FILTER (WHERE ctp.custom_trading_post_name IS NOT NULL),
                 '{}'::text[]
-            ) AS tp_names
+            ) AS tp_names,
+            bool_or(ctpe.banned) AS banned
         FROM custom_trading_post_equipment ctpe
         JOIN custom_trading_posts ctp ON ctp.id = ctpe.custom_trading_post_id
         CROSS JOIN gang_data gd

--- a/supabase/migrations/20260620120000_add_banned_to_custom_tp_equipment.sql
+++ b/supabase/migrations/20260620120000_add_banned_to_custom_tp_equipment.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.custom_trading_post_equipment
+  ADD COLUMN banned boolean NOT NULL DEFAULT false;

--- a/types/equipment.ts
+++ b/types/equipment.ts
@@ -109,6 +109,7 @@ export interface Equipment {
   cost_resource_amount?: number | null;
   cost_type_resource_id?: string | null;
   cost_campaign_resource_id?: string | null;
+  banned?: boolean;
   is_consumable?: boolean;
   // Cost breakdown for Exotic Beast equipment (base + advancements + equipment)
   beast_cost_breakdown?: {


### PR DESCRIPTION
Allow custom trading post creators to ban specific equipment items.
Banned items appear greyed out with a "Banned" badge in the equipment
shop and cannot be purchased. The ban is stored as a boolean column
on custom_trading_post_equipment and propagated through the SQL
function, server actions, and UI layers.