### PR TITLE
Log crew roll via react-query mutation and invalidate gang logs cache

### DIFF
--- a/components/battle-session/crew-selection-modal.tsx
+++ b/components/battle-session/crew-selection-modal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import Modal from '@/components/ui/modal';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Button } from '@/components/ui/button';
@@ -12,7 +13,7 @@ import { FaMedkit } from 'react-icons/fa';
 import { LuMinus, LuPlus } from 'react-icons/lu';
 import { countsTowardRating } from '@/utils/fighter-status';
 import { rollInRange } from '@/utils/dice';
-import { createGangLog } from '@/app/actions/logs/gang-logs';
+import { createGangLog, type CreateGangLogParams } from '@/app/actions/logs/gang-logs';
 
 interface GangFighterOption {
   id: string;
@@ -140,6 +141,16 @@ export default function CrewSelectionModal({
   const [randomCount, setRandomCount] = useState(0);
   const [randomlySelected, setRandomlySelected] = useState<Set<string>>(new Set());
   const [rolling, setRolling] = useState(false);
+  const queryClient = useQueryClient();
+  const gangLogsQueryKey = ['logs', `/api/gangs/${gangId}/logs`] as const;
+  const logCrewRollMutation = useMutation({
+    mutationFn: async (params: CreateGangLogParams) => {
+      const result = await createGangLog(params);
+      if (!result.success) throw new Error(result.error || 'Failed to log crew roll');
+      return result;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: gangLogsQueryKey }),
+  });
 
   const isAvailable = (f: GangFighterOption) =>
     countsTowardRating(f) && !f.recovery;
@@ -245,7 +256,7 @@ export default function CrewSelectionModal({
       setSelected(next);
 
       const pickedNames = picked.map((f) => f.fighter_name).join(', ');
-      await createGangLog({
+      await logCrewRollMutation.mutateAsync({
         gang_id: gangId,
         action_type: 'crew_roll',
         description: `Random crew selection: ${picked.length} fighter(s) rolled — ${pickedNames}`,

--- a/components/battle-session/crew-selection-modal.tsx
+++ b/components/battle-session/crew-selection-modal.tsx
@@ -150,6 +150,7 @@ export default function CrewSelectionModal({
       return result;
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: gangLogsQueryKey }),
+    onError: () => undefined,
   });
 
   const isAvailable = (f: GangFighterOption) =>
@@ -256,11 +257,11 @@ export default function CrewSelectionModal({
       setSelected(next);
 
       const pickedNames = picked.map((f) => f.fighter_name).join(', ');
-      await logCrewRollMutation.mutateAsync({
+      logCrewRollMutation.mutate({
         gang_id: gangId,
         action_type: 'crew_roll',
         description: `Random crew selection: ${picked.length} fighter(s) rolled — ${pickedNames}`,
-      }).catch(() => {});
+      });
     } finally {
       setRolling(false);
     }


### PR DESCRIPTION
### Motivation

- Ensure that random crew selection events are recorded via the app's async mutation flow and that the gang logs list is refreshed after a roll.

### Description

- Import `useMutation` and `useQueryClient` from `@tanstack/react-query` and add a `logCrewRollMutation` that calls `createGangLog` with typed `CreateGangLogParams` and throws on failure.  
- Create a `gangLogsQueryKey` and invalidate it in the mutation `onSuccess` so the UI reloads recent gang logs after a crew roll.  
- Replace the direct `createGangLog` call in the random selection flow with `logCrewRollMutation.mutateAsync(...)` while preserving the existing error swallow behavior.  
- Add the `CreateGangLogParams` type import and the `queryClient` setup used by the mutation.

### Testing

- Ran TypeScript type checking with `tsc --noEmit` and it succeeded.  
- Executed the test suite with `pnpm test` and all tests passed.  
- Ran linting with `eslint .` and there were no new lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b6c6959448332a823a9a45c10c102)