### PR TITLE
Use maybeSingle in `getGangBasic` and narrow error handling for invalid UUIDs

### DIFF
--- a/app/lib/shared/gang-data.ts
+++ b/app/lib/shared/gang-data.ts
@@ -222,14 +222,14 @@ export const getGangBasic = async (gangId: string, supabase: any): Promise<GangB
           hidden
         `)
         .eq('id', gangId)
-        .single();
+        .maybeSingle();
 
       if (error) {
-        // Return null for not found errors or invalid UUID format
-        if (error.code === 'PGRST116' || error.code === '22P02') return null;
+        // Return null for invalid UUID format; maybeSingle returns null for no rows.
+        if (error.code === '22P02') return null;
         throw error;
       }
-      return data;
+      return data ?? null;
     },
     [`gang-basic-${gangId}`],
     {


### PR DESCRIPTION
### Motivation
- Ensure `getGangBasic` returns `null` for missing rows and only treat malformed UUID errors as null, avoiding masking other PostgREST errors.

### Description
- Replace `single()` with `maybeSingle()` in `getGangBasic` so a no-row result yields `null` rather than an error. 
- Remove the special-case for `PGRST116` and only return `null` for `22P02` (invalid UUID), and return `data ?? null` to normalize empty results.

### Testing
- Ran the TypeScript build (`tsc`) and the existing unit test suite (`npm test`), and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bff573214833298be0c02867f1244)