### PR TITLE
Add `disableHoverEffects` to FighterCard and disable hover in modal preview

### DIFF
--- a/components/battle-session/participant-card.tsx
+++ b/components/battle-session/participant-card.tsx
@@ -771,7 +771,7 @@ function FighterRow({
             >
               ×
             </button>
-            <div className="max-h-svh overflow-y-auto [&>.fighter-card-bg]:shadow-none!">
+            <div className="max-h-svh overflow-y-auto">
               <FighterCard
                 {...gangFighter}
                 name={gangFighter.fighter_name}

--- a/components/battle-session/participant-card.tsx
+++ b/components/battle-session/participant-card.tsx
@@ -771,7 +771,7 @@ function FighterRow({
             >
               ×
             </button>
-            <div className="max-h-svh overflow-y-auto [&>.fighter-card-bg]:hover:scale-100! [&>.fighter-card-bg]:hover:shadow-none! [&>.fighter-card-bg]:shadow-none! [&>.fighter-card-bg]:transition-none!">
+            <div className="max-h-svh overflow-y-auto [&>.fighter-card-bg]:shadow-none!">
               <FighterCard
                 {...gangFighter}
                 name={gangFighter.fighter_name}
@@ -779,6 +779,8 @@ function FighterRow({
                 skills={gangFighter.skills}
                 effects={gangFighter.effects as any}
                 vehicle={gangFighter.vehicles?.[0]}
+                // Prevent hover scale from creating modal scrollbars; gang-page cards do not pass this prop.
+                disableHoverEffects
                 advancements={{ characteristics: {}, skills: {} }}
                 base_stats={{
                   movement: gangFighter.movement,

--- a/components/gang/fighter-card.tsx
+++ b/components/gang/fighter-card.tsx
@@ -66,6 +66,8 @@ interface FighterCardProps extends Omit<FighterProps, 'fighter_name' | 'fighter_
   active_loadout_name?: string;  // Name of the active loadout
   dragListeners?: any;  // Drag listeners from dnd-kit for icon-only dragging
   dragAttributes?: any;  // Drag attributes from dnd-kit for icon-only dragging
+  // Used by constrained modal previews; omit this prop to keep the normal gang-page hover scale/shadow.
+  disableHoverEffects?: boolean;
 }
 
 const calculateVehicleStats = (
@@ -166,6 +168,7 @@ const FighterCard = memo(function FighterCard({
   active_loadout_name,
   dragListeners,
   dragAttributes,
+  disableHoverEffects = false,
   is_spyrer = false,
 }: FighterCardProps) {
   const contentRef = useRef<HTMLDivElement>(null);
@@ -460,7 +463,11 @@ const FighterCard = memo(function FighterCard({
     router.push(`/fighter/${id}`);
   }, [id, router, isLoading]);
 
-  const cardClassName = `relative rounded-lg overflow-hidden shadow-md [@media(hover:hover)_and_(pointer:fine)]:hover:shadow-lg [@media(hover:hover)_and_(pointer:fine)]:hover:scale-[1.02] transition-all duration-200 border-2 border-black ${isDragging ? 'border-[3px] border-rose-700 scale-[1.02]' : ''} print:hover:scale-[1] print-fighter-card print:inline-block
+  const hoverEffectClass = disableHoverEffects
+    ? 'shadow-md'
+    : 'shadow-md [@media(hover:hover)_and_(pointer:fine)]:hover:shadow-lg [@media(hover:hover)_and_(pointer:fine)]:hover:scale-[1.02]';
+
+  const cardClassName = `relative rounded-lg overflow-hidden ${hoverEffectClass} transition-all duration-200 border-2 border-black ${isDragging ? 'border-[3px] border-rose-700 scale-[1.02]' : ''} print:hover:scale-[1] print-fighter-card print:inline-block
         ${isPrintView ? `${printCardSize} p-2 relative` : isNormalView ? 'p-4' : `${compactCardSize} relative`} fighter-card-bg
         ${isLoading ? 'cursor-default' : ''}
         ${dragListeners && dragAttributes ? (isDragging ? 'cursor-grabbing' : 'cursor-grab') : ''}`;

--- a/components/gang/fighter-card.tsx
+++ b/components/gang/fighter-card.tsx
@@ -66,8 +66,7 @@ interface FighterCardProps extends Omit<FighterProps, 'fighter_name' | 'fighter_
   active_loadout_name?: string;  // Name of the active loadout
   dragListeners?: any;  // Drag listeners from dnd-kit for icon-only dragging
   dragAttributes?: any;  // Drag attributes from dnd-kit for icon-only dragging
-  // Used by constrained modal previews; omit this prop to keep the normal gang-page hover scale/shadow.
-  disableHoverEffects?: boolean;
+  disableHoverEffects?: boolean;  // Used by constrained modal previews; omit to keep normal gang-page hover scale/shadow.
 }
 
 const calculateVehicleStats = (
@@ -464,7 +463,7 @@ const FighterCard = memo(function FighterCard({
   }, [id, router, isLoading]);
 
   const hoverEffectClass = disableHoverEffects
-    ? 'shadow-md'
+    ? 'shadow-none'
     : 'shadow-md [@media(hover:hover)_and_(pointer:fine)]:hover:shadow-lg [@media(hover:hover)_and_(pointer:fine)]:hover:scale-[1.02]';
 
   const cardClassName = `relative rounded-lg overflow-hidden ${hoverEffectClass} transition-all duration-200 border-2 border-black ${isDragging ? 'border-[3px] border-rose-700 scale-[1.02]' : ''} print:hover:scale-[1] print-fighter-card print:inline-block


### PR DESCRIPTION
### Motivation
- Prevent the card hover scale/shadow from affecting constrained modal previews which can create unwanted scrollbars and visual glitches.
- Make the hover behavior configurable so gang-page cards keep the normal hover while modal previews can opt out.
- Reduce duplicated forced hover-related utility classes in the participant modal wrapper.

### Description
- Added a new `disableHoverEffects?: boolean` prop to `FighterCard` and wired it into the card class generation to toggle hover scale and shadow effects.  
- Replaced the previous hover-heavy wrapper class in `participant-card.tsx` and pass `disableHoverEffects` when rendering a `FighterCard` inside the info modal to prevent hover scaling.  
- Kept the default behavior unchanged so existing gang-page cards continue to show hover effects.

### Testing
- Ran the frontend test suite with `yarn test` and all tests passed.  
- Performed a production build with `yarn build` which completed successfully.  
- Linted the codebase with `yarn lint` and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b9c79e6b88332bf881095b55a97f9)