### PR TITLE
Include post_battle sessions in Active filter

### DIFF
--- a/components/gang/battle-sessions-tab.tsx
+++ b/components/gang/battle-sessions-tab.tsx
@@ -31,7 +31,7 @@ export default function BattleSessionsList({
   const [showCreateModal, setShowCreateModal] = useState(false);
 
   const filteredSessions = filter === 'active'
-    ? sessions.filter((s) => s.status === 'pre_battle' || s.status === 'active')
+    ? sessions.filter((s) => s.status !== 'completed')
     : sessions;
 
   const content = (


### PR DESCRIPTION
### Motivation
- Ensure the Active filter treats `post_battle` as in-progress so only `completed` sessions are excluded, which fixes both gang and campaign pages that reuse this component.

### Description
- Update `components/gang/battle-sessions-tab.tsx` so `filteredSessions` uses `sessions.filter((s) => s.status !== 'completed')` when `filter === 'active'`, thereby including `pre_battle`, `active`, and `post_battle`.

### Testing
- Ran `npm run lint`; the lint step executed but failed due to unrelated pre-existing lint errors in `app/gang/[id]/page.tsx`, `components/gang/fighter-card-action-menu.tsx`, and `components/pwa-install-button.tsx` and `hooks/use-viewport-width.ts`, with one warning in `postcss.config.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c1224c4188332acb5ae358b34e27e)