### PR TITLE
Mark Supabase client and permissions utils as server-only

### DIFF
--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -1,3 +1,5 @@
+import 'server-only'
+
 import { createServerClient } from '@supabase/ssr'
 import { createClient as createSupabaseClient } from '@supabase/supabase-js'
 import { cookies } from 'next/headers'

--- a/utils/user-permissions.ts
+++ b/utils/user-permissions.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 import { createClient } from '@/utils/supabase/server';
 import type { UserPermissions, CampaignPermissions } from '@/types/user-permissions';
 import type { CampaignRole } from '@/types/user-permissions';


### PR DESCRIPTION
### Motivation

- Prevent these utility modules from being bundled into client-side code by designating them as server-only so server runtime APIs like `cookies` and Supabase server client are used only on the server.

### Description

- Add `import 'server-only'` to `utils/supabase/server.ts` and `utils/user-permissions.ts` to explicitly mark these modules as server-only and avoid accidental client-side usage.

### Testing

- Ran a TypeScript check with `tsc --noEmit` and the project's automated test suite with `npm test`, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3837f4e9848332afa96d24ad4b2983)