### PR TITLE
Set NOT NULL and add index + FK for fighter_types.gang_type_id

### DIFF
--- a/supabase/migrations/20260630120000_add_fighter_types_gang_type_fk.sql
+++ b/supabase/migrations/20260630120000_add_fighter_types_gang_type_fk.sql
@@ -1,0 +1,13 @@
+-- Ensure fighter_types inherit edition through their gang type.
+
+ALTER TABLE public.fighter_types
+  ALTER COLUMN gang_type_id SET NOT NULL;
+
+CREATE INDEX fighter_types_gang_type_id_idx
+  ON public.fighter_types USING btree (gang_type_id);
+
+ALTER TABLE public.fighter_types
+  ADD CONSTRAINT fighter_types_gang_type_id_fkey
+  FOREIGN KEY (gang_type_id)
+  REFERENCES public.gang_types(gang_type_id)
+  ON DELETE CASCADE;


### PR DESCRIPTION
### Motivation

- Ensure `fighter_types` inherit edition through their `gang_type` by making `gang_type_id` required and enforcing referential integrity. 

### Description

- Add migration `supabase/migrations/20260630120000_add_fighter_types_gang_type_fk.sql` that sets `gang_type_id` to `NOT NULL`, creates index `fighter_types_gang_type_id_idx`, and adds a foreign key constraint to `gang_types(gang_type_id)` with `ON DELETE CASCADE`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42c8171774833295ad3e9b2c925b76)