### PR TITLE
Add editions table and add nullable edition_id to catalog root tables

### DIFF
--- a/supabase/migrations/20260630095837_add_editions_and_root_edition_ids.sql
+++ b/supabase/migrations/20260630095837_add_editions_and_root_edition_ids.sql
@@ -64,6 +64,7 @@ DECLARE
     'gang_affiliation',
     'equipment',
     'skill_types',
+    'skills',
     'fighter_effect_types',
     'fighter_classes',
     'territories',

--- a/supabase/migrations/20260630095837_add_editions_and_root_edition_ids.sql
+++ b/supabase/migrations/20260630095837_add_editions_and_root_edition_ids.sql
@@ -1,0 +1,97 @@
+-- Add edition support for catalog root tables.
+-- Instance tables (gangs, campaigns, fighters, fighter_injuries, etc.) derive
+-- edition through their required parent catalog/type relationships.
+-- Root edition columns start nullable until server actions and catalog reads are
+-- updated to consistently write and consume edition_id.
+
+CREATE TABLE IF NOT EXISTS public.editions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  released_at date,
+  is_active boolean NOT NULL DEFAULT false,
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  updated_at timestamp with time zone
+);
+
+ALTER TABLE public.editions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow authenticated users to view editions"
+  ON public.editions
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "Only admin can create editions entries"
+  ON public.editions
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (( SELECT private.is_admin() AS is_admin));
+
+CREATE POLICY "Only admin can update editions"
+  ON public.editions
+  FOR UPDATE
+  TO authenticated
+  USING (( SELECT private.is_admin() AS is_admin))
+  WITH CHECK (( SELECT private.is_admin() AS is_admin));
+
+CREATE POLICY "Only admin can delete editions"
+  ON public.editions
+  FOR DELETE
+  TO authenticated
+  USING (( SELECT private.is_admin() AS is_admin));
+
+CREATE UNIQUE INDEX IF NOT EXISTS editions_single_active_idx
+  ON public.editions (is_active)
+  WHERE is_active;
+
+INSERT INTO public.editions (name, is_active, sort_order)
+SELECT 'Necromunda (2023)', true, 1
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.editions
+  WHERE name = 'Necromunda (2023)'
+);
+
+DO $$
+DECLARE
+  t text;
+  roots text[] := ARRAY[
+    -- official catalog roots
+    'gang_types',
+    'gang_origins',
+    'gang_variant_types',
+    'gang_affiliation',
+    'equipment',
+    'skill_types',
+    'fighter_effect_types',
+    'fighter_classes',
+    'territories',
+    'scenarios',
+    'vehicle_types',
+    'alliances',
+    'trading_post_types',
+    'campaign_types',
+
+    -- custom roots
+    'custom_gang_types',
+    'custom_equipment',
+    'custom_fighter_types',
+    'custom_skill_types',
+    'custom_trading_posts',
+    'custom_collections'
+  ];
+BEGIN
+  FOREACH t IN ARRAY roots LOOP
+    EXECUTE format(
+      'ALTER TABLE public.%I ADD COLUMN IF NOT EXISTS edition_id uuid REFERENCES public.editions(id) ON DELETE SET NULL',
+      t
+    );
+
+    EXECUTE format(
+      'CREATE INDEX IF NOT EXISTS %I ON public.%I (edition_id)',
+      t || '_edition_id_idx',
+      t
+    );
+  END LOOP;
+END $$;

--- a/supabase/migrations/20260630095837_add_editions_and_root_edition_ids.sql
+++ b/supabase/migrations/20260630095837_add_editions_and_root_edition_ids.sql
@@ -118,46 +118,46 @@ BEGIN
   END LOOP;
 END $$;
 
--- fighter_classes needs a stable, edition-independent key so per-edition rows of
+-- fighter_classes needs a stable, edition-independent slug so per-edition rows of
 -- the same class can be matched to each other without relying on display names.
 ALTER TABLE public.fighter_classes
-  ADD COLUMN IF NOT EXISTS code text;
+  ADD COLUMN IF NOT EXISTS slug text;
 
 UPDATE public.fighter_classes
-SET code = CASE
+SET slug = CASE
     WHEN class_name = '*' THEN 'any'
     ELSE trim(BOTH '_' FROM lower(regexp_replace(class_name, '[^a-zA-Z0-9]+', '_', 'g')))
   END
-WHERE code IS NULL;
+WHERE slug IS NULL;
 
 ALTER TABLE public.fighter_classes
-  ALTER COLUMN code SET NOT NULL;
+  ALTER COLUMN slug SET NOT NULL;
 
 DO $$
 BEGIN
   IF NOT EXISTS (
     SELECT 1
     FROM pg_constraint
-    WHERE conname = 'fighter_classes_code_format_chk'
+    WHERE conname = 'fighter_classes_slug_format_chk'
       AND conrelid = 'public.fighter_classes'::regclass
   ) THEN
     ALTER TABLE public.fighter_classes
-      ADD CONSTRAINT fighter_classes_code_format_chk
-      CHECK (code ~ '^[a-z][a-z0-9_]*$');
+      ADD CONSTRAINT fighter_classes_slug_format_chk
+      CHECK (slug ~ '^[a-z][a-z0-9_]*$');
   END IF;
 END $$;
 
-CREATE UNIQUE INDEX IF NOT EXISTS fighter_classes_edition_code_idx
-  ON public.fighter_classes (edition_id, code)
+CREATE UNIQUE INDEX IF NOT EXISTS fighter_classes_edition_slug_idx
+  ON public.fighter_classes (edition_id, slug)
   WHERE edition_id IS NOT NULL;
 
 -- Naming collision worth documenting: the rulebook term "Subtypes" refers to
 -- what this schema calls fighter_classes, not to fighter_sub_types.
 COMMENT ON TABLE public.fighter_classes IS
-  'Fighter roles (Leader, Champion, Ganger, ...). The new edition rulebook calls these "Subtypes"; the display label is resolved per edition in app code. NOT related to fighter_sub_types. One row per class per edition, joined across editions on code.';
+  'Fighter roles (Leader, Champion, Ganger, ...). The new edition rulebook calls these "Subtypes"; the display label is resolved per edition in app code. NOT related to fighter_sub_types. One row per class per edition, joined across editions on slug.';
 
 COMMENT ON TABLE public.fighter_sub_types IS
   'Variants within a single fighter type. Unrelated to the rulebook term "Subtypes", which maps to fighter_classes.';
 
-COMMENT ON COLUMN public.fighter_classes.code IS
-  'Stable slug shared across editions; match on this, never on class_name or id. Not user-editable.';
+COMMENT ON COLUMN public.fighter_classes.slug IS
+  'Stable identifier shared across editions; match on this, never on class_name or id. Not user-editable.';

--- a/supabase/migrations/20260630095837_add_editions_and_root_edition_ids.sql
+++ b/supabase/migrations/20260630095837_add_editions_and_root_edition_ids.sql
@@ -10,7 +10,6 @@ CREATE TABLE IF NOT EXISTS public.editions (
   slug text NOT NULL UNIQUE,
   released_at date,
   is_current boolean NOT NULL DEFAULT false,
-  sort_order integer NOT NULL DEFAULT 0,
   created_at timestamp with time zone NOT NULL DEFAULT now(),
   updated_at timestamp with time zone,
   CONSTRAINT editions_slug_format_chk CHECK (slug ~ '^[a-z][a-z0-9_]*$')
@@ -53,8 +52,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS editions_single_current_idx
   ON public.editions (is_current)
   WHERE is_current;
 
-INSERT INTO public.editions (name, slug, is_current, sort_order)
-SELECT 'Necromunda (2023)', 'n23', true, 1
+INSERT INTO public.editions (name, slug, is_current)
+SELECT 'Necromunda (2023)', 'n23', true
 WHERE NOT EXISTS (
   SELECT 1
   FROM public.editions

--- a/supabase/migrations/20260630095837_add_editions_and_root_edition_ids.sql
+++ b/supabase/migrations/20260630095837_add_editions_and_root_edition_ids.sql
@@ -7,12 +7,20 @@
 CREATE TABLE IF NOT EXISTS public.editions (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   name text NOT NULL,
+  slug text NOT NULL UNIQUE,
   released_at date,
-  is_active boolean NOT NULL DEFAULT false,
+  is_current boolean NOT NULL DEFAULT false,
   sort_order integer NOT NULL DEFAULT 0,
   created_at timestamp with time zone NOT NULL DEFAULT now(),
-  updated_at timestamp with time zone
+  updated_at timestamp with time zone,
+  CONSTRAINT editions_slug_format_chk CHECK (slug ~ '^[a-z][a-z0-9_]*$')
 );
+
+COMMENT ON COLUMN public.editions.slug IS
+  'Stable identifier for an edition so application code can reference it without hardcoding UUIDs.';
+
+COMMENT ON COLUMN public.editions.is_current IS
+  'Picks the default edition for pages that have no gang or campaign context to derive an edition from. It does NOT mark other editions unsupported, and catalog rows must never be filtered on it.';
 
 ALTER TABLE public.editions ENABLE ROW LEVEL SECURITY;
 
@@ -41,21 +49,22 @@ CREATE POLICY "Only admin can delete editions"
   TO authenticated
   USING (( SELECT private.is_admin() AS is_admin));
 
-CREATE UNIQUE INDEX IF NOT EXISTS editions_single_active_idx
-  ON public.editions (is_active)
-  WHERE is_active;
+CREATE UNIQUE INDEX IF NOT EXISTS editions_single_current_idx
+  ON public.editions (is_current)
+  WHERE is_current;
 
-INSERT INTO public.editions (name, is_active, sort_order)
-SELECT 'Necromunda (2023)', true, 1
+INSERT INTO public.editions (name, slug, is_current, sort_order)
+SELECT 'Necromunda (2023)', 'n23', true, 1
 WHERE NOT EXISTS (
   SELECT 1
   FROM public.editions
-  WHERE name = 'Necromunda (2023)'
+  WHERE slug = 'n23'
 );
 
 DO $$
 DECLARE
   t text;
+  current_edition_id uuid;
   roots text[] := ARRAY[
     -- official catalog roots
     'gang_types',
@@ -64,7 +73,8 @@ DECLARE
     'gang_affiliation',
     'equipment',
     'skill_types',
-    'skills',
+    -- 'skills' is deliberately excluded: it derives its edition through
+    -- skills.skill_type_id, so a column here could disagree with its parent.
     'fighter_effect_types',
     'fighter_classes',
     'territories',
@@ -83,9 +93,14 @@ DECLARE
     'custom_collections'
   ];
 BEGIN
+  SELECT id
+  INTO STRICT current_edition_id
+  FROM public.editions
+  WHERE slug = 'n23';
+
   FOREACH t IN ARRAY roots LOOP
     EXECUTE format(
-      'ALTER TABLE public.%I ADD COLUMN IF NOT EXISTS edition_id uuid REFERENCES public.editions(id) ON DELETE SET NULL',
+      'ALTER TABLE public.%I ADD COLUMN IF NOT EXISTS edition_id uuid REFERENCES public.editions(id) ON DELETE RESTRICT',
       t
     );
 
@@ -94,5 +109,55 @@ BEGIN
       t || '_edition_id_idx',
       t
     );
+
+    -- Backfill existing catalog rows onto the current edition. edition_id stays
+    -- nullable here; NOT NULL follows once every write path passes it explicitly.
+    EXECUTE format(
+      'UPDATE public.%I SET edition_id = $1 WHERE edition_id IS NULL',
+      t
+    ) USING current_edition_id;
   END LOOP;
 END $$;
+
+-- fighter_classes needs a stable, edition-independent key so per-edition rows of
+-- the same class can be matched to each other without relying on display names.
+ALTER TABLE public.fighter_classes
+  ADD COLUMN IF NOT EXISTS code text;
+
+UPDATE public.fighter_classes
+SET code = CASE
+    WHEN class_name = '*' THEN 'any'
+    ELSE trim(BOTH '_' FROM lower(regexp_replace(class_name, '[^a-zA-Z0-9]+', '_', 'g')))
+  END
+WHERE code IS NULL;
+
+ALTER TABLE public.fighter_classes
+  ALTER COLUMN code SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'fighter_classes_code_format_chk'
+      AND conrelid = 'public.fighter_classes'::regclass
+  ) THEN
+    ALTER TABLE public.fighter_classes
+      ADD CONSTRAINT fighter_classes_code_format_chk
+      CHECK (code ~ '^[a-z][a-z0-9_]*$');
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS fighter_classes_edition_code_idx
+  ON public.fighter_classes (edition_id, code);
+
+-- Naming collision worth documenting: the rulebook term "Subtypes" refers to
+-- what this schema calls fighter_classes, not to fighter_sub_types.
+COMMENT ON TABLE public.fighter_classes IS
+  'Fighter roles (Leader, Champion, Ganger, ...). The new edition rulebook calls these "Subtypes"; the display label is resolved per edition in app code. NOT related to fighter_sub_types. One row per class per edition, joined across editions on code.';
+
+COMMENT ON TABLE public.fighter_sub_types IS
+  'Variants within a single fighter type. Unrelated to the rulebook term "Subtypes", which maps to fighter_classes.';
+
+COMMENT ON COLUMN public.fighter_classes.code IS
+  'Stable slug shared across editions; match on this, never on class_name or id. Not user-editable.';

--- a/supabase/migrations/20260630095837_add_editions_and_root_edition_ids.sql
+++ b/supabase/migrations/20260630095837_add_editions_and_root_edition_ids.sql
@@ -148,7 +148,8 @@ BEGIN
 END $$;
 
 CREATE UNIQUE INDEX IF NOT EXISTS fighter_classes_edition_code_idx
-  ON public.fighter_classes (edition_id, code);
+  ON public.fighter_classes (edition_id, code)
+  WHERE edition_id IS NOT NULL;
 
 -- Naming collision worth documenting: the rulebook term "Subtypes" refers to
 -- what this schema calls fighter_classes, not to fighter_sub_types.


### PR DESCRIPTION
### Motivation

- Introduce edition support for catalog root tables so instance tables can derive an edition through parent relationships.

### Description

- Create `public.editions` with a UUID primary key, metadata columns, timestamps, a `NOT NULL UNIQUE` `slug` (format-checked by `editions_slug_format_chk` against `^[a-z][a-z0-9_]*$`), and the `editions_single_current_idx` unique partial index enforcing a single current edition.
- `is_current` (not `is_active`) only picks the default edition for pages that have no gang or campaign context to derive an edition from. It does **not** mark other editions unsupported, and catalog rows must never be filtered on it — documented as a column comment so the flag isn't misread later.
- Enable row-level security on `public.editions` and add policies restricting insert/update/delete to admins via `private.is_admin()` while allowing authenticated users to select.
- Seed the default edition `Necromunda (2023)` with slug `n23`, guarding the insert on `slug = 'n23'` rather than on the display name.
- Add a nullable `edition_id` UUID column (FK to `public.editions`, `ON DELETE RESTRICT`) plus a supporting index to each catalog root table (official and custom) in a looped `ALTER TABLE`/`CREATE INDEX` sequence, and backfill existing rows onto the current edition in the same loop. `edition_id` stays nullable; `NOT NULL` comes in a follow-up once every write path passes it explicitly.
- `skills` is deliberately excluded from the roots array: it derives its edition through `skills.skill_type_id`, so a column of its own could disagree with its parent. `skill_types` still gets one.
- Add `fighter_classes.code`, a stable slug shared across editions (backfilled from `class_name`, with `'*'` mapping to `any`), made `NOT NULL`, format-checked by `fighter_classes_code_format_chk`, and covered by the partial unique index `fighter_classes_edition_code_idx` on `(edition_id, code) WHERE edition_id IS NOT NULL`. The partial index avoids PostgreSQL's NULL-is-distinct behavior so uniqueness is enforced on all backfilled rows while `edition_id` remains nullable. This lets per-edition rows of the same class be matched without relying on display names or IDs.
- Document the rulebook naming collision in table/column comments: what this schema calls `fighter_classes` is what the new edition rulebook calls "Subtypes" (display label resolved per edition in app code). That term is unrelated to `fighter_sub_types`, which holds variants within a single fighter type.

### Testing

- Applied `supabase/migrations/20260630095837_add_editions_and_root_edition_ids.sql` to a scratch Postgres 16 instance with `psql -f` against a fixture of the affected tables; the script ran to completion without errors.
- Verified the seeded row is `name = 'Necromunda (2023)'`, `slug = 'n23'`, `is_current = true`, and that `editions_single_current_idx` and the `slug` unique constraint are present.
- Confirmed RLS is enabled and all four policies exist via `pg_policies`.
- Confirmed each root table gained `edition_id` and its index, that every pre-existing row was backfilled to the current edition, that `skills` has no `edition_id`, and that the FK delete rule is `RESTRICT` (a `DELETE` from `editions` is rejected while catalog rows reference it).
- Confirmed `fighter_classes.code` backfilled to the expected slugs for all 17 existing rows (`* -> any`, `Hanger-on -> hanger_on`, `Exotic Beast Specialist -> exotic_beast_specialist`, …), is `NOT NULL`, and that both the format check and the `(edition_id, code)` partial unique index exist.
- Confirmed `editions_slug_format_chk` rejects a non-conforming slug, and re-ran the migration from the seed insert onward to confirm the guarded sections (seed, roots loop, `code` column, check constraint, unique index) are idempotent and produce no duplicate edition row.