### PR TITLE
Enforce 1024-char report limit and add character counter in battle modals

### DIFF
--- a/components/battle-session/complete-battle-modal.tsx
+++ b/components/battle-session/complete-battle-modal.tsx
@@ -21,6 +21,8 @@ import {
 } from '@/utils/battle-winners';
 import { useWinnerSelection } from '@/utils/hooks/use-winner-selection';
 
+const reportCharLimit = 1024;
+
 interface CompleteBattleTerritory {
   id: string;
   name: string;
@@ -55,6 +57,7 @@ export default function CompleteBattleModal({
   const [selectedTerritory, setSelectedTerritory] = useState('');
   const [cycle, setCycle] = useState('');
   const [notes, setNotes] = useState('');
+  const isReportOverLimit = notes.length > reportCharLimit;
   const [submitting, setSubmitting] = useState(false);
 
   const gangNameMap = useMemo(
@@ -99,6 +102,11 @@ export default function CompleteBattleModal({
     const territoryClaimed = !isDraw && selectedTerritory;
     if (territoryClaimed && activeWinners.length > 1 && !claimedByGangId) {
       toast.error('Please select which winner claims the Territory');
+      return false;
+    }
+
+    if (isReportOverLimit) {
+      toast.error(`Report cannot exceed ${reportCharLimit} characters`);
       return false;
     }
 
@@ -161,7 +169,7 @@ export default function CompleteBattleModal({
       onClose={onClose}
       onConfirm={handleConfirm}
       confirmText="Complete Battle"
-      confirmDisabled={!hasAnyWinnerSelected || submitting}
+      confirmDisabled={!hasAnyWinnerSelected || submitting || isReportOverLimit}
     >
       <div className="space-y-4">
         {session.scenario && (
@@ -411,8 +419,14 @@ export default function CompleteBattleModal({
                 placeholder="Add any additional details about the battle..."
                 value={notes}
                 onChange={(e) => setNotes(e.target.value)}
+                maxLength={reportCharLimit}
                 className="min-h-[100px] bg-muted"
               />
+              <div className="mt-1 flex justify-end">
+                <span className={`text-sm ${isReportOverLimit ? 'text-red-500' : 'text-muted-foreground'}`}>
+                  {notes.length}/{reportCharLimit} characters
+                </span>
+              </div>
             </div>
             <p className="text-sm text-neutral-500">
               A battle log entry will be created for the campaign.

--- a/components/battle-session/complete-battle-modal.tsx
+++ b/components/battle-session/complete-battle-modal.tsx
@@ -412,8 +412,11 @@ export default function CompleteBattleModal({
               />
             </div>
             <div>
-              <label className="mb-1 block text-sm font-medium text-muted-foreground">
-                Report
+              <label className="mb-1 flex items-center justify-between text-sm font-medium text-muted-foreground">
+                <span>Report</span>
+                <span className={`text-sm ${isReportOverLimit ? 'text-red-500' : 'text-muted-foreground'}`}>
+                  {notes.length}/{reportCharLimit} characters
+                </span>
               </label>
               <Textarea
                 placeholder="Add any additional details about the battle..."
@@ -422,11 +425,6 @@ export default function CompleteBattleModal({
                 maxLength={reportCharLimit}
                 className="min-h-[100px] bg-muted"
               />
-              <div className="mt-1 flex justify-end">
-                <span className={`text-sm ${isReportOverLimit ? 'text-red-500' : 'text-muted-foreground'}`}>
-                  {notes.length}/{reportCharLimit} characters
-                </span>
-              </div>
             </div>
             <p className="text-sm text-neutral-500">
               A battle log entry will be created for the campaign.

--- a/components/campaigns/[id]/campaign-battle-log-modal.tsx
+++ b/components/campaigns/[id]/campaign-battle-log-modal.tsx
@@ -32,6 +32,8 @@ interface CampaignBattleLogModalProps {
   userRole?: 'OWNER' | 'ARBITRATOR' | 'MEMBER';
 }
 
+const reportCharLimit = 1024;
+
 type GangRole = 'none' | 'attacker' | 'defender';
 
 type GangEntry = {
@@ -62,6 +64,7 @@ const CampaignBattleLogModal = ({
   const [scenarios, setScenarios] = useState<Scenario[]>([]);
   const [isLoadingBattleData, setIsLoadingBattleData] = useState(false);
   const [selectedTerritory, setSelectedTerritory] = useState<string>('');
+  const isReportOverLimit = notes.length > reportCharLimit;
 
   const selectedGangs = useMemo(
     () => gangsInBattle.filter((entry) => !!entry.gangId),
@@ -1091,16 +1094,22 @@ const CampaignBattleLogModal = ({
               placeholder="Add any additional details about the battle..."
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
+              maxLength={reportCharLimit}
               className="min-h-[100px] bg-muted"
               disabled={isLoadingBattleData}
             />
+            <div className="mt-1 flex justify-end">
+              <span className={`text-sm ${isReportOverLimit ? 'text-red-500' : 'text-muted-foreground'}`}>
+                {notes.length}/{reportCharLimit} characters
+              </span>
+            </div>
           </div>
         </div>
       }
       onClose={handleClose}
       onConfirm={handleSaveBattle}
       confirmText={isEditMode ? "Update" : "Add Battle Report"}
-      confirmDisabled={isLoadingBattleData || !formValid}
+      confirmDisabled={isLoadingBattleData || !formValid || isReportOverLimit}
     />
   );
 };

--- a/components/campaigns/[id]/campaign-battle-log-modal.tsx
+++ b/components/campaigns/[id]/campaign-battle-log-modal.tsx
@@ -1087,8 +1087,11 @@ const CampaignBattleLogModal = ({
           )}
 
           <div>
-            <label className="block text-sm font-medium text-muted-foreground mb-1">
-              Report
+            <label className="mb-1 flex items-center justify-between text-sm font-medium text-muted-foreground">
+              <span>Report</span>
+              <span className={`text-sm ${isReportOverLimit ? 'text-red-500' : 'text-muted-foreground'}`}>
+                {notes.length}/{reportCharLimit} characters
+              </span>
             </label>
             <Textarea
               placeholder="Add any additional details about the battle..."
@@ -1098,11 +1101,6 @@ const CampaignBattleLogModal = ({
               className="min-h-[100px] bg-muted"
               disabled={isLoadingBattleData}
             />
-            <div className="mt-1 flex justify-end">
-              <span className={`text-sm ${isReportOverLimit ? 'text-red-500' : 'text-muted-foreground'}`}>
-                {notes.length}/{reportCharLimit} characters
-              </span>
-            </div>
           </div>
         </div>
       }


### PR DESCRIPTION
### Motivation
- Prevent overly long battle reports by enforcing a hard character limit and giving immediate feedback to users.
- Make the report UI consistent across the battle completion flow and campaign battle-log editor.

### Description
- Introduced a `reportCharLimit = 1024` constant in `complete-battle-modal.tsx` and `campaign-battle-log-modal.tsx` and derived `isReportOverLimit` from `notes.length`.
- Added `maxLength={reportCharLimit}` to the `Textarea` components and a character counter that turns red when the limit is exceeded.
- Disabled the confirm button when the report is over the limit and, in `CompleteBattleModal`, show a toast error if submission is attempted while the report exceeds the limit.
- Minor UI adjustments to display the character count aligned to the right of the textarea.

### Testing
- Ran TypeScript type-check (`tsc --noEmit`) and a frontend build (`next build`); both succeeded.
- No new automated unit tests were added for this UI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4408bb26b483329a66c199df4c4a0e)