### PR TITLE
Increase report character limit to 4096 and truncate Discord embed descriptions

### DIFF
--- a/components/battle-session/complete-battle-modal.tsx
+++ b/components/battle-session/complete-battle-modal.tsx
@@ -21,7 +21,7 @@ import {
 } from '@/utils/battle-winners';
 import { useWinnerSelection } from '@/utils/hooks/use-winner-selection';
 
-const reportCharLimit = 1024;
+const reportCharLimit = 4096;
 
 interface CompleteBattleTerritory {
   id: string;

--- a/components/campaigns/[id]/campaign-battle-log-modal.tsx
+++ b/components/campaigns/[id]/campaign-battle-log-modal.tsx
@@ -32,7 +32,7 @@ interface CampaignBattleLogModalProps {
   userRole?: 'OWNER' | 'ARBITRATOR' | 'MEMBER';
 }
 
-const reportCharLimit = 1024;
+const reportCharLimit = 4096;
 
 type GangRole = 'none' | 'attacker' | 'defender';
 

--- a/supabase/edge-functions/discord-campaign-bot/index.ts
+++ b/supabase/edge-functions/discord-campaign-bot/index.ts
@@ -12,13 +12,38 @@ const DISCORD_BOT_TOKEN = Deno.env.get("DISCORD_BOT_TOKEN")!
 
 const DISCORD_CHANNEL_TYPES = { TEXT: 0, FORUM: 15 } as const;
 const discordEmbedDescriptionLimit = 4096;
+const discordEmbedTotalLimit = 6000;
 
-const truncateDiscordEmbedDescription = (value: string) => {
-  if (value.length <= discordEmbedDescriptionLimit) {
+const getCharacterCount = (value?: string) => Array.from(value ?? "").length;
+
+const truncateDiscordEmbedDescription = (value: string, limit: number) => {
+  const characters = Array.from(value);
+
+  if (characters.length <= limit) {
     return value;
   }
 
-  return `${value.slice(0, discordEmbedDescriptionLimit - 1)}…`;
+  return `${characters.slice(0, limit - 1).join("")}…`;
+};
+
+const getDiscordEmbedCharacterCount = (embed: {
+  title?: string;
+  description?: string;
+  fields?: { name: string; value: string }[];
+  footer?: { text?: string };
+}) => {
+  const fieldsTotal = embed.fields?.reduce(
+    (total, field) =>
+      total + getCharacterCount(field.name) + getCharacterCount(field.value),
+    0
+  ) ?? 0;
+
+  return (
+    getCharacterCount(embed.title) +
+    getCharacterCount(embed.description) +
+    fieldsTotal +
+    getCharacterCount(embed.footer?.text)
+  );
 };
 
 Deno.serve(async (req) => {
@@ -203,13 +228,28 @@ Deno.serve(async (req) => {
       fields.push({ name: "📋 Scenario", value: battle.scenario, inline: true });
     }
 
+    const title = `Battle Report — ${campaign.campaign_name}`;
+    const footer = { text: "MundaManager" };
+    const descriptionLimit = Math.min(
+      discordEmbedDescriptionLimit,
+      Math.max(
+        0,
+        discordEmbedTotalLimit -
+          getDiscordEmbedCharacterCount({ title, fields, footer })
+      )
+    );
+    const description =
+      battle.note && descriptionLimit > 0
+        ? truncateDiscordEmbedDescription(battle.note, descriptionLimit)
+        : undefined;
+
     const embed = {
-      title: `Battle Report — ${campaign.campaign_name}`,
-      description: battle.note ? truncateDiscordEmbedDescription(battle.note) : undefined,
+      title,
+      description,
       color: 0xd4a017,
       fields,
       timestamp: battle.created_at,
-      footer: { text: "MundaManager" },
+      footer,
     };
 
     let discordRes: Response

--- a/supabase/edge-functions/discord-campaign-bot/index.ts
+++ b/supabase/edge-functions/discord-campaign-bot/index.ts
@@ -11,6 +11,15 @@ const supabase = createClient(
 const DISCORD_BOT_TOKEN = Deno.env.get("DISCORD_BOT_TOKEN")!
 
 const DISCORD_CHANNEL_TYPES = { TEXT: 0, FORUM: 15 } as const;
+const discordEmbedDescriptionLimit = 4096;
+
+const truncateDiscordEmbedDescription = (value: string) => {
+  if (value.length <= discordEmbedDescriptionLimit) {
+    return value;
+  }
+
+  return `${value.slice(0, discordEmbedDescriptionLimit - 1)}…`;
+};
 
 Deno.serve(async (req) => {
   const auth = req.headers.get("Authorization");
@@ -194,12 +203,9 @@ Deno.serve(async (req) => {
       fields.push({ name: "📋 Scenario", value: battle.scenario, inline: true });
     }
 
-    if (battle.note) {
-      fields.push({ name: "📝 Report", value: battle.note, inline: false });
-    }
-
     const embed = {
       title: `Battle Report — ${campaign.campaign_name}`,
+      description: battle.note ? truncateDiscordEmbedDescription(battle.note) : undefined,
       color: 0xd4a017,
       fields,
       timestamp: battle.created_at,


### PR DESCRIPTION
### Motivation
- Allow longer battle reports up to Discord's embed description limit so users can submit more detailed notes without client-side truncation.
- Ensure the Discord edge function never produces an embed description that exceeds Discord limits to avoid API rejections or broken messages.

### Description
- Bumped `reportCharLimit` from `1024` to `4096` in `complete-battle-modal.tsx` and `campaign-battle-log-modal.tsx` to permit longer reports. 
- Added `discordEmbedDescriptionLimit = 4096` and `truncateDiscordEmbedDescription` helper in the Discord edge function to trim long notes to the allowed length. 
- Switched the Discord embed to set `description` to the (truncated) `battle.note` and removed adding the note as a separate embed field. 
- Left existing embed fields and channel posting logic unchanged.

### Testing
- Ran a TypeScript typecheck with `tsc --noEmit` which completed successfully. 
- Executed the project test suite with `pnpm test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45282f05888332a19e373c0fda520a)