### PR TITLE
ci: move Vercel preview + production deploys to GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Vercel Production
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: production
+  cancel-in-progress: false   # don't kill an in-flight prod deploy
+
+permissions:
+  contents: read
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+jobs:
+  deploy-production:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel environment (production)
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy prebuilt to production
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,59 @@
+name: Vercel Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+# one run per PR; cancel superseded pushes to save minutes
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    # same-repo branch + repo member (not a bot/fork) + not a draft
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel environment (preview)
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy prebuilt to preview
+        id: deploy
+        run: |
+          url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = '${{ steps.deploy.outputs.url }}';
+            const marker = '<!-- vercel-preview -->';
+            const body = `${marker}\n**Preview deployed:** ${url}\n\n_Commit ${context.sha.slice(0,7)}_`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body?.includes(marker));
+            const params = { owner: context.repo.owner, repo: context.repo.repo };
+            if (existing) {
+              await github.rest.issues.updateComment({ ...params, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ ...params, issue_number: context.issue.number, body });
+            }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
Replaces Vercel's native Git integration with CLI-based deploys routed through a CI token.

**Why:** Preview deployments currently require a paid Vercel Developer seat. Routing deploys through a CI token lets a free-viewer collaborator's PRs still get previews, while production deploys continue to attribute correctly to a paid-seat account.

## What's in this PR

- **`.github/workflows/preview.yml`** — On `pull_request` (opened / synchronize / reopened / ready_for_review), builds and deploys a Vercel preview, then upserts a comment with the preview URL. Guarded to same-repo (non-fork) PRs, non-draft, from `OWNER`/`MEMBER`/`COLLABORATOR` authors. Concurrency is per-PR with `cancel-in-progress: true` to save minutes.
- **`.github/workflows/deploy.yml`** — On push to `main`, builds with `--prod` and deploys the prebuilt output to production. Concurrency group `production` with `cancel-in-progress: false` so an in-flight prod deploy is never killed.
- **`vercel.json`** — Sets `git.deploymentEnabled = false` to disable Vercel's native Git integration. Without this, both the native integration and these workflows would fire on the same push (double builds). The repo stays connected to the Vercel project, so CLI deploys keep their commit metadata.

## ⚠️ Required follow-up before merge

**Add repository secrets** `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` (GitHub → repo → Settings → Secrets and variables → Actions → Repository secrets):
- Org/project IDs come from `.vercel/project.json` after running `vercel link` (org ID = Team ID).
- The token must be generated under a **paid-seat account** so deploys attribute correctly — since Vercel CLI v44+, the git-author check is enforced in CI, so the token owner must be a paid seat.

No secret values are created, modified, or committed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)