### PR TITLE
ci: attach git metadata to Vercel preview deploys (fix HEAD attribution)

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,6 +27,8 @@ jobs:
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Pull Vercel environment (preview)
@@ -35,9 +37,32 @@ jobs:
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy prebuilt to preview
         id: deploy
+        env:
+          GIT_REF:  ${{ github.event.pull_request.head.ref }}
+          GIT_SHA:  ${{ github.event.pull_request.head.sha }}
+          GIT_ORG:  ${{ github.repository_owner }}
+          GIT_REPO: ${{ github.event.repository.name }}
         run: |
-          url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          MSG=$(git log -1 --pretty=%s)
+          AUTHOR=$(git log -1 --pretty=%an)
+          url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} \
+            -m githubDeployment=1 \
+            -m githubCommitRef="$GIT_REF" \
+            -m githubCommitSha="$GIT_SHA" \
+            -m githubCommitMessage="$MSG" \
+            -m githubCommitAuthorName="$AUTHOR" \
+            -m githubCommitOrg="$GIT_ORG" \
+            -m githubCommitRepo="$GIT_REPO" \
+            -m githubOrg="$GIT_ORG" \
+            -m githubRepo="$GIT_REPO")
           echo "url=$url" >> "$GITHUB_OUTPUT"
+      # Uncomment and set the domain to pin an assigned preview domain to the
+      # latest push. Needed only if you rely on a branch-assigned domain in
+      # Vercel's Domains section — CLI deploys don't reliably auto-advance it.
+      # - name: Point branch domain at this deployment
+      #   run: |
+      #     vercel alias set "${{ steps.deploy.outputs.url }}" TODO-your-preview-domain.example.com \
+      #       --token=${{ secrets.VERCEL_TOKEN }} --scope="$VERCEL_ORG_ID"
       - name: Comment preview URL on PR
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,7 +2,7 @@ name: Vercel Preview
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 # one run per PR; cancel superseded pushes to save minutes
 concurrency:
@@ -20,11 +20,14 @@ env:
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
-    # same-repo branch + repo member (not a bot/fork) + not a draft
+    # same-repo branch + repo member (not a bot/fork) + not a draft;
+    # on a `labeled` event, only run for the preview-test label so unrelated
+    # labels don't trigger a rebuild
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.draft == false &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
+      (github.event.action != 'labeled' || github.event.label.name == 'preview-test')
     steps:
       - uses: actions/checkout@v4
         with:
@@ -56,13 +59,14 @@ jobs:
             -m githubOrg="$GIT_ORG" \
             -m githubRepo="$GIT_REPO")
           echo "url=$url" >> "$GITHUB_OUTPUT"
-      # Uncomment and set the domain to pin an assigned preview domain to the
-      # latest push. Needed only if you rely on a branch-assigned domain in
-      # Vercel's Domains section — CLI deploys don't reliably auto-advance it.
-      # - name: Point branch domain at this deployment
-      #   run: |
-      #     vercel alias set "${{ steps.deploy.outputs.url }}" TODO-your-preview-domain.example.com \
-      #       --token=${{ secrets.VERCEL_TOKEN }} --scope="$VERCEL_ORG_ID"
+      # Point test.mundamanager.com at this deployment, but only for the one PR
+      # labeled `preview-test`. Every push to that PR re-points the domain, so it
+      # always serves the PR's latest changes; move the label to switch PRs.
+      - name: Point test domain at this deployment
+        if: contains(github.event.pull_request.labels.*.name, 'preview-test')
+        run: |
+          vercel alias set "${{ steps.deploy.outputs.url }}" test.mundamanager.com \
+            --token=${{ secrets.VERCEL_TOKEN }} --scope="$VERCEL_ORG_ID"
       - name: Comment preview URL on PR
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## Symptom

GitHub Actions preview deploys show up in Vercel labelled **"HEAD"** instead of the PR branch name. Because of that:

- No branch-specific preview URL is generated.
- Branch-scoped environment variables and domains don't link to the deployment.

## Root cause

Two things combine:

1. On `pull_request` events, `actions/checkout` checks out the ephemeral merge ref (`refs/pull/N/merge`) in **detached-HEAD** state, so there's no branch context.
2. CLI deploys (`vercel deploy --prebuilt`) don't attach git metadata on their own, so Vercel has nothing to attribute the deployment to and falls back to "HEAD".

## Fix

Edits only `.github/workflows/preview.yml`:

- **Check out the real PR head SHA** — `actions/checkout` now uses `ref: ${{ github.event.pull_request.head.sha }}` instead of the merge ref, so `git log` reflects the actual PR commit.
- **Pass GitHub git metadata to `vercel deploy`** via `-m` flags: `githubDeployment=1` (required for Vercel to treat it as a GitHub deployment) plus `githubCommitRef`/`githubCommitSha`/`githubCommitMessage`/`githubCommitAuthorName`/`githubCommitOrg`/`githubCommitRepo` and `githubOrg`/`githubRepo`. Commit message and author are read from `git log -1` on the checked-out head.

## Assigned test domain (`test.mundamanager.com`)

Because native Vercel Git integration is disabled (`vercel.json` → `git.deploymentEnabled: false`), Vercel won't auto-advance an assigned domain to CLI deploys. This PR wires that up explicitly, scoped to a single PR at a time:

- A **`vercel alias set … test.mundamanager.com`** step runs **only when the PR carries the `preview-test` label**. Every push to that PR re-points the domain, so `test.mundamanager.com` always serves that PR's latest changes.
- A **`labeled` trigger** is added (gated in the job `if:` to the `preview-test` label, so unrelated labels don't cause rebuilds). This means **applying the label claims the domain immediately** — no need to wait for the next push. To switch which PR owns the domain, move the label; the newly-labeled PR's deploy takes over.

**Prerequisites to use it:** create a `preview-test` label in the repo, and add `test.mundamanager.com` as a domain on the Vercel project. Only one PR should hold the label at a time.

## Notes

- The "Comment preview URL on PR" step is unchanged. No changes to secrets or `vercel.json`.
- `preview.yml` is present on `main`, so this PR targets `main` (the `ci/vercel-gha-deploys` branch no longer exists — that work has already merged). Development happened on the session's designated branch `claude/vercel-preview-git-metadata-uejmr1` rather than `fix/vercel-preview-git-metadata`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)