### PR TITLE
prevent crash when adding a lasting injury via gang page quick action…

### DIFF
--- a/components/fighter/edit-fighter/fighter-edit-modal.tsx
+++ b/components/fighter/edit-fighter/fighter-edit-modal.tsx
@@ -711,6 +711,7 @@ export function EditFighterModal({
     const removed = new Set<string>();
     if (fighter.effects) {
       Object.values(fighter.effects).flat().forEach((effect: any) => {
+        if (!effect) return;
         const tsd = typeof effect.type_specific_data === 'object' && effect.type_specific_data
           ? effect.type_specific_data : null;
         if (tsd) {

--- a/components/gang/gang-page-content.tsx
+++ b/components/gang/gang-page-content.tsx
@@ -736,7 +736,7 @@ export default function GangPageContent({
                           injuries: isSpyrer ? [] : updatedInjuries,
                           'rig-glitches': isSpyrer
                             ? updatedInjuries
-                            : f.effects['rig-glitches'],
+                            : (f.effects?.['rig-glitches'] || []),
                         },
                       };
                     }),

--- a/utils/effect-modifiers.ts
+++ b/utils/effect-modifiers.ts
@@ -294,6 +294,11 @@ export function applyWeaponModifiers(
     return profiles;
   }
 
+  // Guard against stray falsy entries (e.g. from Object.values(effects).flat()
+  // where a category was set to undefined instead of an empty array)
+  const validEffects = effects.filter(Boolean);
+  if (validEffects.length === 0) return profiles;
+
   return profiles.map((profile) => {
     // Work on a copy
     const modified = { ...profile };
@@ -307,7 +312,7 @@ export function applyWeaponModifiers(
 
       // Collect all modifiers for this field
       const fieldModifiers: EffectModifier[] = [];
-      effects.forEach(eff => {
+      validEffects.forEach(eff => {
         (eff.fighter_effect_modifiers || []).forEach(m => {
           if (m.stat_name === fieldName) {
             fieldModifiers.push(m);
@@ -340,8 +345,7 @@ export function applyWeaponModifiers(
       .map((t: string) => t.trim())
       .filter(Boolean);
 
-    effects.forEach((eff) => {
-      if (!eff) return;
+    validEffects.forEach((eff) => {
       const tsd = typeof eff.type_specific_data === 'object' ? eff.type_specific_data || {} : {};
       const toRemove: string[] = tsd.traits_to_remove || [];
       const toAdd: string[] = tsd.traits_to_add || [];

--- a/utils/effect-modifiers.ts
+++ b/utils/effect-modifiers.ts
@@ -341,6 +341,7 @@ export function applyWeaponModifiers(
       .filter(Boolean);
 
     effects.forEach((eff) => {
+      if (!eff) return;
       const tsd = typeof eff.type_specific_data === 'object' ? eff.type_specific_data || {} : {};
       const toRemove: string[] = tsd.traits_to_remove || [];
       const toAdd: string[] = tsd.traits_to_add || [];
@@ -372,6 +373,7 @@ export function applySpecialRulesModifiers(
 
   let rules = [...baseRules];
   for (const eff of effects) {
+    if (!eff) continue;
     const tsd = typeof eff.type_specific_data === 'object' && eff.type_specific_data
       ? eff.type_specific_data
       : null;


### PR DESCRIPTION
…. Setting rig-glitches to undefined when a fighter has no existing

entry left a stray undefined item after Object.values(effects).flat(), which applySpecialRulesModifiers then dereferenced. Default to an empty array and guard effect loops against falsy entries.