### PR TITLE
Split invite notification type into campaign_invite and battle_invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ The notification system provides real-time notifications to users for various ap
 interface Notification {
   id: string;
   text: string;
-  type: 'info' | 'warning' | 'error' | 'invite';
+  type: 'info' | 'warning' | 'error' | 'invite' | 'campaign_invite' | 'friend_request' | 'battle_invite' | 'gang_invite';
   created_at: string;
   dismissed: boolean;
   link: string | null;

--- a/app/actions/battle-sessions.ts
+++ b/app/actions/battle-sessions.ts
@@ -186,7 +186,7 @@ export async function createBattleSession(params: {
             otherGangs.map((g) => ({
               receiver_id: g.user_id,
               sender_id: user.id,
-              type: 'invite',
+              type: 'battle_invite',
               text: `${senderName} added you to a battle session.`,
               link: `/gang/${g.id}/battle-session/${sessionId}`,
               dismissed: false,
@@ -708,7 +708,7 @@ export async function addParticipant(params: {
       await supabase.from('notifications').insert({
         receiver_id: params.user_id,
         sender_id: currentUser.id,
-        type: 'invite',
+        type: 'battle_invite',
         text: `${senderName} invited you to a battle session.`,
         link: `/gang/${params.gang_id}/battle-session/${params.session_id}`,
         dismissed: false,

--- a/components/account/notifications-content.tsx
+++ b/components/account/notifications-content.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useState, useEffect } from 'react';
-import { LuOctagonX, LuUserPlus, LuTriangleAlert } from "react-icons/lu";
+import { LuOctagonX, LuUserPlus, LuTriangleAlert, LuSwords } from "react-icons/lu";
 import { LuCheck } from "react-icons/lu";
 import { ImInfo } from "react-icons/im";
 import { HiX } from "react-icons/hi";
@@ -187,8 +187,11 @@ export default function NotificationsContent({ userId }: { userId: string }) {
         return <LuOctagonX className="h-5 w-5 text-red-500" />;
       case 'warning':
         return <LuTriangleAlert className="h-5 w-5 text-amber-500" />;
-      case 'invite':
+      case 'invite': // legacy: pre-split campaign/battle invites
+      case 'campaign_invite':
         return <LuUserPlus className="h-5 w-5 text-indigo-500" />;
+      case 'battle_invite':
+        return <LuSwords className="h-5 w-5 text-rose-500" />;
       case 'friend_request':
         return <LuUserPlus className="h-5 w-5 text-green-500" />;
       case 'gang_invite':

--- a/supabase/edge-functions/send-notification-email/index.ts
+++ b/supabase/edge-functions/send-notification-email/index.ts
@@ -47,7 +47,7 @@ const MASTER_PREF_KEY = "all";
 // Mirror of the email-eligible subset of utils/notifications.ts. Kept in
 // sync deliberately — see the note in _email-layout.ts about the Deno/Next import split.
 const EMAIL_CONFIG: Record<string, { defaultEnabled: boolean; subject: string }> = {
-  invite: { defaultEnabled: true, subject: "You have a new invitation on Munda Manager" },
+  campaign_invite: { defaultEnabled: true, subject: "You've been invited to a campaign" },
   gang_invite: { defaultEnabled: true, subject: "Someone wants to add your gang to a campaign" },
   friend_request: { defaultEnabled: true, subject: "You have a new friend request on Munda Manager" },
 };

--- a/supabase/functions/enqueue_notification_email.sql
+++ b/supabase/functions/enqueue_notification_email.sql
@@ -16,9 +16,9 @@
 -- It gates on a COARSE capability list — the notification types that can ever be
 -- emailed. This is intentionally NOT the preference check: it only avoids creating
 -- skipped delivery rows (and waking the worker via the webhook) for the majority of
--- notifications, which are in-app only (info / warning / error / battle_invite). The
--- worker remains the single authority on per-user preferences + defaults, resolved at
--- send time, so a preference change AFTER enqueue is still honored.
+-- notifications, which are in-app only (info / warning / error / battle_invite / the
+-- legacy invite). The worker remains the single authority on per-user preferences +
+-- defaults, resolved at send time, so a preference change AFTER enqueue is still honored.
 --
 -- Keep this list in step with the supportsEmail:true entries in
 -- utils/notifications.ts. The UNIQUE (notification_id) constraint
@@ -30,7 +30,7 @@ LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = public AS $$
 BEGIN
-   IF NEW.type IN ('invite', 'gang_invite', 'friend_request') THEN
+   IF NEW.type IN ('campaign_invite', 'gang_invite', 'friend_request') THEN
       INSERT INTO email_deliveries (notification_id, user_id)
       VALUES (NEW.id, NEW.receiver_id)
       ON CONFLICT (notification_id) DO NOTHING;

--- a/supabase/functions/notify_campaign_member_added.sql
+++ b/supabase/functions/notify_campaign_member_added.sql
@@ -25,7 +25,7 @@ BEGIN
    ) VALUES (
        NEW.user_id,
        NEW.invited_by,
-       'invite',
+       'campaign_invite',
        'You have been invited to the campaign "' || COALESCE(campaign_name_var, 'Unknown Campaign') || '". Click this notification to go to the campaign.',
        'https://www.mundamanager.com/campaigns/' || NEW.campaign_id,
        false

--- a/supabase/migrations/20260717120000_split_invite_type.sql
+++ b/supabase/migrations/20260717120000_split_invite_type.sql
@@ -1,0 +1,47 @@
+-- Split the overloaded `invite` notification type into campaign_invite / battle_invite.
+--
+-- The single `invite` type was produced by two unrelated events (campaign-member
+-- invitations and battle-session invitations), so they shared one email toggle and one
+-- generic subject. They are now distinct types:
+--   * campaign_invite — email-eligible (see utils/notifications.ts).
+--   * battle_invite    — in-app only (already allowed by the CHECK; unchanged here).
+--
+-- DEPLOY ORDER: this migration must be applied BEFORE the SQL-function producers that
+-- emit the new values auto-deploy (deploy_supabase_functions.yml). Otherwise an INSERT of
+-- type = 'campaign_invite' would violate notifications_type_check. Migrations run ahead of
+-- function deploys in the pipeline; keep this file in the same merge as those producers.
+--
+-- The legacy `invite` value is intentionally kept in the CHECK: existing notifications
+-- rows are NOT purged (retention is a soft read-time filter on the 30-day expires_at
+-- default, not a delete job), so historical `invite` rows must remain valid. Remove it in
+-- a later cleanup once all such rows have aged out.
+
+-- 1. Allow campaign_invite (keep invite + battle_invite valid).
+ALTER TABLE public.notifications
+    DROP CONSTRAINT IF EXISTS notifications_type_check;
+
+ALTER TABLE public.notifications
+    ADD CONSTRAINT notifications_type_check
+    CHECK (type = ANY (ARRAY[
+        'info',
+        'warning',
+        'error',
+        'invite',
+        'campaign_invite',
+        'friend_request',
+        'battle_invite',
+        'gang_invite'
+    ]::text[]));
+
+-- 2. Defensive, idempotent preference migration. If the email feature was already live and
+--    any user stored a per-category preference under the old 'invite' key, move it to
+--    'campaign_invite' (battle_invite is in-app only and stores no preference). A no-op when
+--    no such rows exist (the feature ships on this same branch, so normally there are none).
+INSERT INTO public.user_notification_preferences (user_id, notification_type, enabled, created_at, updated_at)
+SELECT user_id, 'campaign_invite', enabled, created_at, now()
+FROM public.user_notification_preferences
+WHERE notification_type = 'invite'
+ON CONFLICT (user_id, notification_type) DO NOTHING;
+
+DELETE FROM public.user_notification_preferences
+WHERE notification_type = 'invite';

--- a/utils/notifications.ts
+++ b/utils/notifications.ts
@@ -15,6 +15,7 @@ export type NotificationType =
   | 'warning'
   | 'error'
   | 'invite'
+  | 'campaign_invite'
   | 'friend_request'
   | 'battle_invite'
   | 'gang_invite';
@@ -31,12 +32,12 @@ export interface NotificationEmailConfig {
 }
 
 export const notificationEmailConfig: Record<NotificationType, NotificationEmailConfig> = {
-  // Campaign-member and battle-session invites (both use type 'invite' today).
-  invite: {
-    label: 'Campaign & battle invitations',
+  // Campaign-member invitations.
+  campaign_invite: {
+    label: 'Campaign invitations',
     supportsEmail: true,
     defaultEnabled: true,
-    subject: 'You have a new invitation on Munda Manager',
+    subject: "You've been invited to a campaign",
   },
   // Gang-into-campaign invitations (PENDING) — the gang owner is asked to accept.
   gang_invite: {
@@ -55,7 +56,12 @@ export const notificationEmailConfig: Record<NotificationType, NotificationEmail
   info: { label: 'Account & campaign updates', supportsEmail: false, defaultEnabled: false, subject: '' },
   warning: { label: 'Warnings', supportsEmail: false, defaultEnabled: false, subject: '' },
   error: { label: 'Errors', supportsEmail: false, defaultEnabled: false, subject: '' },
-  battle_invite: { label: 'Battle invitations', supportsEmail: false, defaultEnabled: false, subject: '' },
+  // Battle-session invitations — in-app only (deliberately not emailed).
+  battle_invite: { label: 'Battle session invitations', supportsEmail: false, defaultEnabled: false, subject: '' },
+  // Legacy type: campaign AND battle invites both used 'invite' before they were split
+  // into campaign_invite / battle_invite. Retained (in-app only) so historical rows still
+  // render; no new producer emits it. Safe to remove once all such rows have expired.
+  invite: { label: 'Invitations', supportsEmail: false, defaultEnabled: false, subject: '' },
 };
 
 /**


### PR DESCRIPTION
## Summary
This PR splits the overloaded `invite` notification type into two distinct types: `campaign_invite` (for campaign-member invitations) and `battle_invite` (for battle-session invitations). This allows for separate email preferences and more specific messaging for each invitation type.

## Key Changes

- **Database Migration**: Added `20260717120000_split_invite_type.sql` that:
  - Updates the `notifications_type_check` constraint to allow both `campaign_invite` and `battle_invite`
  - Retains the legacy `invite` type for backward compatibility with existing notification rows
  - Migrates any existing user preferences from `invite` to `campaign_invite`

- **Notification Configuration** (`utils/notifications.ts`):
  - Renamed `invite` config to `campaign_invite` with email support enabled
  - Updated subject line to "You've been invited to a campaign"
  - Added explicit `battle_invite` config (in-app only, no email)
  - Kept legacy `invite` config for historical rows with no email support

- **Email Delivery Logic**:
  - Updated `enqueue_notification_email.sql` trigger to check for `campaign_invite` instead of `invite`
  - Updated `send-notification-email/index.ts` to use `campaign_invite` in email config
  - Updated schema definition to reflect the new constraint

- **Battle Session Creation** (`app/actions/battle-sessions.ts`):
  - Changed battle session invitation notifications from type `invite` to `battle_invite`
  - Applied to both initial session creation and participant additions

- **UI Updates** (`components/account/notifications-content.tsx`):
  - Added `LuSwords` icon for `battle_invite` notifications (rose color)
  - Updated icon mapping to handle both legacy `invite` and new `campaign_invite` types
  - Distinct visual representation for battle invitations

- **SQL Functions**:
  - Updated `notify_campaign_member_added.sql` to emit `campaign_invite` type

## Implementation Details

- The legacy `invite` type is intentionally preserved in the CHECK constraint to maintain compatibility with existing notification rows that haven't expired (30-day default retention)
- The migration is idempotent and defensive, handling cases where user preferences may have already been stored
- Email delivery is now type-specific: `campaign_invite` supports email, `battle_invite` is in-app only
- The deployment order is critical: this migration must be applied before SQL function producers auto-deploy to avoid constraint violations

https://claude.ai/code/session_01P3iBqkgJ7NrWuQEwGU1M8g