### PR TITLE
Add local Supabase bootstrap for new developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,55 @@ For questions about contributing, feel free to ask in our [Discord server](https
    The Supabase DB schema can be accessed through https://supabase-schema.vercel.app/
    Use the Supabase URL and the and the anon key to connect to it
 
+### Setting up a local Supabase database
+
+For step 2 above you can either point `.env.local` at a shared remote Supabase
+project (ask a maintainer for the URL + anon key) **or** run the whole stack
+locally with the Supabase CLI. Local is recommended for schema/backend work so
+you can experiment without touching shared data.
+
+> **Why not just `supabase start`?**
+> The files in `supabase/migrations/` are *incremental* deltas for developers
+> who already have the full database — they assume base tables that were never
+> captured as a migration, so replaying them from empty crashes. Local migration
+> auto-run is therefore disabled in `supabase/config.toml`. A fresh local
+> database is built instead from the committed schema snapshot
+> (`supabase/schema/schema.public.sql`, regenerated daily by CI) plus three
+> pieces a `--schema=public` dump can never contain: the `private` schema (the
+> `is_admin` / `is_arb` helpers that ~200 RLS policies call), the `auth.users`
+> signup trigger, and the standard public-schema grants. The setup script layers
+> all of these in, in the right order.
+
+**Prerequisites:** [Supabase CLI](https://supabase.com/docs/guides/cli), Docker
+(for the local stack), and a `psql` client.
+
+1. **Bootstrap the database** from the repo root:
+   ```bash
+   ./scripts/setup-local-db.sh
+   ```
+   The script runs `supabase start`, then loads the private schema + helper
+   functions, the schema snapshot, the grants, and the auth trigger. It is safe
+   to re-run — each run rebuilds the `public` schema from scratch, discarding any
+   existing local data.
+
+2. **Point `.env.local` at the local stack.** Run `supabase status` to get the
+   local API URL and anon key, then set:
+   ```
+   NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+   NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon key from `supabase status`>
+   ```
+
+3. **Start the app** with `npm run dev` as usual.
+
+**Notes**
+- `supabase db reset` wipes the local database and (with migrations disabled)
+  leaves it empty — re-run `./scripts/setup-local-db.sh` afterwards to rebuild it.
+- The email webhook is intentionally **not** part of local setup: it needs AWS
+  SES secrets and only matters for outbound notification email. See
+  `supabase/webhooks/README.md` if you need it.
+- To pull the latest production schema before bootstrapping, `git pull` first —
+  `schema.public.sql` is refreshed by CI daily.
+
 
 ## Component Architecture
 

--- a/scripts/setup-local-db.sh
+++ b/scripts/setup-local-db.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# setup-local-db.sh — bootstrap a fresh LOCAL Supabase database.
+#
+# Why this exists:
+#   supabase/migrations/ holds INCREMENTAL deltas meant for developers who
+#   already have the full database. They assume a base schema that was never
+#   captured as a migration, so `supabase start` cannot replay them from an
+#   empty database (it crashes on the first ALTER TABLE of a table that does
+#   not exist yet). Local migration auto-run is therefore disabled in
+#   supabase/config.toml ([db.migrations] enabled = false).
+#
+#   New developers instead load the committed full schema snapshot
+#   (supabase/schema/schema.public.sql, regenerated daily by CI) plus the three
+#   pieces a `--schema=public` dump can never contain: the `private` schema, the
+#   auth.users trigger, and the standard public-schema grants. This script loads
+#   all of them, in the order the RLS policies require.
+#
+# Usage:
+#   ./scripts/setup-local-db.sh
+#
+#   Requires the Supabase CLI and a psql client (v15+; a v17 client is fine).
+#   Override the target database with SUPABASE_DB_URL if your local stack does
+#   not use the default port:
+#       SUPABASE_DB_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
+
+set -euo pipefail
+
+# --- resolve paths -----------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SUPABASE_DIR="$REPO_ROOT/supabase"
+cd "$REPO_ROOT"
+
+DB_URL="${SUPABASE_DB_URL:-postgresql://postgres:postgres@127.0.0.1:54322/postgres}"
+
+# --- preflight ---------------------------------------------------------------
+command -v supabase >/dev/null 2>&1 || { echo "error: the Supabase CLI is not installed (https://supabase.com/docs/guides/cli)"; exit 1; }
+command -v psql     >/dev/null 2>&1 || { echo "error: psql is not installed (Postgres client tools)"; exit 1; }
+
+echo "==> Ensuring the local Supabase stack is running (supabase start)…"
+supabase start
+
+echo "==> Target database: $DB_URL"
+
+# One psql session per step, ON_ERROR_STOP so any failure aborts the bootstrap.
+run_sql() { psql "$DB_URL" -v ON_ERROR_STOP=1 --quiet "$@"; }
+
+# --- 1. reset public + private schema + RLS helper functions -----------------
+# The public schema is dropped and recreated so this script is safely re-runnable
+# (a pg_dump snapshot is not idempotent — re-loading over existing tables fails).
+# This DISCARDS any existing local data in public.
+#
+# The private schema + helpers are created before the snapshot loads: 200+ of its
+# policies reference private.is_admin()/private.is_arb(), which must already
+# exist. check_function_bodies=off lets the helpers compile now, before the
+# public tables they read exist.
+echo "==> [1/4] Resetting public and creating the private schema + RLS helpers…"
+run_sql \
+  -c 'drop schema if exists public cascade;' \
+  -c 'create schema public;' \
+  -c 'set check_function_bodies = off;' \
+  -f "$SUPABASE_DIR/bootstrap/private_schema.sql" \
+  -f "$SUPABASE_DIR/functions/is_admin.sql" \
+  -f "$SUPABASE_DIR/functions/is_arb.sql"
+
+# --- 2. full public schema snapshot ------------------------------------------
+# The dump is emitted by pg_dump 17 and carries `\restrict`/`\unrestrict` meta
+# commands (unknown to older psql) and a `CREATE SCHEMA public;` that clashes
+# with the public schema we just recreated in step 1. Strip those before loading;
+# every object lands in that fresh public schema.
+echo "==> [2/4] Loading the public schema snapshot…"
+STRIPPED="$(mktemp)"
+trap 'rm -f "$STRIPPED"' EXIT
+sed -E '/^\\restrict/d; /^\\unrestrict/d; /^CREATE SCHEMA public;$/d' \
+  "$SUPABASE_DIR/schema/schema.public.sql" > "$STRIPPED"
+run_sql -f "$STRIPPED"
+
+# --- 3. restore standard Supabase grants -------------------------------------
+# The snapshot is dumped --no-privileges, so re-grant public to the API roles.
+echo "==> [3/4] Restoring public-schema grants for the API roles…"
+run_sql -f "$SUPABASE_DIR/bootstrap/grants.sql"
+
+# --- 4. auth.users signup trigger --------------------------------------------
+echo "==> [4/4] Installing the auth.users signup trigger…"
+run_sql -f "$SUPABASE_DIR/bootstrap/auth_trigger.sql"
+
+echo ""
+echo "✅ Local database ready."
+echo "   Point .env.local at the local stack (see 'supabase status' for the URL and anon key)."
+echo "   Note: 'supabase db reset' wipes the database — re-run this script afterwards."

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,5 +1,35 @@
 # README
 
+## Local development
+
+To spin up a fresh local database, run `./scripts/setup-local-db.sh` from the repo
+root and follow the "Setting up a local Supabase database" section of the top-level
+README. `supabase start` on its own does **not** work: the files in `migrations/`
+are incremental deltas that assume a pre-existing base schema, so local migration
+auto-run is disabled in `config.toml` and the local database is built from
+`schema/schema.public.sql` instead.
+
+`schema/schema.public.sql` is a `pg_dump --schema=public` snapshot (regenerated
+daily by `.github/workflows/supabase_schema_snapshot.yml`). Because it is
+public-only, three things live **outside** it and are applied separately:
+
+| Piece | Where it lives | Applied by |
+|-------|----------------|------------|
+| `private` schema (`is_admin`, `is_arb`) | `functions/is_admin.sql`, `functions/is_arb.sql` + `bootstrap/private_schema.sql` | `setup-local-db.sh` locally; manually on the remote |
+| `auth.users` signup trigger (`on_auth_user_created` → `handle_new_user`) | `migrations/20260525_create_handle_new_user_trigger.sql` / `bootstrap/auth_trigger.sql` | migrations on the remote; `setup-local-db.sh` locally |
+| Notification-email webhook | `webhooks/send_notification_email.sql` | manually (see `webhooks/README.md`) |
+
+### Private schema
+
+The `private` schema holds SECURITY DEFINER helpers used by Row Level Security
+policies. Roughly 200 policies reference them, so the schema must exist before the
+public snapshot loads.
+
+| Name        | Arguments                | Return type | Security |
+|-------------|--------------------------|-------------|----------|
+| is_admin    | (none)                   | boolean     | Definer  |
+| is_arb      | campaign_id_param uuid   | boolean     | Definer  |
+
 ## Supabase functions
 
 https://supabase.com/dashboard/project/iojoritxhpijprgkjfre/database/functions
@@ -33,3 +63,5 @@ Syncing of those files is not automatic. If you update a function on Supabase, m
 | notify_campaign_member_added | campaign_members   | Sends notification when member is added   |
 | notify_friend_request_sent   | friends            | Sends notification for friend requests    |
 | notify_gang_invite           | campaign_gangs     | Sends notification for gang invites       |
+| enqueue_notification_email   | notifications      | Queues an outbound email for a new notification |
+| handle_new_user              | auth.users         | Creates a profiles row on signup (`on_auth_user_created`) |

--- a/supabase/bootstrap/auth_trigger.sql
+++ b/supabase/bootstrap/auth_trigger.sql
@@ -1,0 +1,17 @@
+-- Bootstrap: the auth.users signup trigger
+--
+-- On signup this trigger creates the matching public.profiles row. The trigger
+-- FUNCTION (public.handle_new_user) lives in the public schema and therefore IS
+-- included in ../schema/schema.public.sql. The TRIGGER itself sits on auth.users,
+-- so a `pg_dump --schema=public` snapshot can never capture it — this file
+-- recreates just the binding after the snapshot has loaded the function.
+--
+-- Canonical copy of the function + trigger:
+--   ../migrations/20260525_create_handle_new_user_trigger.sql
+-- Keep the two in sync if the trigger definition ever changes.
+
+drop trigger if exists on_auth_user_created on auth.users;
+
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_user();

--- a/supabase/bootstrap/grants.sql
+++ b/supabase/bootstrap/grants.sql
@@ -1,0 +1,19 @@
+-- Bootstrap: restore the standard Supabase public-schema grants
+--
+-- The schema snapshot is dumped with `--no-privileges`, so every GRANT is
+-- stripped out of ../schema/schema.public.sql. On the hosted project these
+-- grants already exist, but a freshly loaded local database ends up with tables
+-- that the API roles cannot see, which makes PostgREST return empty/forbidden
+-- for everything. This re-applies the grants Supabase normally sets up so the
+-- local API behaves like production. Row Level Security still gates actual row
+-- access — these are the coarse schema/role grants RLS is evaluated on top of.
+
+grant usage on schema public to anon, authenticated, service_role;
+
+grant all on all tables    in schema public to anon, authenticated, service_role;
+grant all on all routines  in schema public to anon, authenticated, service_role;
+grant all on all sequences in schema public to anon, authenticated, service_role;
+
+alter default privileges in schema public grant all on tables    to anon, authenticated, service_role;
+alter default privileges in schema public grant all on routines  to anon, authenticated, service_role;
+alter default privileges in schema public grant all on sequences to anon, authenticated, service_role;

--- a/supabase/bootstrap/private_schema.sql
+++ b/supabase/bootstrap/private_schema.sql
@@ -1,0 +1,21 @@
+-- Bootstrap: the `private` schema
+--
+-- `private` holds the SECURITY DEFINER helpers that Row Level Security policies
+-- lean on across the database (private.is_admin(), private.is_arb(campaign_id)).
+-- The committed schema snapshot (../schema/schema.public.sql) is produced with
+-- `pg_dump --schema=public`, so it can NOT contain this schema even though 200+
+-- of its RLS policies reference it. That is why the snapshot fails to load on a
+-- fresh database unless this schema (and its functions) already exist.
+--
+-- The helper function bodies themselves live in ../functions/is_admin.sql and
+-- ../functions/is_arb.sql (deployed to the remote by deploy_supabase_functions.yml);
+-- the local bootstrap loads those two files right after this one.
+--
+-- USAGE on the schema must be granted to the API roles, otherwise policies that
+-- call private.is_admin()/is_arb() as `authenticated` fail with "permission
+-- denied for schema private" — the calling role needs schema USAGE even for a
+-- SECURITY DEFINER function.
+
+create schema if not exists private;
+
+grant usage on schema private to anon, authenticated, service_role;

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,6 +1,16 @@
 [db]
 major_version = 15
 
+[db.migrations]
+# The files in supabase/migrations/ are INCREMENTAL deltas for developers who
+# already have the full database; they assume a base schema that was never
+# captured as a migration, so they cannot be replayed from an empty database.
+# Disabling auto-run stops `supabase start` / `supabase db reset` from crashing
+# on them locally. New local databases are built from the schema snapshot with
+# `./scripts/setup-local-db.sh` instead (see the repo README). This flag is
+# local-only and does not affect how migrations are applied to the remote.
+enabled = false
+
 [functions.discord-interactions]
 entrypoint = "./edge-functions/discord-interactions/index.ts"
 verify_jwt = false


### PR DESCRIPTION
`supabase start` crashes on a fresh database because supabase/migrations/
are incremental deltas that assume a base schema never captured as a
migration. New developers had no documented path to a working local DB, and
the public-only schema snapshot omits pieces the app needs.

- Disable local migration auto-run ([db.migrations] enabled = false); this
  is local-only and does not affect how migrations reach the remote.
- Add scripts/setup-local-db.sh to build a local DB from the schema snapshot
  plus the three pieces a --schema=public dump can't contain: the private
  schema (is_admin/is_arb, used by ~200 RLS policies), the auth.users signup
  trigger, and the standard public-schema grants (dump is --no-privileges).
- Add supabase/bootstrap/ SQL applied by the script in dependency order.
- Document the whole flow step by step in the top-level and supabase READMEs,
  and fill in the previously missing trigger/private-schema entries.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JdacCELusT96CxBuiHfEmR