### PR TITLE
Fix header auth state going stale after login

### DIFF
--- a/components/header-auth.tsx
+++ b/components/header-auth.tsx
@@ -1,27 +1,21 @@
-'use client';
-
-import { useClaims } from '@/hooks/use-claims';
+import { createClient } from '@/utils/supabase/server';
+import { getClaims } from '@/utils/auth';
 import SettingsModal from '@/components/settings-modal';
 import { ThemeToggleDropdown } from '@/components/theme-toggle';
 
-export default function HeaderAuth() {
-  const { userId, email, profile, loading } = useClaims();
+export default async function HeaderAuth() {
+  const supabase = await createClient();
+  const claims = await getClaims(supabase);
 
-  if (loading) {
-    return (
-      <div className="flex items-center gap-2 mr-2">
-        <ThemeToggleDropdown />
-      </div>
-    );
-  }
-
-  if (!userId) {
+  if (!claims) {
     return (
       <div className="mr-2">
         <ThemeToggleDropdown />
       </div>
     );
   }
+
+  const { userId, email, profile } = claims;
 
   return (
     <div className="flex items-center gap-2 mr-2">


### PR DESCRIPTION
Render the header's auth-gated UI from the server instead of the
client-only useClaims hook. Previously, signing in ran as a server
action that set the session cookies server-side and finished with a
soft redirect(); the browser Supabase client behind useClaims never
saw a SIGNED_IN event and the layout never remounted, so userId stayed
null and the settings (hamburger) menu was hidden until a manual
refresh re-instantiated the browser client.

HeaderAuth is now an async server component that reads getClaims() via
the server Supabase client, so the existing revalidatePath('/', 'layout')
in signInAction/signOutAction updates the header on the same navigation
with no reload. This follows the documented Supabase Next.js SSR pattern
of deriving auth-gated UI on the server.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V9nGi1PHDUTSE6z5BbYB9E