### PR TITLE
Deploy changed edge functions in CI

### DIFF
--- a/.github/workflows/deploy_supabase_edge_functions.yml
+++ b/.github/workflows/deploy_supabase_edge_functions.yml
@@ -5,6 +5,9 @@ name: Deploy Supabase Edge Functions
 # this covers supabase/edge-functions/**. verify_jwt and entrypoints come from
 # supabase/config.toml.
 #
+# Every function declared as [functions.<name>] in supabase/config.toml is
+# deployed, so adding a new function there is enough — no need to edit this file.
+#
 # Requires repo secrets:
 #   SUPABASE_ACCESS_TOKEN  — a Supabase personal access token
 #   SUPABASE_PROJECT_REF   — the project ref (iojoritxhpijprgkjfre)
@@ -31,5 +34,17 @@ jobs:
         with:
           version: latest
 
-      - name: Deploy send-notification-email
-        run: supabase functions deploy send-notification-email --project-ref "${{ secrets.SUPABASE_PROJECT_REF }}"
+      - name: Deploy all edge functions declared in config.toml
+        run: |
+          set -euo pipefail
+          functions=$(grep -oP '^\[functions\.\K[^]]+' supabase/config.toml)
+          if [ -z "$functions" ]; then
+            echo "No [functions.*] entries found in supabase/config.toml" >&2
+            exit 1
+          fi
+          echo "Deploying functions:" $functions
+          for fn in $functions; do
+            echo "::group::Deploy $fn"
+            supabase functions deploy "$fn" --project-ref "${{ secrets.SUPABASE_PROJECT_REF }}"
+            echo "::endgroup::"
+          done

--- a/.github/workflows/deploy_supabase_edge_functions.yml
+++ b/.github/workflows/deploy_supabase_edge_functions.yml
@@ -5,8 +5,11 @@ name: Deploy Supabase Edge Functions
 # this covers supabase/edge-functions/**. verify_jwt and entrypoints come from
 # supabase/config.toml.
 #
-# Every function declared as [functions.<name>] in supabase/config.toml is
-# deployed, so adding a new function there is enough — no need to edit this file.
+# Only the functions whose files actually changed in the push are deployed
+# (mapped from supabase/edge-functions/<name>/**). A change to config.toml
+# redeploys all declared functions, since it can alter verify_jwt/entrypoint for
+# any of them. A manual dispatch (or a push with no usable base commit) also
+# redeploys all.
 #
 # Requires repo secrets:
 #   SUPABASE_ACCESS_TOKEN  — a Supabase personal access token
@@ -28,23 +31,60 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          # Full history so we can diff the pushed range to find changed functions.
+          fetch-depth: 0
 
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v1
         with:
           version: latest
 
-      - name: Deploy all edge functions declared in config.toml
+      - name: Deploy changed edge functions
+        env:
+          PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          functions=$(grep -oP '^\[functions\.\K[^]]+' supabase/config.toml)
-          if [ -z "$functions" ]; then
+
+          # Functions declared in config.toml (each has entrypoint + verify_jwt there).
+          declared=$(grep -oP '^\[functions\.\K[^]]+' supabase/config.toml)
+          if [ -z "$declared" ]; then
             echo "No [functions.*] entries found in supabase/config.toml" >&2
             exit 1
           fi
-          echo "Deploying functions:" $functions
-          for fn in $functions; do
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] \
+             || [ -z "${BEFORE_SHA:-}" ] \
+             || [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ] \
+             || ! git rev-parse -q --verify "$BEFORE_SHA^{commit}" >/dev/null 2>&1; then
+            echo "Manual run or no base commit -> deploying all declared functions."
+            targets="$declared"
+          else
+            changed=$(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA")
+            echo "Changed files:"
+            echo "$changed"
+            if echo "$changed" | grep -qx 'supabase/config.toml'; then
+              echo "config.toml changed -> deploying all declared functions."
+              targets="$declared"
+            else
+              targets=$(echo "$changed" | grep -oP '^supabase/edge-functions/\K[^/]+' | sort -u || true)
+            fi
+          fi
+
+          if [ -z "${targets//[[:space:]]/}" ]; then
+            echo "No declared edge functions changed. Nothing to deploy."
+            exit 0
+          fi
+
+          for fn in $targets; do
+            if ! printf '%s\n' $declared | grep -qx "$fn"; then
+              echo "Skipping '$fn' (no [functions.$fn] entry in config.toml)"
+              continue
+            fi
             echo "::group::Deploy $fn"
-            supabase functions deploy "$fn" --project-ref "${{ secrets.SUPABASE_PROJECT_REF }}"
+            supabase functions deploy "$fn" --project-ref "$PROJECT_REF"
             echo "::endgroup::"
           done

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -17,6 +17,7 @@ verify_jwt = false
 
 [functions.discord-campaign-bot]
 entrypoint = "./edge-functions/discord-campaign-bot/index.ts"
+verify_jwt = false
 
 [functions.users-images-cleanup-drafts]
 entrypoint = "./edge-functions/users-images-cleanup-drafts/index.ts"


### PR DESCRIPTION
## Problem

The `Deploy Supabase Edge Functions` workflow triggers on any change under `supabase/edge-functions/**`, but its only deploy step was hardcoded to `supabase functions deploy send-notification-email`. So when the battle-log report change (#1886) merged, the workflow ran and went green — but it only redeployed `send-notification-email` and never deployed `discord-campaign-bot`, leaving that function running old code in production.

## Changes

- **`.github/workflows/deploy_supabase_edge_functions.yml`** — replace the single hardcoded deploy step with logic that deploys **only the functions whose files actually changed**:
  - Diff the pushed commit range and map changed paths under `supabase/edge-functions/<name>/**` back to function names, deploying just those.
  - A change to `config.toml` redeploys **all** declared functions (it can alter `verify_jwt`/entrypoint for any of them).
  - A manual `workflow_dispatch` (or a push with no usable base commit) falls back to deploying all.
  - Requires `fetch-depth: 0` so the range can be diffed.
- **`supabase/config.toml`** — set `verify_jwt = false` for `discord-campaign-bot`. It is invoked by a database webhook using the `WEBHOOK_SECRET` header, not a JWT. The entry previously had no `verify_jwt`, so the CLI would default it to `true` on deploy and break the webhook. This matches the currently-deployed setting.

## Effect

Merging this PR touches `config.toml`, so the workflow will deploy all four declared functions once — which brings the already-merged two-embed battle-report change live on `discord-campaign-bot`. After that, future merges deploy only the function(s) that changed.

## Verification

- Validated the workflow YAML parses.
- Simulated the change-detection locally: a change to one function's file resolves to just that function; a `config.toml` change resolves to all four; a non-edge change resolves to nothing (no-op deploy).
- `verify_jwt` values in `config.toml` match each function's currently-deployed state (`discord-interactions`/`discord-campaign-bot`/`send-notification-email` = false; `users-images-cleanup-drafts` = default true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Ttt9cmYSxuYmreR8fQLcF