### PR TITLE
Fix campaign name overflowing header buttons on mobile

### DIFF
--- a/components/campaigns/[id]/campaign-page-content.tsx
+++ b/components/campaigns/[id]/campaign-page-content.tsx
@@ -583,9 +583,9 @@ export default function CampaignPageContent({
 
             {/* Right Section: Content */}
             <div className="grow w-full">
-                             <div className="flex justify-between items-start mb-1">
-                 <h2 className="text-xl md:text-2xl font-bold">{campaignData.campaign_name}</h2>
-                 <div className="flex gap-2 print:hidden">
+                             <div className="flex justify-between items-start mb-1 gap-2">
+                 <h2 className="text-xl md:text-2xl font-bold min-w-0 break-words">{campaignData.campaign_name}</h2>
+                 <div className="flex gap-2 shrink-0 print:hidden">
                    {canRequestToJoin && (
                      joinRequestPending ? (
                        <Button


### PR DESCRIPTION
Long campaign names pushed the Edit / Request to join buttons out of the
card container. Add min-w-0 + break-words to the name heading so it can
shrink and wrap, shrink-0 to the button group so it stays intact and
right-aligned, and gap-2 to the row.