### PR TITLE
Fix misaligned Fighter's List radio button on mobile

### DIFF
--- a/components/equipment/equipment.tsx
+++ b/components/equipment/equipment.tsx
@@ -593,7 +593,7 @@ const ItemModal: React.FC<ItemModalProps> = ({
             </div>
             <div className="flex items-center gap-3 justify-center">
               {!isStashMode && (
-                <label className="flex text-sm text-muted-foreground cursor-pointer whitespace-nowrap leading-8">
+                <label className="flex items-center text-sm text-muted-foreground cursor-pointer whitespace-nowrap">
                   <input
                     type="radio"
                     name="equipment-list"
@@ -609,7 +609,7 @@ const ItemModal: React.FC<ItemModalProps> = ({
                   {isVehicleEquipment ? "Vehicle's List" : "Fighter's List"}
                 </label>
               )}
-              <label className="flex text-sm text-muted-foreground cursor-pointer whitespace-nowrap">
+              <label className="flex items-center text-sm text-muted-foreground cursor-pointer whitespace-nowrap">
                 <input
                   type="radio"
                   name="equipment-list"
@@ -624,7 +624,7 @@ const ItemModal: React.FC<ItemModalProps> = ({
                 />
                 Trading Post
               </label>
-              <label className="flex text-sm text-muted-foreground cursor-pointer whitespace-nowrap">
+              <label className="flex items-center text-sm text-muted-foreground cursor-pointer whitespace-nowrap">
                 <input
                   type="radio"
                   name="equipment-list"


### PR DESCRIPTION
Add items-center to the three equipment-list radio labels and remove
the stray leading-8 on the Fighter's List label so the radio inputs
align vertically with their text consistently.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014M1pbUrN88HQ9doKZqvWJr