### PR TITLE
refactor: consolidate fighter positioning-sort onto sortByPositioning

### DIFF
--- a/components/fighter/fighter-page.tsx
+++ b/components/fighter/fighter-page.tsx
@@ -30,6 +30,7 @@ import { TbMeatOff } from "react-icons/tb";
 import { FaMedkit } from "react-icons/fa";
 import { GiHandcuffs } from "react-icons/gi";
 import { applyWeaponModifiers } from '@/utils/effect-modifiers';
+import { sortFightersByPositioning } from '@/utils/fighter-positioning';
 
 interface FighterPageProps {
   initialFighterData: any;
@@ -579,15 +580,10 @@ export default function FighterPage({
   const vehicle = fighterData.fighter?.vehicles?.[0];
 
   // Prepare options for Combobox
-  const fighterOptions = [...fighterData.gangFighters]
-    .sort((a, b) => {
-      const positioning = fighterData.gang?.positioning || {};
-      const indexA = Object.entries(positioning).find(([, id]) => id === a.id)?.[0];
-      const indexB = Object.entries(positioning).find(([, id]) => id === b.id)?.[0];
-      const posA = indexA !== undefined ? parseInt(indexA) : Infinity;
-      const posB = indexB !== undefined ? parseInt(indexB) : Infinity;
-      return posA - posB;
-    })
+  const fighterOptions = sortFightersByPositioning(
+    fighterData.gangFighters,
+    fighterData.gang?.positioning
+  )
     .map((f) => {
       const statusIcons = [];
       if (f.killed) statusIcons.push(<IoSkull className="text-gray-400 w-4 h-4" key="killed" />);

--- a/components/gang/my-fighters.tsx
+++ b/components/gang/my-fighters.tsx
@@ -4,6 +4,7 @@ import { FighterProps } from '@/types/fighter';
 import { calculateAdjustedStats } from '@/utils/effect-modifiers';
 import { SortableFighter } from './sortable-fighter';
 import { fighterClassRank } from '@/utils/fighterClassRank';
+import { sortFightersByPositioning } from '@/utils/fighter-positioning';
 import { GangPageViewMode } from './ViewModeDropdown';
 import { UserPermissions } from '@/types/user-permissions';
 
@@ -69,23 +70,10 @@ export function MyFighters({ fighters, positions, isLoading, error, viewMode = '
     }
   }), []);
 
-  const sortedFighters = useMemo(() => {
-    // Create a position-based ordering using the positions object directly
-    const positionMap: Record<string, number> = {};
-    
-    // First, create a mapping of fighter IDs to their positions
-    Object.entries(positions).forEach(([position, fighterId]) => {
-      positionMap[fighterId] = parseInt(position);
-    });
-    
-    // Then sort the fighters based on their positions
-    return [...fighters].sort((a, b) => {
-      // If fighter has a position, use it; otherwise put it at the end
-      const posA = positionMap[a.id] !== undefined ? positionMap[a.id] : Number.MAX_SAFE_INTEGER;
-      const posB = positionMap[b.id] !== undefined ? positionMap[b.id] : Number.MAX_SAFE_INTEGER;
-      return posA - posB;
-    });
-  }, [fighters, positions]);
+  const sortedFighters = useMemo(
+    () => sortFightersByPositioning(fighters, positions),
+    [fighters, positions]
+  );
 
   // Filter out any invalid fighters
   const validFighters = fighters.filter(fighter => 

--- a/components/gang/my-fighters.tsx
+++ b/components/gang/my-fighters.tsx
@@ -75,11 +75,6 @@ export function MyFighters({ fighters, positions, isLoading, error, viewMode = '
     [fighters, positions]
   );
 
-  // Filter out any invalid fighters
-  const validFighters = fighters.filter(fighter => 
-    fighter && fighter.id && fighter.fighter_name && fighter.fighter_type
-  );
-
   if (isLoading) {
     return <div className="animate-pulse">Loading fighters...</div>;
   }

--- a/components/gang/print-gang.tsx
+++ b/components/gang/print-gang.tsx
@@ -6,6 +6,7 @@ import { FighterProps, Vehicle, FighterEffect } from "@/types/fighter";
 import { Equipment } from "@/types/equipment";
 import { VehicleEquipment } from "@/types/fighter";
 import { calculateAdjustedStats, applySpecialRulesModifiers } from "@/utils/effect-modifiers";
+import { sortFightersByPositioning } from "@/utils/fighter-positioning";
 import { injuryAggregationLabel } from "@/utils/bitterEnmityDisplay";
 import WeaponTable from "./fighter-card-weapon-table";
 import { StatsTable, StatsType } from "../ui/fighter-card-stats-table";
@@ -201,42 +202,35 @@ export default function PrintGang({ gang }: PrintGangProps) {
     }, 100);
   };
 
-  // Order fighters by positioning and filter based on options
-  const positionMap: Record<string, number> = {};
-  Object.entries(positioning || {}).forEach(([pos, fighterId]) => {
-    positionMap[fighterId] = Number(pos);
-  });
-
   // Use pre-filtered list when "Inactive Fighters Loadouts" is off (server-side filter is reliable)
   const sourceFighters =
     !showInactiveFighterLoadouts && fightersActiveLoadoutOnly.length > 0
       ? fightersActiveLoadoutOnly
       : fighters;
 
-  const sortedFighters = [...sourceFighters]
-    .filter((f) => {
-      // Filter out inactive fighters if option is disabled
-      if (!showInactiveFighters && (f.killed || f.enslaved || f.retired)) {
-        return false;
-      }
-      // Filter out fighters in recovery if option is disabled
-      if (!showFightersInRecovery && f.recovery) {
-        return false;
-      }
-      // If both options are disabled, only show active fighters (not killed, not enslaved, not retired, not captured, not in recovery)
-      if (!showInactiveFighters && !showFightersInRecovery) {
-        return !f.killed && !f.enslaved && !f.retired && !f.recovery;
-      }
-      return true;
-    })
-    .sort((a, b) => {
-      const posA = positionMap[a.id] ?? Number.MAX_SAFE_INTEGER;
-      const posB = positionMap[b.id] ?? Number.MAX_SAFE_INTEGER;
-      if (posA !== posB) return posA - posB;
-      const loadoutIdA = (a as { active_loadout_id?: string }).active_loadout_id ?? "";
-      const loadoutIdB = (b as { active_loadout_id?: string }).active_loadout_id ?? "";
-      return loadoutIdA.localeCompare(loadoutIdB);
-    });
+  const filteredFighters = sourceFighters.filter((f) => {
+    // Filter out inactive fighters if option is disabled
+    if (!showInactiveFighters && (f.killed || f.enslaved || f.retired)) {
+      return false;
+    }
+    // Filter out fighters in recovery if option is disabled
+    if (!showFightersInRecovery && f.recovery) {
+      return false;
+    }
+    // If both options are disabled, only show active fighters (not killed, not enslaved, not retired, not captured, not in recovery)
+    if (!showInactiveFighters && !showFightersInRecovery) {
+      return !f.killed && !f.enslaved && !f.retired && !f.recovery;
+    }
+    return true;
+  });
+
+  // Order fighters by positioning; fighters sharing a position (multiple loadouts)
+  // keep a stable order by active loadout id.
+  const sortedFighters = sortFightersByPositioning(filteredFighters, positioning, (a, b) => {
+    const loadoutIdA = (a as { active_loadout_id?: string }).active_loadout_id ?? "";
+    const loadoutIdB = (b as { active_loadout_id?: string }).active_loadout_id ?? "";
+    return loadoutIdA.localeCompare(loadoutIdB);
+  });
 
   return (
     <div className="min-h-screen print:min-h-0 text-foreground w-full">

--- a/components/gang/stash-tab.tsx
+++ b/components/gang/stash-tab.tsx
@@ -32,6 +32,7 @@ import { Tooltip } from 'react-tooltip';
 import { UserPermissions } from '@/types/user-permissions';
 import FighterEffectSelection from '@/components/fighter-effect-selection';
 import { applyWeaponModifiers } from '@/utils/effect-modifiers';
+import { sortFightersByPositioning } from '@/utils/fighter-positioning';
 
 interface GangInventoryProps {
   stash: StashItem[];
@@ -744,14 +745,7 @@ export default function GangInventory({
     if (!hasVehicleExclusiveItem) {
       options.push({ value: '__fighters_header__', label: <span className="font-bold">Fighters</span>, displayValue: 'Fighters', disabled: true });
 
-      const sorted = [...fighters].sort((a, b) => {
-        if (!positioning) return 0;
-        const indexA = Object.entries(positioning).find(([, id]) => id === a.id)?.[0];
-        const indexB = Object.entries(positioning).find(([, id]) => id === b.id)?.[0];
-        const posA = indexA !== undefined ? parseInt(indexA) : Infinity;
-        const posB = indexB !== undefined ? parseInt(indexB) : Infinity;
-        return posA - posB;
-      });
+      const sorted = sortFightersByPositioning(fighters, positioning);
 
       for (const fighter of sorted) {
         const isDisabled = hasSelectedVehicle && !isCrew(fighter);

--- a/utils/crew-fighter-combobox-options.tsx
+++ b/utils/crew-fighter-combobox-options.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { FighterProps } from '@/types/fighter';
+import { sortFightersByPositioning } from '@/utils/fighter-positioning';
 import { IoSkull } from 'react-icons/io5';
 import { MdChair } from 'react-icons/md';
 import { GiCrossedChains, GiHandcuffs } from 'react-icons/gi';
@@ -26,20 +27,12 @@ export function useCrewFighterOptions(
   positioning: Record<number, string> | undefined
 ): CrewFighterOption[] {
   return useMemo(() => {
-    return fighters
-      .filter(
-        (f) =>
-          f.fighter_class === 'Crew' &&
-          (!f.vehicles || f.vehicles.length === 0)
-      )
-      .sort((a, b) => {
-        if (!positioning) return 0;
-        const indexA = Object.entries(positioning).find(([, id]) => id === a.id)?.[0];
-        const indexB = Object.entries(positioning).find(([, id]) => id === b.id)?.[0];
-        const posA = indexA !== undefined ? parseInt(indexA) : Infinity;
-        const posB = indexB !== undefined ? parseInt(indexB) : Infinity;
-        return posA - posB;
-      })
+    const crewFighters = fighters.filter(
+      (f) =>
+        f.fighter_class === 'Crew' &&
+        (!f.vehicles || f.vehicles.length === 0)
+    );
+    return sortFightersByPositioning(crewFighters, positioning)
       .map((f) => {
         const statusIcons: React.ReactNode[] = [];
         if (f.killed) statusIcons.push(<IoSkull className="text-gray-400 w-4 h-4" key="killed" />);

--- a/utils/fighter-positioning.ts
+++ b/utils/fighter-positioning.ts
@@ -37,11 +37,15 @@ export async function initializePositioningIfNeeded(
 /**
  * Core sorting engine that sorts items based on a gang's positioning map using explicit key extractors.
  * Preserves original array order stability for unpositioned items to match Gang Overview sorting.
+ *
+ * When two items share the same position index, `tiebreak` (if provided) decides their order;
+ * otherwise their relative order is preserved (stable sort).
  */
 export function sortByPositioning<T>(
   items: T[],
   positioning: Record<string, any> | null | undefined,
-  getId: (item: T) => string
+  getId: (item: T) => string,
+  tiebreak?: (a: T, b: T) => number
 ): T[] {
   if (!items || items.length === 0) return [];
 
@@ -58,7 +62,8 @@ export function sortByPositioning<T>(
     const posA = idA && posMap.has(idA) ? posMap.get(idA)! : Number.MAX_SAFE_INTEGER;
     const posB = idB && posMap.has(idB) ? posMap.get(idB)! : Number.MAX_SAFE_INTEGER;
 
-    return posA - posB;
+    if (posA !== posB) return posA - posB;
+    return tiebreak ? tiebreak(a, b) : 0;
   });
 }
 
@@ -67,8 +72,9 @@ export function sortByPositioning<T>(
  */
 export const sortFightersByPositioning = <T extends { id: string }>(
   fighters: T[],
-  positioning?: Record<string, any> | null
-) => sortByPositioning(fighters, positioning, (f) => f.id);
+  positioning?: Record<string, any> | null,
+  tiebreak?: (a: T, b: T) => number
+) => sortByPositioning(fighters, positioning, (f) => f.id, tiebreak);
 
 /**
  * Sorts Battle Session Participant Fighters (which reference their gang fighter via `.fighter_id`)


### PR DESCRIPTION
## Context

Every fighter list in the app is meant to render in one order — the order stored in the gang's `positioning` map (edited via drag-and-drop on the Gang Overview). But "sort fighters by that map" was reimplemented inline in **five** separate places, three of them doing an O(n²) `Object.entries(positioning).find()` per item.

PR #1891 introduced a reusable engine (`sortByPositioning` / `sortFightersByPositioning` in `utils/fighter-positioning.ts`) but only wired up one consumer (`participant-card.tsx`). This PR finishes that consolidation so there is genuinely one sort of a gang's fighters.

## Changes

- **`utils/fighter-positioning.ts`** — added an optional `tiebreak` comparator to `sortByPositioning` (and threaded it through `sortFightersByPositioning`). Default behavior is unchanged for existing callers.
- **`my-fighters.tsx`**, **`crew-fighter-combobox-options.tsx`**, **`stash-tab.tsx`**, **`fighter-page.tsx`** — replaced inline positioning sorts with `sortFightersByPositioning`. Behavior is preserved (empty/absent positioning → stable input order), and this removes three O(n²) sorts.
- **`print-gang.tsx`** — migrated onto the engine using the new `tiebreak` to preserve its secondary `active_loadout_id` ordering for fighters that share a position (multiple loadouts).

## Intentionally out of scope

- **`draggable-fighters.tsx`** — the drag-and-drop editor, which *normalizes* positions and re-appends unpositioned fighters as part of managing DnD state rather than doing a plain render sort. Its output order already matches the engine's semantics, so lists stay in lockstep.
- **`participant-card.tsx`** — already on the helper (#1891).

## Verification

- `npx tsc --noEmit` — clean (only the pre-existing tsconfig deprecation notices remain).
- `eslint` on all touched files — clean.
- Suggested manual check: confirm the Gang Overview, stash "assign to fighter" dropdown, fighter-page switcher, crew combobox, and print view all render fighters in the same order as the Overview, including a gang with newly-added/unpositioned fighters (which should appear at the end), and a fighter with multiple loadouts in the print view (tiebreak intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012EN4D7eb9xc6pm2iyQEPg4)_