### PR TITLE
Add Boschi to Ongoing Members on contributors page

### DIFF
--- a/app/contributors/page.tsx
+++ b/app/contributors/page.tsx
@@ -93,6 +93,7 @@ export default async function ContributorsPage() {
     { name: "Steady" },
     { name: "T_H_E_S_E_U_S" },
     { name: "Age" },
+    { name: "Boschi" },
   ];
 
   const pastContributors: Contributor[] = [


### PR DESCRIPTION
## Summary
- Add "Boschi" to the Ongoing Members list under Team Members on the Contributors page

## Test plan
- [ ] Visual check of `/contributors` page to confirm Boschi appears under Ongoing Members


---
_Generated by [Claude Code](https://claude.ai/code/session_01BuoohGzu5yz7ZpwM3tCspK)_