### PR TITLE
Fix drag-and-drop of favourite gangs/campaigns on mobile

### DIFF
--- a/components/gang/draggable-fighters.tsx
+++ b/components/gang/draggable-fighters.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { DndContext, closestCenter } from '@dnd-kit/core';
 import { rectSortingStrategy, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
-import { useDndSensorsConfig } from '@/hooks/use-dnd-sensors';
+import { useDndSensorsConfig, useSuppressClickAfterDrag } from '@/hooks/use-dnd-sensors';
 import { useIsMounted } from '@/hooks/use-is-mounted';
 import { MyFighters } from './my-fighters';
 import { FighterProps } from '@/types/fighter';
@@ -108,32 +108,7 @@ export function DraggableFighters({
 
   const sensors = useDndSensorsConfig();
 
-  // After a pointer drag, the browser still synthesizes a `click` on whatever is under the
-  // pointer (often a *different* fighter card than the one dragged). Swallow that one click
-  // in the capture phase so no card's `<a>` navigates away. Scoped to fighter-card links only
-  // so unrelated UI (nav, "Add Fighter", menus, etc.) stays clickable if the listener is still
-  // armed. Keyboard reorder never produces a trailing click, so we skip arming for it.
-  const suppressClickAfterDrag = (activatorEvent?: Event | null) => {
-    if (activatorEvent instanceof KeyboardEvent) return;
-
-    const suppress = (event: Event) => {
-      const target = event.target;
-      if (!(target instanceof Element)) return;
-      // Only eat navigation clicks on fighter cards — leave everything else alone and keep
-      // listening until a card click arrives or the timeout clears.
-      if (!target.closest('.fighter-card-bg')?.closest('a')) return;
-
-      event.preventDefault();
-      event.stopPropagation();
-      cleanup();
-    };
-    const cleanup = () => {
-      document.removeEventListener('click', suppress, true);
-      window.clearTimeout(timeoutId);
-    };
-    document.addEventListener('click', suppress, true);
-    const timeoutId = window.setTimeout(cleanup, 500);
-  };
+  const suppressClickAfterDrag = useSuppressClickAfterDrag('.fighter-card-bg');
 
   const handleDragEnd = async (event: any) => {
     // Always consider suppress for pointer drags — including same-position drops — because a

--- a/components/home/campaign-card.tsx
+++ b/components/home/campaign-card.tsx
@@ -9,6 +9,20 @@ import { CSS } from '@dnd-kit/utilities'
 import { FiStar } from 'react-icons/fi'
 import { AiFillStar } from 'react-icons/ai'
 
+// A long press over an `<a href>` makes the browser offer its own link menu ("Open in New
+// Tab"), which on iOS steals the gesture before dnd-kit's TouchSensor delay elapses. Cancelling
+// `contextmenu` is what stops it — the same trick fighter-card-action-menu.tsx uses for its menu
+// trigger. dnd-kit has a contextmenu guard of its own, but only once a drag has activated, which
+// is too late. The CSS is belt-and-braces for iOS; both properties inherit, so they cover the
+// `<Link>` inside. Only for favourites, so plain cards keep normal selection and link behaviour.
+const dragSurfaceStyle = {
+  WebkitTouchCallout: 'none',
+  WebkitUserSelect: 'none',
+  userSelect: 'none',
+  WebkitTapHighlightColor: 'transparent',
+  touchAction: 'manipulation',
+} as const;
+
 export interface CampaignCardProps {
   campaign: Campaign;
   onToggleFavourite: (campaignMemberId: string, isFavourite: boolean) => void;
@@ -19,6 +33,8 @@ export interface CampaignCardProps {
 }
 
 export function CampaignCardContent({ campaign, onToggleFavourite, dragListeners, dragAttributes, isDragging, disableLink = false }: CampaignCardProps) {
+  const isDraggable = Boolean(dragListeners);
+
   const innerContent = (
     <>
       <div className="relative w-[80px] md:w-20 h-[80px] md:h-20 mr-3 md:mr-4 shrink-0 flex items-center justify-center">
@@ -76,16 +92,25 @@ export function CampaignCardContent({ campaign, onToggleFavourite, dragListeners
       className={`flex items-center p-2 md:p-4 rounded-md hover:bg-muted transition-colors duration-200 ${isDragging ? 'border-[3px] border-rose-700' : ''} ${dragListeners ? 'cursor-grab' : ''}`}
       {...(dragListeners || {})}
       {...(dragAttributes || {})}
+      style={isDraggable ? dragSurfaceStyle : undefined}
+      onContextMenu={isDraggable ? (e) => {
+        // Only on touch devices, so desktop right-click still opens the browser menu.
+        if (window.matchMedia('(pointer: coarse)').matches) e.preventDefault();
+      } : undefined}
     >
-      {disableLink ? (
-        <div className="flex items-center grow min-w-0">
-          {innerContent}
-        </div>
-      ) : (
-        <Link href={`/campaigns/${campaign.id}`} prefetch={false} className="flex items-center grow min-w-0">
-          {innerContent}
-        </Link>
-      )}
+      {/* Always rendered — never swapped for a bare div when `disableLink` flips on drag start,
+          so the touch target stays stable for the whole gesture. Next's Link skips navigating
+          when a click handler calls preventDefault, so soft navigation is preserved. */}
+      <Link
+        href={`/campaigns/${campaign.id}`}
+        prefetch={false}
+        onClick={(e) => { if (disableLink) e.preventDefault(); }}
+        tabIndex={disableLink ? -1 : undefined}
+        aria-hidden={disableLink || undefined}
+        className={`flex items-center grow min-w-0${isDraggable ? ' home-favourite-card-link' : ''}`}
+      >
+        {innerContent}
+      </Link>
       <button
         type="button"
         onClick={(e) => {

--- a/components/home/campaign-card.tsx
+++ b/components/home/campaign-card.tsx
@@ -8,20 +8,7 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { FiStar } from 'react-icons/fi'
 import { AiFillStar } from 'react-icons/ai'
-
-// A long press over an `<a href>` makes the browser offer its own link menu ("Open in New
-// Tab"), which on iOS steals the gesture before dnd-kit's TouchSensor delay elapses. Cancelling
-// `contextmenu` is what stops it — the same trick fighter-card-action-menu.tsx uses for its menu
-// trigger. dnd-kit has a contextmenu guard of its own, but only once a drag has activated, which
-// is too late. The CSS is belt-and-braces for iOS; both properties inherit, so they cover the
-// `<Link>` inside. Only for favourites, so plain cards keep normal selection and link behaviour.
-const dragSurfaceStyle = {
-  WebkitTouchCallout: 'none',
-  WebkitUserSelect: 'none',
-  userSelect: 'none',
-  WebkitTapHighlightColor: 'transparent',
-  touchAction: 'manipulation',
-} as const;
+import { dragSurfaceProps } from '@/hooks/use-dnd-sensors'
 
 export interface CampaignCardProps {
   campaign: Campaign;
@@ -92,11 +79,7 @@ export function CampaignCardContent({ campaign, onToggleFavourite, dragListeners
       className={`flex items-center p-2 md:p-4 rounded-md hover:bg-muted transition-colors duration-200 ${isDragging ? 'border-[3px] border-rose-700' : ''} ${dragListeners ? 'cursor-grab' : ''}`}
       {...(dragListeners || {})}
       {...(dragAttributes || {})}
-      style={isDraggable ? dragSurfaceStyle : undefined}
-      onContextMenu={isDraggable ? (e) => {
-        // Only on touch devices, so desktop right-click still opens the browser menu.
-        if (window.matchMedia('(pointer: coarse)').matches) e.preventDefault();
-      } : undefined}
+      {...dragSurfaceProps(isDraggable)}
     >
       {/* Always rendered — never swapped for a bare div when `disableLink` flips on drag start,
           so the touch target stays stable for the whole gesture. Next's Link skips navigating

--- a/components/home/campaign-card.tsx
+++ b/components/home/campaign-card.tsx
@@ -76,7 +76,7 @@ export function CampaignCardContent({ campaign, onToggleFavourite, dragListeners
 
   return (
     <div
-      className={`flex items-center p-2 md:p-4 rounded-md hover:bg-muted transition-colors duration-200 ${isDragging ? 'border-[3px] border-rose-700' : ''} ${dragListeners ? 'cursor-grab' : ''}`}
+      className={`flex items-center p-2 md:p-4 rounded-md hover:bg-muted transition-colors duration-200 ${isDragging ? 'border-[3px] border-rose-700 bg-card' : ''} ${dragListeners ? 'cursor-grab' : ''}`}
       {...(dragListeners || {})}
       {...(dragAttributes || {})}
       {...dragSurfaceProps(isDraggable)}

--- a/components/home/campaigns-tab.tsx
+++ b/components/home/campaigns-tab.tsx
@@ -7,7 +7,7 @@ import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-ki
 import { toggleFavourite } from '@/app/actions/toggle-favourite'
 import { reorderFavourites } from '@/app/actions/reorder-favourites'
 import { toast } from 'sonner'
-import { useDndSensorsConfig } from '@/hooks/use-dnd-sensors'
+import { useDndSensorsConfig, useSuppressClickAfterDrag } from '@/hooks/use-dnd-sensors'
 import { useIsMounted } from '@/hooks/use-is-mounted'
 import { CampaignCardContent, SortableCampaignCard } from '@/components/home/campaign-card'
 
@@ -19,6 +19,7 @@ export function CampaignsTab({ campaigns }: CampaignsTabProps) {
   const [localCampaigns, setLocalCampaigns] = useState<Campaign[]>(campaigns);
   const isMounted = useIsMounted();
   const sensors = useDndSensorsConfig();
+  const suppressClickAfterDrag = useSuppressClickAfterDrag('.home-favourite-card-link');
 
   const [prevCampaigns, setPrevCampaigns] = useState(campaigns);
   if (campaigns !== prevCampaigns) {
@@ -66,7 +67,11 @@ export function CampaignsTab({ campaigns }: CampaignsTabProps) {
     }
   }, [localCampaigns]);
 
-  const handleCampaignDragEnd = useCallback(async (event: { active: { id: string | number }; over: { id: string | number } | null }) => {
+  const handleCampaignDragEnd = useCallback(async (event: { active: { id: string | number }; over: { id: string | number } | null; activatorEvent?: Event | null }) => {
+    // Always consider suppress for pointer drags — including same-position drops — because a
+    // real drag still produces a trailing click.
+    suppressClickAfterDrag(event.activatorEvent);
+
     const { active, over } = event;
     if (!over || active.id === over.id) return;
 
@@ -92,7 +97,7 @@ export function CampaignsTab({ campaigns }: CampaignsTabProps) {
     if (!result.success) {
       toast.error(result.error || 'Failed to reorder favourites');
     }
-  }, [favouriteCampaigns]);
+  }, [favouriteCampaigns, suppressClickAfterDrag]);
 
   return (
     <div className="bg-card shadow-md rounded-lg p-4">
@@ -109,6 +114,7 @@ export function CampaignsTab({ campaigns }: CampaignsTabProps) {
                   sensors={sensors}
                   collisionDetection={closestCenter}
                   onDragEnd={handleCampaignDragEnd}
+                  onDragCancel={(event) => suppressClickAfterDrag(event.activatorEvent)}
                 >
                   <SortableContext
                     items={favouriteCampaigns.map(c => c.campaign_member_id)}

--- a/components/home/gang-card.tsx
+++ b/components/home/gang-card.tsx
@@ -88,7 +88,7 @@ export function GangCardContent({ gang, onToggleFavourite, dragListeners, dragAt
 
   return (
     <div
-      className={`flex items-center p-2 md:p-4 rounded-md hover:bg-muted transition-colors duration-200 ${isDragging ? 'border-[3px] border-rose-700' : ''} ${dragListeners ? 'cursor-grab' : ''}`}
+      className={`flex items-center p-2 md:p-4 rounded-md hover:bg-muted transition-colors duration-200 ${isDragging ? 'border-[3px] border-rose-700 bg-card' : ''} ${dragListeners ? 'cursor-grab' : ''}`}
       {...(dragListeners || {})}
       {...(dragAttributes || {})}
       {...dragSurfaceProps(isDraggable)}

--- a/components/home/gang-card.tsx
+++ b/components/home/gang-card.tsx
@@ -8,20 +8,7 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { FiStar } from 'react-icons/fi'
 import { AiFillStar } from 'react-icons/ai'
-
-// A long press over an `<a href>` makes the browser offer its own link menu ("Open in New
-// Tab"), which on iOS steals the gesture before dnd-kit's TouchSensor delay elapses. Cancelling
-// `contextmenu` is what stops it — the same trick fighter-card-action-menu.tsx uses for its menu
-// trigger. dnd-kit has a contextmenu guard of its own, but only once a drag has activated, which
-// is too late. The CSS is belt-and-braces for iOS; both properties inherit, so they cover the
-// `<Link>` inside. Only for favourites, so plain cards keep normal selection and link behaviour.
-const dragSurfaceStyle = {
-  WebkitTouchCallout: 'none',
-  WebkitUserSelect: 'none',
-  userSelect: 'none',
-  WebkitTapHighlightColor: 'transparent',
-  touchAction: 'manipulation',
-} as const;
+import { dragSurfaceProps } from '@/hooks/use-dnd-sensors'
 
 export interface GangCardProps {
   gang: Gang;
@@ -104,11 +91,7 @@ export function GangCardContent({ gang, onToggleFavourite, dragListeners, dragAt
       className={`flex items-center p-2 md:p-4 rounded-md hover:bg-muted transition-colors duration-200 ${isDragging ? 'border-[3px] border-rose-700' : ''} ${dragListeners ? 'cursor-grab' : ''}`}
       {...(dragListeners || {})}
       {...(dragAttributes || {})}
-      style={isDraggable ? dragSurfaceStyle : undefined}
-      onContextMenu={isDraggable ? (e) => {
-        // Only on touch devices, so desktop right-click still opens the browser menu.
-        if (window.matchMedia('(pointer: coarse)').matches) e.preventDefault();
-      } : undefined}
+      {...dragSurfaceProps(isDraggable)}
     >
       {/* Always rendered — never swapped for a bare div when `disableLink` flips on drag start,
           so the touch target stays stable for the whole gesture. Next's Link skips navigating

--- a/components/home/gang-card.tsx
+++ b/components/home/gang-card.tsx
@@ -9,6 +9,20 @@ import { CSS } from '@dnd-kit/utilities'
 import { FiStar } from 'react-icons/fi'
 import { AiFillStar } from 'react-icons/ai'
 
+// A long press over an `<a href>` makes the browser offer its own link menu ("Open in New
+// Tab"), which on iOS steals the gesture before dnd-kit's TouchSensor delay elapses. Cancelling
+// `contextmenu` is what stops it — the same trick fighter-card-action-menu.tsx uses for its menu
+// trigger. dnd-kit has a contextmenu guard of its own, but only once a drag has activated, which
+// is too late. The CSS is belt-and-braces for iOS; both properties inherit, so they cover the
+// `<Link>` inside. Only for favourites, so plain cards keep normal selection and link behaviour.
+const dragSurfaceStyle = {
+  WebkitTouchCallout: 'none',
+  WebkitUserSelect: 'none',
+  userSelect: 'none',
+  WebkitTapHighlightColor: 'transparent',
+  touchAction: 'manipulation',
+} as const;
+
 export interface GangCardProps {
   gang: Gang;
   onToggleFavourite: (gangId: string, isFavourite: boolean) => void;
@@ -19,6 +33,8 @@ export interface GangCardProps {
 }
 
 export function GangCardContent({ gang, onToggleFavourite, dragListeners, dragAttributes, isDragging, disableLink = false }: GangCardProps) {
+  const isDraggable = Boolean(dragListeners);
+
   let imageUrl: string | null = null;
 
   if (gang.image_url) {
@@ -88,16 +104,25 @@ export function GangCardContent({ gang, onToggleFavourite, dragListeners, dragAt
       className={`flex items-center p-2 md:p-4 rounded-md hover:bg-muted transition-colors duration-200 ${isDragging ? 'border-[3px] border-rose-700' : ''} ${dragListeners ? 'cursor-grab' : ''}`}
       {...(dragListeners || {})}
       {...(dragAttributes || {})}
+      style={isDraggable ? dragSurfaceStyle : undefined}
+      onContextMenu={isDraggable ? (e) => {
+        // Only on touch devices, so desktop right-click still opens the browser menu.
+        if (window.matchMedia('(pointer: coarse)').matches) e.preventDefault();
+      } : undefined}
     >
-      {disableLink ? (
-        <div className="flex items-center grow min-w-0">
-          {innerContent}
-        </div>
-      ) : (
-        <Link href={`/gang/${gang.id}`} prefetch={false} className="flex items-center grow min-w-0">
-          {innerContent}
-        </Link>
-      )}
+      {/* Always rendered — never swapped for a bare div when `disableLink` flips on drag start,
+          so the touch target stays stable for the whole gesture. Next's Link skips navigating
+          when a click handler calls preventDefault, so soft navigation is preserved. */}
+      <Link
+        href={`/gang/${gang.id}`}
+        prefetch={false}
+        onClick={(e) => { if (disableLink) e.preventDefault(); }}
+        tabIndex={disableLink ? -1 : undefined}
+        aria-hidden={disableLink || undefined}
+        className={`flex items-center grow min-w-0${isDraggable ? ' home-favourite-card-link' : ''}`}
+      >
+        {innerContent}
+      </Link>
       <button
         type="button"
         onClick={(e) => {

--- a/components/home/gangs-tab.tsx
+++ b/components/home/gangs-tab.tsx
@@ -7,7 +7,7 @@ import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-ki
 import { toggleFavourite } from '@/app/actions/toggle-favourite'
 import { reorderFavourites } from '@/app/actions/reorder-favourites'
 import { toast } from 'sonner'
-import { useDndSensorsConfig } from '@/hooks/use-dnd-sensors'
+import { useDndSensorsConfig, useSuppressClickAfterDrag } from '@/hooks/use-dnd-sensors'
 import { useIsMounted } from '@/hooks/use-is-mounted'
 import { GangCardContent, SortableGangCard } from '@/components/home/gang-card'
 
@@ -19,6 +19,7 @@ export function GangsTab({ gangs }: GangsTabProps) {
   const [localGangs, setLocalGangs] = useState<Gang[]>(gangs);
   const isMounted = useIsMounted();
   const sensors = useDndSensorsConfig();
+  const suppressClickAfterDrag = useSuppressClickAfterDrag('.home-favourite-card-link');
 
   const [prevGangs, setPrevGangs] = useState(gangs);
   if (gangs !== prevGangs) {
@@ -66,7 +67,11 @@ export function GangsTab({ gangs }: GangsTabProps) {
     }
   }, [localGangs]);
 
-  const handleDragEnd = useCallback(async (event: { active: { id: string | number }; over: { id: string | number } | null }) => {
+  const handleDragEnd = useCallback(async (event: { active: { id: string | number }; over: { id: string | number } | null; activatorEvent?: Event | null }) => {
+    // Always consider suppress for pointer drags — including same-position drops — because a
+    // real drag still produces a trailing click.
+    suppressClickAfterDrag(event.activatorEvent);
+
     const { active, over } = event;
     if (!over || active.id === over.id) return;
 
@@ -92,7 +97,7 @@ export function GangsTab({ gangs }: GangsTabProps) {
     if (!result.success) {
       toast.error(result.error || 'Failed to reorder favourites');
     }
-  }, [favouriteGangs]);
+  }, [favouriteGangs, suppressClickAfterDrag]);
 
   return (
     <div className="bg-card shadow-md rounded-lg p-4">
@@ -109,6 +114,7 @@ export function GangsTab({ gangs }: GangsTabProps) {
                   sensors={sensors}
                   collisionDetection={closestCenter}
                   onDragEnd={handleDragEnd}
+                  onDragCancel={(event) => suppressClickAfterDrag(event.activatorEvent)}
                 >
                   <SortableContext
                     items={favouriteGangs.map(g => g.id)}

--- a/hooks/use-dnd-sensors.ts
+++ b/hooks/use-dnd-sensors.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback } from 'react'
+import { useCallback, type MouseEvent as ReactMouseEvent } from 'react'
 import { MouseSensor, TouchSensor, KeyboardSensor, useSensor, useSensors } from '@dnd-kit/core'
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 
@@ -16,6 +16,34 @@ export function useDndSensorsConfig() {
       coordinateGetter: sortableKeyboardCoordinates,
     })
   );
+}
+
+const dragSurfaceStyle = {
+  WebkitTouchCallout: 'none',
+  WebkitUserSelect: 'none',
+  userSelect: 'none',
+  WebkitTapHighlightColor: 'transparent',
+  touchAction: 'manipulation',
+} as const;
+
+// Props for a drag surface that wraps a link. A long press over an `<a href>` makes the browser
+// offer its own menu ("Open in New Tab"), which on iOS steals the gesture before the TouchSensor
+// delay elapses. Cancelling `contextmenu` is what stops it — the same trick
+// fighter-card-action-menu.tsx uses for its menu trigger. dnd-kit has a contextmenu guard of its
+// own, but only once a drag has activated, which is too late. The CSS is belt-and-braces for
+// iOS; `-webkit-touch-callout` and `user-select` inherit, so they cover the link inside.
+//
+// Returns nothing when the card isn't draggable, so plain cards keep normal text selection and
+// native link behaviour.
+export function dragSurfaceProps(isDraggable: boolean) {
+  if (!isDraggable) return {};
+  return {
+    style: dragSurfaceStyle,
+    onContextMenu: (e: ReactMouseEvent) => {
+      // Only on touch devices, so desktop right-click still opens the browser menu.
+      if (window.matchMedia('(pointer: coarse)').matches) e.preventDefault();
+    },
+  };
 }
 
 // A drag that starts and ends on the same spot still leaves the browser with a matching

--- a/hooks/use-dnd-sensors.ts
+++ b/hooks/use-dnd-sensors.ts
@@ -1,5 +1,6 @@
 "use client"
 
+import { useCallback } from 'react'
 import { MouseSensor, TouchSensor, KeyboardSensor, useSensor, useSensors } from '@dnd-kit/core'
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 
@@ -15,4 +16,33 @@ export function useDndSensorsConfig() {
       coordinateGetter: sortableKeyboardCoordinates,
     })
   );
+}
+
+// A drag that starts and ends on the same spot still leaves the browser with a matching
+// mousedown/mouseup (or tap), so it follows the card's `<a href>` and navigates away. dnd-kit
+// stops the click propagating, which kills React's onClick, but not the anchor's default
+// action. Returns a callback that swallows that one click in the capture phase.
+//
+// `cardSelector` scopes it to draggable cards, so unrelated UI stays clickable if the listener
+// is still armed. Keyboard reorder produces no trailing click, so we skip arming for it.
+export function useSuppressClickAfterDrag(cardSelector: string) {
+  return useCallback((activatorEvent?: Event | null) => {
+    if (activatorEvent instanceof KeyboardEvent) return;
+
+    const suppress = (event: Event) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (!target.closest(cardSelector)?.closest('a')) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      cleanup();
+    };
+    const cleanup = () => {
+      document.removeEventListener('click', suppress, true);
+      window.clearTimeout(timeoutId);
+    };
+    document.addEventListener('click', suppress, true);
+    const timeoutId = window.setTimeout(cleanup, 500);
+  }, [cardSelector]);
 }


### PR DESCRIPTION
Problem
Long-pressing a favourite gang or campaign card on the home page showed the red “selected” border — so dnd-kit did activate the drag — but the browser then took over the gesture with its native link menu (“Open in New Tab”) and the reorder never completed. Desktop was fine.
The equivalent DnD on the gang page (reordering fighters) works on mobile using the same sensors (useDndSensorsConfig) and the same mount gate (useIsMounted). The difference is that the fighter card carries workarounds the home cards never got.
Changes
1. Cancel the long-press context menu on a favourite card. This is what actually stops the native link menu stealing the gesture — the same trick fighter-card-action-menu.tsx:160-166 already uses for its menu trigger. dnd-kit registers a contextmenu guard of its own, but only once a drag has activated, which is too late: the browser’s menu fires first. Gated on touch-primary devices so desktop right-click still opens the browser menu, and on the card being draggable so plain cards are untouched. The accompanying CSS (-webkit-touch-callout, user-select, tap highlight, touch-action) is belt-and-braces for iOS.
2. Stop swapping the card’s <Link> for a bare <div> when the drag activates, so the touch target stays stable for the whole gesture. Navigation is cancelled via onClick instead — Next’s Link skips navigating when the handler calls preventDefault() — so soft navigation and prefetch={false} are both preserved.
3. Swallow the click the browser synthesises after a drag. A drag ending where it started leaves a matching mousedown/mouseup, so the browser follows the card’s href: pressing and holding a favourite on a phone already navigated into the gang instead of reordering. dnd-kit stops that click propagating, which kills React’s onClick, but not the anchor’s default action. suppressClickAfterDrag moves from draggable-fighters.tsx into the shared use-dnd-sensors.ts, parameterised by selector, so all three drag surfaces share one copy.
4. Give a dragged card an opaque background. The card row has no background of its own — it inherits the look of the panel it sits on. Invisible at rest, but once dnd-kit lifts a card to z-index: 50 you read the cards underneath straight through it. It didn’t show on desktop because the pointer sits over the card while dragging, so hover:bg-muted paints it; on touch there’s no hover, so the dragged card stayed see-through the whole way.
The shared sensor config itself (including the 600 ms TouchSensor delay) and the useIsMounted hydration gate from #1785 are unchanged.
Verification
Driven in Chromium against the real components, with touch emulation and raw CDP touch events:
	•	Long-press context menu is cancelled on favourite cards, not on plain ones, and a desktop right-click is still allowed through.
	•	A same-position drop and a drag-and-return no longer navigate — both did before this PR.
	•	Touch long-press reorders favourite gangs and campaigns, with the right reorderFavourites payload and no stray navigation.
	•	Plain taps still navigate; the dragged card is opaque on touch (rgba(0,0,0,0) → rgb(255,255,255)).
	•	Mouse drag, plain clicks, the favourite star and keyboard reorder are unaffected.
	•	tsc --noEmit, eslint and next build all clean.
Caveat: the CSS half of change 1 (-webkit-touch-callout) is Safari-only and has no Chromium equivalent, so it can’t be proven by emulation. The contextmenu cancellation — the load-bearing part — is verified above. Worth a quick check on a real iPhone before merging.
Follow-up (not in this PR)
Dragging fighter cards on the gang page pops iOS’s text-selection magnifier mid-drag, because that card body never disabled text selection. Fixed separately on claude/ios-fighter-card-drag-loupe, branched off main so it can merge in any order.