### PR TITLE
Stop iOS showing its text magnifier while dragging a fighter card

### DIFF
--- a/components/gang/fighter-card.tsx
+++ b/components/gang/fighter-card.tsx
@@ -525,7 +525,20 @@ const FighterCard = memo(function FighterCard({
           ...(compactMinHeightPx ? { minHeight: `${compactMinHeightPx}px` } : {}),
           // Prevent hover effects from sticking on touch devices
           WebkitTapHighlightColor: 'transparent',
-          touchAction: 'manipulation'
+          touchAction: 'manipulation',
+          // The long press that starts a drag is also a long press on the card's text, so iOS
+          // opens its text-selection magnifier over your finger — it reads as the page zooming
+          // mid-drag. Only on draggable cards, so view-only and print cards keep selectable text.
+          //
+          // This also removes the short haptic tick iOS played when that gesture fired. That tick
+          // was never ours — there's no vibration code in the app — and it can't be reinstated:
+          // since iOS 18.4 navigator.vibrate needs a recent *click* to be granted, and dragging
+          // doesn't count. Losing it is the accepted trade for losing the magnifier.
+          ...(dragListeners ? {
+            WebkitUserSelect: 'none' as const,
+            userSelect: 'none' as const,
+            WebkitTouchCallout: 'none' as const,
+          } : {})
         }}
       >
       {isLoading && (


### PR DESCRIPTION
Reordering fighter cards on a phone looks like the page zooms mid-drag. The long press that arms dnd-kit's TouchSensor is also a long press on the card's text, so iOS opens its text-selection magnifier over your finger.

The card body already sets WebkitTapHighlightColor and touchAction, but never disabled text selection, so nothing stopped the loupe. Add user-select and -webkit-touch-callout, gated on the card actually being draggable so view-only and print cards keep selectable text.

Note this also silences the short haptic tick iOS played when a drag started. That tick came from the same long-press gesture, not from the app — there is no vibration code anywhere in it — so it goes with the magnifier. It can't be added back deliberately either: since iOS 18.4 navigator.vibrate requires a recent click to be granted and dragging does not qualify, so a vibrate() call at drag activation is ignored. The home page favourites already behave this way, so this makes the two drag surfaces consistent.

Verified with tsc, eslint and next build. The magnifier is Safari-only and has no Chromium equivalent, so the behaviour itself needs a device to confirm.


Claude-Session: https://claude.ai/code/session_013k9esac5w6bmf5tEMDV7AM