### PR TITLE
feat(fighter-types): allow linking default equipment accessories to

### DIFF
--- a/app/actions/add-fighter.ts
+++ b/app/actions/add-fighter.ts
@@ -11,6 +11,15 @@ import {
   mapArchetypeSkillAccessToOverrides,
 } from '@/utils/archetypeEligibility';
 
+interface InsertedEquipment {
+  id: string;
+  equipment_id: string | null;
+  custom_equipment_id: string | null;
+  purchase_cost?: number;
+  equipment?: { equipment_name: string; equipment_type: string; equipment_category: string; equipment_category_id?: string; is_consumable?: boolean };
+  custom_equipment?: { equipment_name: string; equipment_type: string; equipment_category: string; is_consumable?: boolean };
+}
+
 interface SelectedEquipment {
   equipment_id: string;
   cost: number;
@@ -171,7 +180,8 @@ async function applyEffectsForEquipmentOptimized(
   fighterEquipmentId: string,
   fighterId: string,
   userId: string,
-  includeCreditIncrease: boolean = false
+  includeCreditIncrease: boolean = false,
+  targetEquipmentId?: string | null
 ): Promise<{ appliedEffects: any[], effectsCreditsIncrease: number }> {
   if (!effectTypes || effectTypes.length === 0) {
     return { appliedEffects: [], effectsCreditsIncrease: 0 };
@@ -187,6 +197,7 @@ async function applyEffectsForEquipmentOptimized(
       type_specific_data: effectType.type_specific_data,
       sort_order: effectType.sort_order ?? null,
       fighter_equipment_id: fighterEquipmentId,
+      target_equipment_id: targetEquipmentId || null,
       user_id: userId
     }));
 
@@ -546,8 +557,10 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
     const { data: allDefaultsData } = await supabase
       .from('fighter_defaults')
       .select(`
+        id,
         skill_id,
         equipment_id,
+        target_fighter_default_id,
         custom_equipment_id,
         skills!skill_id(
           id,
@@ -578,12 +591,16 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
       .map(item => {
         if (item.equipment_id && item.equipment) {
           return {
+            default_id: item.id,
+            target_fighter_default_id: item.target_fighter_default_id || null,
             equipment_id: item.equipment_id,
             equipment: item.equipment,
             is_editable: (item.equipment as any)?.is_editable || false
           };
         } else if (item.custom_equipment_id && item.custom_equipment) {
           return {
+            default_id: item.id,
+            target_fighter_default_id: item.target_fighter_default_id || null,
             equipment_id: `custom_${item.custom_equipment_id}`,
             equipment: {
               id: `custom_${item.custom_equipment_id}`,
@@ -608,6 +625,12 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
       is_editable?: boolean;
     }> = [];
 
+    // Parallel array to track default metadata (default_id and target_fighter_default_id)
+    const equipmentMeta: Array<{
+      default_id?: string;
+      target_fighter_default_id?: string | null;
+    }> = [];
+
     // Track added equipment to prevent cross-source duplicates
     const addedEquipment = new Set<string>();
 
@@ -627,6 +650,10 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
           gang_id: params.gang_id,
           user_id: gangData.user_id,
           is_editable: defaultEquipment.is_editable || false
+        });
+        equipmentMeta.push({
+          default_id: defaultEquipment.default_id,
+          target_fighter_default_id: defaultEquipment.target_fighter_default_id || null
         });
       });
     }
@@ -649,6 +676,7 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
               user_id: gangData.user_id,
               is_editable: defaultItem.is_editable || false
             });
+            equipmentMeta.push({});
           }
         }
       });
@@ -670,6 +698,7 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
             user_id: gangData.user_id,
             is_editable: selectedItem.is_editable || false
           });
+          equipmentMeta.push({});
         }
       });
     }
@@ -769,13 +798,13 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
         switch (type) {
           case 'equipment':
             if (queryResult.data) {
-              const insertedEquipment = queryResult.data;
+              const insertedEquipment: InsertedEquipment[] = queryResult.data;
 
               // Apply equipment effects automatically for ALL equipment (OPTIMIZED)
               // Filter valid equipment IDs for batch processing
               const validEquipmentIds = insertedEquipment
-                .filter((item: any) => item.equipment_id && !item.custom_equipment_id)
-                .map((item: any) => item.equipment_id);
+                .filter((item) => item.equipment_id && !item.custom_equipment_id)
+                .map((item) => item.equipment_id);
 
               if (validEquipmentIds.length > 0) {
                 try {
@@ -825,29 +854,75 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
                         fixedEffectsByEquipment.set(equipmentId, fixedEffects);
                       }
                     });
+                  }
 
-                    // Apply effects for each equipment piece
-                    for (const equipmentItem of insertedEquipment) {
-                      if (!equipmentItem.equipment_id || equipmentItem.custom_equipment_id) continue;
+                  // Build map of default_id -> inserted fighter_equipment.id for linking target equipment
+                  // Note: We rely on Supabase/PostgREST returning the inserted rows in the exact same array order.
+                  // This allows us to map the newly generated DB 'id' back to our local 'equipmentMeta' using the index.
+                  const defaultToFighterEquipMap = new Map<string, string>();
+                  insertedEquipment.forEach((item, idx: number) => {
+                    const meta = equipmentMeta[idx];
+                    if (meta?.default_id) {
+                      defaultToFighterEquipMap.set(meta.default_id, item.id);
+                    }
+                  });
 
-                      const effectsForThisEquipment = fixedEffectsByEquipment.get(equipmentItem.equipment_id) || [];
+                  // Apply effects for each equipment piece
+                  for (let i = 0; i < insertedEquipment.length; i++) {
+                    const equipmentItem = insertedEquipment[i];
+                    if (!equipmentItem.equipment_id || equipmentItem.custom_equipment_id) continue;
 
-                      if (effectsForThisEquipment.length > 0) {
-                        try {
-                          const effectsResult = await applyEffectsForEquipmentOptimized(
-                            supabase,
-                            effectsForThisEquipment,
-                            equipmentItem.id,
-                            fighterId,
-                            effectiveUserId,
-                            false // Don't include credit increase for fighter creation
-                          );
+                    const meta = equipmentMeta[i];
+                    let targetFighterEquipId: string | null = null;
+                    if (meta?.target_fighter_default_id) {
+                      targetFighterEquipId = defaultToFighterEquipMap.get(meta.target_fighter_default_id) || null;
+                    }
 
-                          allAppliedEffects.push(...effectsResult.appliedEffects);
-                          totalEffectsCreditsIncrease += effectsResult.effectsCreditsIncrease;
-                        } catch (effectError) {
-                          console.error('Error applying effects for equipment:', equipmentItem.equipment_id, effectError);
+                    const effectsForThisEquipment = fixedEffectsByEquipment.get(equipmentItem.equipment_id) || [];
+
+                    if (effectsForThisEquipment.length > 0) {
+                      try {
+                        const effectsResult = await applyEffectsForEquipmentOptimized(
+                          supabase,
+                          effectsForThisEquipment,
+                          equipmentItem.id,
+                          fighterId,
+                          effectiveUserId,
+                          false, // Don't include credit increase for fighter creation
+                          targetFighterEquipId
+                        );
+
+                        allAppliedEffects.push(...effectsResult.appliedEffects);
+                        totalEffectsCreditsIncrease += effectsResult.effectsCreditsIncrease;
+                      } catch (effectError) {
+                        console.error(`Error applying effects for equipment ${equipmentItem.equipment_id} on fighter ${fighterId} (User: ${effectiveUserId}):`, effectError);
+                      }
+                    } else if (targetFighterEquipId) {
+                      // Fallback for equipment attached to a weapon that does not have pre-registered effect types.
+                      // Since the accessory lacks predefined effects, we generate a raw, generic 'fighter_effects'
+                      // row pointing at the target weapon so it properly displays as attached in the UI.
+                      try {
+                        const effectName = equipmentItem.equipment?.equipment_name || 'Wargear';
+                        const { data: directEffect, error: directEffectErr } = await supabase
+                          .from('fighter_effects')
+                          .insert({
+                            fighter_id: fighterId,
+                            vehicle_id: null,
+                            fighter_equipment_id: equipmentItem.id,
+                            target_equipment_id: targetFighterEquipId,
+                            effect_name: effectName,
+                            type_specific_data: {},
+                            sort_order: null,
+                            user_id: effectiveUserId
+                          })
+                          .select()
+                          .single();
+
+                        if (!directEffectErr && directEffect) {
+                          allAppliedEffects.push(directEffect);
                         }
+                      } catch (directEffectError) {
+                        console.error(`Error applying direct target effect for equipment ${equipmentItem.equipment_id} on fighter ${fighterId} (User: ${effectiveUserId}):`, directEffectError);
                       }
                     }
                   }
@@ -888,9 +963,9 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
 
               // Check for exotic beast equipment and create beasts
               const exoticBeastCategoryId = '6b5eabd8-0865-439c-98bb-09bd78f0fbac';
-              const exoticBeastEquipment = insertedEquipment.filter((item: any) =>
-                (item.equipment as any)?.equipment_category_id === exoticBeastCategoryId ||
-                (item.custom_equipment as any)?.equipment_category === 'exotic beast'
+              const exoticBeastEquipment = insertedEquipment.filter((item) =>
+                item.equipment?.equipment_category_id === exoticBeastCategoryId ||
+                item.custom_equipment?.equipment_category === 'exotic beast'
               );
 
               // Create exotic beasts for equipment that grants them
@@ -901,7 +976,7 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
                 for (const equipmentItem of exoticBeastEquipment) {
                   try {
                     const beastResult = await createExoticBeastsForEquipment({
-                      equipmentId: equipmentItem.equipment_id,
+                      equipmentId: equipmentItem.equipment_id || '',
                       ownerFighterId: fighterId,
                       ownerFighterName: insertedFighter.fighter_name,
                       gangId: params.gang_id,
@@ -922,16 +997,16 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
                       totalBeastsRatingDelta += createdBeastsRatingDelta;
                     }
                   } catch (beastError) {
-                    console.error('Error creating exotic beast for equipment:', equipmentItem.equipment_id, beastError);
+                    console.error(`Error creating exotic beast for equipment ${equipmentItem.equipment_id} on fighter ${fighterId} (User: ${effectiveUserId}):`, beastError);
                     throw beastError;
                   }
                 }
 
               }
 
-              equipmentWithProfiles = insertedEquipment.map((item: any) => {
+              equipmentWithProfiles = insertedEquipment.map((item) => {
                 const isCustomEquipment = !!item.custom_equipment_id;
-                const equipmentType = (item.equipment as any)?.equipment_type || (item.custom_equipment as any)?.equipment_type;
+                const equipmentType = item.equipment?.equipment_type || item.custom_equipment?.equipment_type;
 
                 // Get weapon profiles based on equipment type
                 let itemWeaponProfiles: any[] = [];
@@ -951,12 +1026,12 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
                   fighter_equipment_id: item.id,
                   equipment_id: item.equipment_id || undefined,
                   custom_equipment_id: item.custom_equipment_id || undefined,
-                  equipment_name: (item.equipment as any)?.equipment_name || (item.custom_equipment as any)?.equipment_name || 'Unknown',
+                  equipment_name: item.equipment?.equipment_name || item.custom_equipment?.equipment_name || 'Unknown',
                   equipment_type: equipmentType || 'unknown',
-                  equipment_category: (item.equipment as any)?.equipment_category || (item.custom_equipment as any)?.equipment_category || 'unknown',
+                  equipment_category: item.equipment?.equipment_category || item.custom_equipment?.equipment_category || 'unknown',
                   cost: item.purchase_cost,
                   weapon_profiles: itemWeaponProfiles,
-                  is_editable: item.is_editable || false
+                  is_editable: false
                 };
               });
 
@@ -968,11 +1043,11 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
               //   those grants will be skipped (the equipment itself is still added)
               // - Users can later purchase equipment with selection grants via the normal purchase flow
               const standardEquipmentItems = insertedEquipment.filter(
-                (item: any) => item.equipment_id && !item.custom_equipment_id
+                (item) => item.equipment_id && !item.custom_equipment_id
               );
 
               if (standardEquipmentItems.length > 0) {
-                const equipmentIds = standardEquipmentItems.map((item: any) => item.equipment_id);
+                const equipmentIds = standardEquipmentItems.map((item) => item.equipment_id).filter((id): id is string => !!id);
 
                 // Fetch equipment that grants other equipment (JSONB grants_equipment)
                 const { data: equipmentWithGrantsData } = await supabase

--- a/app/actions/add-fighter.ts
+++ b/app/actions/add-fighter.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { randomUUID } from 'crypto';
 import { createClient } from "@/utils/supabase/server";
 import { getAuthenticatedUser } from "@/utils/auth";
 import { invalidateFighterAddition, invalidateUserGangsList } from '@/utils/cache-tags';
@@ -16,8 +17,11 @@ interface InsertedEquipment {
   equipment_id: string | null;
   custom_equipment_id: string | null;
   purchase_cost?: number;
-  equipment?: { equipment_name: string; equipment_type: string; equipment_category: string; equipment_category_id?: string; is_consumable?: boolean };
-  custom_equipment?: { equipment_name: string; equipment_type: string; equipment_category: string; is_consumable?: boolean };
+  is_editable?: boolean;
+  // Shapes mirror the embedded resources in the fighter_equipment `.select(...)` below.
+  // `equipment` exposes equipment_category_id (not equipment_category); custom_equipment exposes equipment_category.
+  equipment?: { equipment_name: string; equipment_type: string; equipment_category_id?: string };
+  custom_equipment?: { equipment_name: string; equipment_type: string; equipment_category: string };
 }
 
 interface SelectedEquipment {
@@ -107,6 +111,7 @@ interface AddFighterResult {
       equipment_type: string;
       cost: number;
       weapon_profiles?: any[];
+      effect_names?: string[];
     }>;
     skills: Array<{
       skill_id: string;
@@ -613,8 +618,12 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
         return null;
       }).filter(Boolean);
 
-    // Prepare equipment insertions with deduplication
+    // Prepare equipment insertions with deduplication.
+    // We pre-generate each fighter_equipment `id` client-side (the column accepts a supplied
+    // uuid) so we can correlate inserted rows back to their source metadata by id, without
+    // relying on PostgREST returning the RETURNING rows in the same order they were submitted.
     const equipmentInserts: Array<{
+      id: string;
       fighter_id: string;
       equipment_id: string | null;
       custom_equipment_id?: string | null;
@@ -625,8 +634,9 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
       is_editable?: boolean;
     }> = [];
 
-    // Parallel array to track default metadata (default_id and target_fighter_default_id)
+    // Parallel array to track metadata keyed by the pre-generated fighter_equipment id (feId).
     const equipmentMeta: Array<{
+      feId: string;
       default_id?: string;
       target_fighter_default_id?: string | null;
     }> = [];
@@ -641,7 +651,9 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
         const isCustomEquipment = defaultEquipment.equipment_id.startsWith('custom_');
         // Track for cross-source deduplication (prevents params.default_equipment from duplicating)
         addedEquipment.add(defaultEquipment.equipment_id);
+        const feId = randomUUID();
         equipmentInserts.push({
+          id: feId,
           fighter_id: fighterId,
           equipment_id: isCustomEquipment ? null : defaultEquipment.equipment_id,
           custom_equipment_id: isCustomEquipment ? defaultEquipment.equipment_id.replace('custom_', '') : null,
@@ -652,6 +664,7 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
           is_editable: defaultEquipment.is_editable || false
         });
         equipmentMeta.push({
+          feId,
           default_id: defaultEquipment.default_id,
           target_fighter_default_id: defaultEquipment.target_fighter_default_id || null
         });
@@ -666,7 +679,9 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
           addedEquipment.add(defaultItem.equipment_id);
           for (let i = 0; i < (defaultItem.quantity || 1); i++) {
             const isCustomEquipment = defaultItem.equipment_id.startsWith('custom_');
+            const feId = randomUUID();
             equipmentInserts.push({
+              id: feId,
               fighter_id: fighterId,
               equipment_id: isCustomEquipment ? null : defaultItem.equipment_id,
               custom_equipment_id: isCustomEquipment ? defaultItem.equipment_id.replace('custom_', '') : null,
@@ -676,7 +691,7 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
               user_id: gangData.user_id,
               is_editable: defaultItem.is_editable || false
             });
-            equipmentMeta.push({});
+            equipmentMeta.push({ feId });
           }
         }
       });
@@ -687,8 +702,10 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
       params.selected_equipment.forEach((selectedItem) => {
         for (let i = 0; i < (selectedItem.quantity || 1); i++) {
           const isCustomEquipment = selectedItem.equipment_id.startsWith('custom_');
+          const feId = randomUUID();
           // Don't deduplicate selected equipment - user explicitly chose these
           equipmentInserts.push({
+            id: feId,
             fighter_id: fighterId,
             equipment_id: isCustomEquipment ? null : selectedItem.equipment_id,
             custom_equipment_id: isCustomEquipment ? selectedItem.equipment_id.replace('custom_', '') : null,
@@ -698,7 +715,7 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
             user_id: gangData.user_id,
             is_editable: selectedItem.is_editable || false
           });
-          equipmentMeta.push({});
+          equipmentMeta.push({ feId });
         }
       });
     }
@@ -791,6 +808,11 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
     let allAppliedEffects: any[] = [];
     let totalEffectsCreditsIncrease = 0;
 
+    // Names of accessories attached to a given weapon's fighter_equipment.id, so the
+    // equipment response can show them attached (matching gang-data.ts's refetch behaviour)
+    // without waiting for a reload.
+    const effectNamesByTargetId = new Map<string, string[]>();
+
     for (const result of insertResults) {
       if (result.status === 'fulfilled') {
         const { type, result: queryResult } = result.value;
@@ -829,6 +851,8 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
                     `)
                     .in('type_specific_data->>equipment_id', validEquipmentIds);
 
+                  // Filter to ONLY auto-apply fixed effects (exclude editable effects that user adds later)
+                  const fixedEffectsByEquipment = new Map<string, any[]>();
                   if (!batchQueryError && allEffectTypes && allEffectTypes.length > 0) {
                     // Group effects by equipment_id for processing
                     const effectsByEquipment = new Map<string, any[]>();
@@ -842,8 +866,6 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
                       }
                     });
 
-                    // Filter to ONLY auto-apply fixed effects (exclude editable effects that user adds later)
-                    const fixedEffectsByEquipment = new Map<string, any[]>();
                     Array.from(effectsByEquipment.entries()).forEach(([equipmentId, effects]) => {
                       const fixedEffects = effects.filter((et: any) => {
                         // Only exclude effects marked as editable (user adds these via edit modal after purchase)
@@ -856,23 +878,29 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
                     });
                   }
 
-                  // Build map of default_id -> inserted fighter_equipment.id for linking target equipment
-                  // Note: We rely on Supabase/PostgREST returning the inserted rows in the exact same array order.
-                  // This allows us to map the newly generated DB 'id' back to our local 'equipmentMeta' using the index.
+                  // Index metadata by the pre-generated fighter_equipment id. Because we supplied
+                  // these ids ourselves, correlation no longer depends on PostgREST returning the
+                  // inserted rows in submission order.
+                  const metaByFeId = new Map<string, (typeof equipmentMeta)[number]>();
                   const defaultToFighterEquipMap = new Map<string, string>();
-                  insertedEquipment.forEach((item, idx: number) => {
-                    const meta = equipmentMeta[idx];
-                    if (meta?.default_id) {
-                      defaultToFighterEquipMap.set(meta.default_id, item.id);
+                  equipmentMeta.forEach((meta) => {
+                    metaByFeId.set(meta.feId, meta);
+                    if (meta.default_id) {
+                      defaultToFighterEquipMap.set(meta.default_id, meta.feId);
                     }
                   });
 
+                  const recordAttachment = (weaponFighterEquipId: string, accessoryName: string) => {
+                    const existing = effectNamesByTargetId.get(weaponFighterEquipId) || [];
+                    existing.push(accessoryName);
+                    effectNamesByTargetId.set(weaponFighterEquipId, existing);
+                  };
+
                   // Apply effects for each equipment piece
-                  for (let i = 0; i < insertedEquipment.length; i++) {
-                    const equipmentItem = insertedEquipment[i];
+                  for (const equipmentItem of insertedEquipment) {
                     if (!equipmentItem.equipment_id || equipmentItem.custom_equipment_id) continue;
 
-                    const meta = equipmentMeta[i];
+                    const meta = metaByFeId.get(equipmentItem.id);
                     let targetFighterEquipId: string | null = null;
                     if (meta?.target_fighter_default_id) {
                       targetFighterEquipId = defaultToFighterEquipMap.get(meta.target_fighter_default_id) || null;
@@ -894,6 +922,9 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
 
                         allAppliedEffects.push(...effectsResult.appliedEffects);
                         totalEffectsCreditsIncrease += effectsResult.effectsCreditsIncrease;
+                        if (targetFighterEquipId) {
+                          recordAttachment(targetFighterEquipId, equipmentItem.equipment?.equipment_name || 'Wargear');
+                        }
                       } catch (effectError) {
                         console.error(`Error applying effects for equipment ${equipmentItem.equipment_id} on fighter ${fighterId} (User: ${effectiveUserId}):`, effectError);
                       }
@@ -920,6 +951,7 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
 
                         if (!directEffectErr && directEffect) {
                           allAppliedEffects.push(directEffect);
+                          recordAttachment(targetFighterEquipId, effectName);
                         }
                       } catch (directEffectError) {
                         console.error(`Error applying direct target effect for equipment ${equipmentItem.equipment_id} on fighter ${fighterId} (User: ${effectiveUserId}):`, directEffectError);
@@ -1022,16 +1054,19 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
                   }
                 }
 
+                const attachedNames = effectNamesByTargetId.get(item.id);
+
                 return {
                   fighter_equipment_id: item.id,
                   equipment_id: item.equipment_id || undefined,
                   custom_equipment_id: item.custom_equipment_id || undefined,
                   equipment_name: item.equipment?.equipment_name || item.custom_equipment?.equipment_name || 'Unknown',
                   equipment_type: equipmentType || 'unknown',
-                  equipment_category: item.equipment?.equipment_category || item.custom_equipment?.equipment_category || 'unknown',
+                  equipment_category: item.custom_equipment?.equipment_category || 'unknown',
                   cost: item.purchase_cost,
                   weapon_profiles: itemWeaponProfiles,
-                  is_editable: false
+                  is_editable: item.is_editable || false,
+                  effect_names: attachedNames && attachedNames.length > 0 ? attachedNames : undefined
                 };
               });
 

--- a/app/api/admin/fighter-types/route.ts
+++ b/app/api/admin/fighter-types/route.ts
@@ -157,7 +157,7 @@ export async function GET(request: Request) {
       // Fetch default equipment
       const { data: defaultEquipment, error: equipmentError } = await supabase
         .from('fighter_defaults')
-        .select('equipment_id')
+        .select('id, equipment_id, target_fighter_default_id')
         .eq('fighter_type_id', fighterType.id)
         .not('equipment_id', 'is', null);
 
@@ -201,7 +201,11 @@ export async function GET(request: Request) {
 
       const formattedFighterType = {
         ...fighterType,
-        default_equipment: defaultEquipment?.map(d => d.equipment_id) || [],
+        default_equipment: defaultEquipment?.map(d => ({
+          id: d.id,
+          equipment_id: d.equipment_id,
+          target_fighter_default_id: d.target_fighter_default_id || null
+        })) || [],
         default_skills: defaultSkills?.map(d => d.skill_id) || [],
         equipment_list: equipmentList?.map(e => e.equipment_id) || [],
         equipment_discounts: fighterType.equipment_discounts?.map(d => ({
@@ -299,7 +303,7 @@ export async function GET(request: Request) {
             // Fetch default equipment
             const { data: defaultEquipment, error: equipmentError } = await supabase
               .from('fighter_defaults')
-              .select('equipment_id')
+              .select('id, equipment_id, target_fighter_default_id')
               .eq('fighter_type_id', fighter.id)
               .not('equipment_id', 'is', null);
 
@@ -346,7 +350,11 @@ export async function GET(request: Request) {
 
             return {
               ...fighter,
-              default_equipment: defaultEquipment?.map(d => d.equipment_id) || [],
+              default_equipment: defaultEquipment?.map(d => ({
+                id: d.id,
+                equipment_id: d.equipment_id,
+                target_fighter_default_id: d.target_fighter_default_id || null
+              })) || [],
               default_skills: defaultSkills?.map(d => d.skill_id) || [],
               equipment_list: equipmentList?.map(e => e.equipment_id) || [],
               equipment_discounts: fighter.equipment_discounts?.map((d: any) => ({
@@ -539,9 +547,11 @@ export async function PUT(request: Request) {
 
     // Insert new equipment defaults
     if (data.default_equipment?.length > 0) {
-      const equipmentDefaults = data.default_equipment.map((equipmentId: string) => ({
+      const equipmentDefaults = data.default_equipment.map((item: any) => ({
+        ...(typeof item === 'object' && item.id ? { id: item.id } : {}),
         fighter_type_id: id,
-        equipment_id: equipmentId,
+        equipment_id: typeof item === 'string' ? item : item.equipment_id,
+        target_fighter_default_id: typeof item === 'object' ? (item.target_fighter_default_id || item.target_id || null) : null,
         skill_id: null
       }));
 
@@ -850,9 +860,11 @@ export async function POST(request: Request) {
 
     // Handle default equipment if provided
     if (data.default_equipment && data.default_equipment.length > 0) {
-      const equipmentDefaults = data.default_equipment.map((equipmentId: string) => ({
+      const equipmentDefaults = data.default_equipment.map((item: any) => ({
+        ...(typeof item === 'object' && item.id ? { id: item.id } : {}),
         fighter_type_id: newFighterType.id,
-        equipment_id: equipmentId
+        equipment_id: typeof item === 'string' ? item : item.equipment_id,
+        target_fighter_default_id: typeof item === 'object' ? (item.target_fighter_default_id || item.target_id || null) : null
       }));
 
       const { error: equipmentError } = await supabase

--- a/app/api/admin/fighter-types/route.ts
+++ b/app/api/admin/fighter-types/route.ts
@@ -551,7 +551,7 @@ export async function PUT(request: Request) {
         ...(typeof item === 'object' && item.id ? { id: item.id } : {}),
         fighter_type_id: id,
         equipment_id: typeof item === 'string' ? item : item.equipment_id,
-        target_fighter_default_id: typeof item === 'object' ? (item.target_fighter_default_id || item.target_id || null) : null,
+        target_fighter_default_id: typeof item === 'object' ? (item.target_fighter_default_id || null) : null,
         skill_id: null
       }));
 
@@ -864,7 +864,7 @@ export async function POST(request: Request) {
         ...(typeof item === 'object' && item.id ? { id: item.id } : {}),
         fighter_type_id: newFighterType.id,
         equipment_id: typeof item === 'string' ? item : item.equipment_id,
-        target_fighter_default_id: typeof item === 'object' ? (item.target_fighter_default_id || item.target_id || null) : null
+        target_fighter_default_id: typeof item === 'object' ? (item.target_fighter_default_id || null) : null
       }));
 
       const { error: equipmentError } = await supabase

--- a/components/admin/admin-create-fighter-type.tsx
+++ b/components/admin/admin-create-fighter-type.tsx
@@ -70,7 +70,11 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
   const [isDramatisPersonae, setIsDramatisPersonae] = useState(false);
   const [isSpyrer, setIsSpyrer] = useState(false);
   const [alignment, setAlignment] = useState<string>('');
-  const [selectedEquipment, setSelectedEquipment] = useState<string[]>([]);
+  const [selectedEquipment, setSelectedEquipment] = useState<{
+    id: string;
+    equipment_id: string;
+    target_fighter_default_id?: string | null;
+  }[]>([]);
   const [selectedSkillType, setSelectedSkillType] = useState('');
   const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
   const [equipmentListSelections, setEquipmentListSelections] = useState<string[]>([]);
@@ -590,42 +594,91 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
                 value=""
                 onChange={(e) => {
                   const value = e.target.value;
-                  if (value && !selectedEquipment.includes(value)) {
-                    setSelectedEquipment([...selectedEquipment, value]);
+                  if (value) {
+                    setSelectedEquipment([
+                      ...selectedEquipment,
+                      { id: crypto.randomUUID(), equipment_id: value, target_fighter_default_id: null }
+                    ]);
                   }
-                  // Reset the select to empty after selection
                   e.target.value = "";
                 }}
                 className="w-full p-2 border rounded-md"
               >
                 <option value="">Select equipment to add</option>
-                {equipment
-                  .filter(item => !selectedEquipment.includes(item.id))
-                  .map((item) => (
-                    <option key={item.id} value={item.id}>
-                      {item.equipment_name}
-                    </option>
-                  ))}
+                {equipment.map((item) => (
+                  <option key={item.id} value={item.id}>
+                    {item.equipment_name}
+                  </option>
+                ))}
               </select>
 
-              <div className="mt-2 flex flex-wrap gap-2">
-                {selectedEquipment.map((equipId) => {
-                  const item = equipment.find(e => e.id === equipId);
+              <div className="mt-2 flex flex-col gap-2">
+                {selectedEquipment.map((slot, index) => {
+                  const item = equipment.find(e => e.id === slot.equipment_id);
                   if (!item) return null;
-                  
+
+                  // Find available weapon slots that this item could be attached to
+                  const availableWeaponSlots = selectedEquipment
+                    .map((s, idx) => {
+                      const eq = equipment.find(e => e.id === s.equipment_id);
+                      return eq && eq.equipment_type === 'weapon' && s.id !== slot.id
+                        ? { slot: s, eq, weaponIndex: idx + 1 }
+                        : null;
+                    })
+                    .filter((w): w is { slot: typeof slot; eq: EquipmentWithId; weaponIndex: number } => w !== null);
+
+                  const isWeaponAccessory = item.equipment_category?.toLowerCase() === 'weapon accessories';
+
                   return (
                     <div 
-                      key={item.id}
-                      className="flex items-center gap-1 bg-muted px-2 py-1 rounded-full text-sm"
+                      key={slot.id}
+                      className="flex flex-wrap items-center justify-between gap-2 bg-muted p-2 rounded-md text-sm"
                     >
-                      <span>{item.equipment_name}</span>
-                      <button
-                        type="button"
-                        onClick={() => setSelectedEquipment(selectedEquipment.filter(id => id !== item.id))}
-                        className="hover:text-red-500 focus:outline-hidden"
-                      >
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium">{item.equipment_name}</span>
+                        <span className="text-xs text-muted-foreground capitalize">({item.equipment_type.replace('_', ' ')})</span>
+                      </div>
+
+                      <div className="flex items-center gap-2">
+                        {isWeaponAccessory && availableWeaponSlots.length > 0 && (
+                          <div className="flex items-center gap-1">
+                            <span className="text-xs text-muted-foreground">Attach to:</span>
+                            <select
+                              value={slot.target_fighter_default_id || ''}
+                              onChange={(e) => {
+                                const targetId = e.target.value || null;
+                                setSelectedEquipment(selectedEquipment.map(s => 
+                                  s.id === slot.id ? { ...s, target_fighter_default_id: targetId } : s
+                                ));
+                              }}
+                              className="text-xs p-1 border rounded bg-background text-foreground"
+                            >
+                              <option value="">(Unattached / Standalone)</option>
+                              {availableWeaponSlots.map(({ slot: wSlot, eq: wEq, weaponIndex }) => (
+                                <option key={wSlot.id} value={wSlot.id}>
+                                  {wEq.equipment_name} #{weaponIndex}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                        )}
+
+                        <button
+                          type="button"
+                          onClick={() => {
+                            // Remove item and clear any target references pointing to this item
+                            setSelectedEquipment(
+                              selectedEquipment
+                                .filter(s => s.id !== slot.id)
+                                .map(s => s.target_fighter_default_id === slot.id ? { ...s, target_fighter_default_id: null } : s)
+                            );
+                          }}
+                          className="hover:text-red-500 focus:outline-hidden p-1"
+                          title="Remove equipment"
+                        >
                           <HiX className="h-4 w-4" />
-                      </button>
+                        </button>
+                      </div>
                     </div>
                   );
                 })}

--- a/components/admin/admin-create-fighter-type.tsx
+++ b/components/admin/admin-create-fighter-type.tsx
@@ -605,6 +605,8 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
                 className="w-full p-2 border rounded-md"
               >
                 <option value="">Select equipment to add</option>
+                {/* Any equipment may be added more than once (e.g. two Stub Guns, or a
+                    Weapon Accessory attached to two different default weapons). */}
                 {equipment.map((item) => (
                   <option key={item.id} value={item.id}>
                     {item.equipment_name}
@@ -612,77 +614,99 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
                 ))}
               </select>
 
-              <div className="mt-2 flex flex-col gap-2">
-                {selectedEquipment.map((slot, index) => {
-                  const item = equipment.find(e => e.id === slot.equipment_id);
-                  if (!item) return null;
+              {/* Number weapon slots globally (in list order) so the same #N is shown both
+                  next to the weapon itself and in every accessory's "Attach to" dropdown,
+                  making the link visible without having to count duplicate weapon names. */}
+              {(() => {
+                const weaponIndexBySlotId = new Map<string, number>();
+                let weaponCounter = 0;
+                selectedEquipment.forEach(s => {
+                  const eq = equipment.find(e => e.id === s.equipment_id);
+                  if (eq && eq.equipment_type === 'weapon') {
+                    weaponCounter += 1;
+                    weaponIndexBySlotId.set(s.id, weaponCounter);
+                  }
+                });
 
-                  // Find available weapon slots that this item could be attached to
-                  const availableWeaponSlots = selectedEquipment
-                    .map((s, idx) => {
-                      const eq = equipment.find(e => e.id === s.equipment_id);
-                      return eq && eq.equipment_type === 'weapon' && s.id !== slot.id
-                        ? { slot: s, eq, weaponIndex: idx + 1 }
-                        : null;
-                    })
-                    .filter((w): w is { slot: typeof slot; eq: EquipmentWithId; weaponIndex: number } => w !== null);
+                return (
+                  <div className="mt-2 flex flex-col gap-2">
+                    {selectedEquipment.map((slot) => {
+                      const item = equipment.find(e => e.id === slot.equipment_id);
+                      if (!item) return null;
 
-                  const isWeaponAccessory = item.equipment_category?.toLowerCase() === 'weapon accessories';
+                      const weaponIndex = weaponIndexBySlotId.get(slot.id);
 
-                  return (
-                    <div 
-                      key={slot.id}
-                      className="flex flex-wrap items-center justify-between gap-2 bg-muted p-2 rounded-md text-sm"
-                    >
-                      <div className="flex items-center gap-2">
-                        <span className="font-medium">{item.equipment_name}</span>
-                        <span className="text-xs text-muted-foreground capitalize">({item.equipment_type.replace('_', ' ')})</span>
-                      </div>
+                      const availableWeaponSlots = selectedEquipment
+                        .filter(s => s.id !== slot.id && weaponIndexBySlotId.has(s.id))
+                        .map(s => ({
+                          slot: s,
+                          eq: equipment.find(e => e.id === s.equipment_id) as EquipmentWithId,
+                          weaponIndex: weaponIndexBySlotId.get(s.id)!
+                        }));
 
-                      <div className="flex items-center gap-2">
-                        {isWeaponAccessory && availableWeaponSlots.length > 0 && (
-                          <div className="flex items-center gap-1">
-                            <span className="text-xs text-muted-foreground">Attach to:</span>
-                            <select
-                              value={slot.target_fighter_default_id || ''}
-                              onChange={(e) => {
-                                const targetId = e.target.value || null;
-                                setSelectedEquipment(selectedEquipment.map(s => 
-                                  s.id === slot.id ? { ...s, target_fighter_default_id: targetId } : s
-                                ));
-                              }}
-                              className="text-xs p-1 border rounded bg-background text-foreground"
-                            >
-                              <option value="">(Unattached / Standalone)</option>
-                              {availableWeaponSlots.map(({ slot: wSlot, eq: wEq, weaponIndex }) => (
-                                <option key={wSlot.id} value={wSlot.id}>
-                                  {wEq.equipment_name} #{weaponIndex}
-                                </option>
-                              ))}
-                            </select>
-                          </div>
-                        )}
+                      const isWeaponAccessory = item.equipment_category?.toLowerCase() === 'weapon accessories';
 
-                        <button
-                          type="button"
-                          onClick={() => {
-                            // Remove item and clear any target references pointing to this item
-                            setSelectedEquipment(
-                              selectedEquipment
-                                .filter(s => s.id !== slot.id)
-                                .map(s => s.target_fighter_default_id === slot.id ? { ...s, target_fighter_default_id: null } : s)
-                            );
-                          }}
-                          className="hover:text-red-500 focus:outline-hidden p-1"
-                          title="Remove equipment"
+                      return (
+                        <div
+                          key={slot.id}
+                          className="flex flex-wrap items-center justify-between gap-2 bg-muted p-2 rounded-md text-sm"
                         >
-                          <HiX className="h-4 w-4" />
-                        </button>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium">
+                              {item.equipment_name}
+                              {weaponIndex !== undefined && (
+                                <span className="text-muted-foreground"> #{weaponIndex}</span>
+                              )}
+                            </span>
+                            <span className="text-xs text-muted-foreground capitalize">({item.equipment_type.replace('_', ' ')})</span>
+                          </div>
+
+                          <div className="flex items-center gap-2">
+                            {isWeaponAccessory && availableWeaponSlots.length > 0 && (
+                              <div className="flex items-center gap-1">
+                                <span className="text-xs text-muted-foreground">Attach to:</span>
+                                <select
+                                  value={slot.target_fighter_default_id || ''}
+                                  onChange={(e) => {
+                                    const targetId = e.target.value || null;
+                                    setSelectedEquipment(selectedEquipment.map(s =>
+                                      s.id === slot.id ? { ...s, target_fighter_default_id: targetId } : s
+                                    ));
+                                  }}
+                                  className="text-xs p-1 border rounded bg-background text-foreground"
+                                >
+                                  <option value="">(Unattached / Standalone)</option>
+                                  {availableWeaponSlots.map(({ slot: wSlot, eq: wEq, weaponIndex }) => (
+                                    <option key={wSlot.id} value={wSlot.id}>
+                                      {wEq.equipment_name} #{weaponIndex}
+                                    </option>
+                                  ))}
+                                </select>
+                              </div>
+                            )}
+
+                            <button
+                              type="button"
+                              onClick={() => {
+                                // Remove item and clear any target references pointing to this item
+                                setSelectedEquipment(
+                                  selectedEquipment
+                                    .filter(s => s.id !== slot.id)
+                                    .map(s => s.target_fighter_default_id === slot.id ? { ...s, target_fighter_default_id: null } : s)
+                                );
+                              }}
+                              className="hover:text-red-500 focus:outline-hidden p-1"
+                              title="Remove equipment"
+                            >
+                              <HiX className="h-4 w-4" />
+                            </button>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                );
+              })()}
             </div>
 
             <div>

--- a/components/admin/admin-edit-fighter-type.tsx
+++ b/components/admin/admin-edit-fighter-type.tsx
@@ -1925,86 +1925,109 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
                   disabled={!selectedFighterTypeId}
                 >
                   <option value="">Select equipment to add</option>
-                  {equipment
-                    .map((item) => (
-                      <option key={item.id} value={item.id}>
-                        {item.equipment_name}
-                      </option>
-                    ))}
+                  {/* Any equipment may be added more than once (e.g. two Stub Guns, or a
+                      Weapon Accessory attached to two different default weapons). */}
+                  {equipment.map((item) => (
+                    <option key={item.id} value={item.id}>
+                      {item.equipment_name}
+                    </option>
+                  ))}
                 </select>
 
-                <div className="mt-2 flex flex-col gap-2">
-                  {selectedEquipment.map((slot, index) => {
-                    const item = equipment.find(e => e.id === slot.equipment_id);
-                    if (!item) return null;
+                {/* Number weapon slots globally (in list order) so the same #N is shown both
+                    next to the weapon itself and in every accessory's "Attach to" dropdown,
+                    making the link visible without having to count duplicate weapon names. */}
+                {(() => {
+                  const weaponIndexBySlotId = new Map<string, number>();
+                  let weaponCounter = 0;
+                  selectedEquipment.forEach(s => {
+                    const eq = equipment.find(e => e.id === s.equipment_id);
+                    if (eq && eq.equipment_type === 'weapon') {
+                      weaponCounter += 1;
+                      weaponIndexBySlotId.set(s.id, weaponCounter);
+                    }
+                  });
 
-                    // Find available weapon slots that this item could be attached to
-                    const availableWeaponSlots = selectedEquipment
-                      .map((s, idx) => {
-                        const eq = equipment.find(e => e.id === s.equipment_id);
-                        return eq && eq.equipment_type === 'weapon' && s.id !== slot.id
-                          ? { slot: s, eq, weaponIndex: idx + 1 }
-                          : null;
-                      })
-                      .filter((w): w is { slot: typeof slot; eq: any; weaponIndex: number } => w !== null);
+                  return (
+                    <div className="mt-2 flex flex-col gap-2">
+                      {selectedEquipment.map((slot) => {
+                        const item = equipment.find(e => e.id === slot.equipment_id);
+                        if (!item) return null;
 
-                    const isWeaponAccessory = item.equipment_category?.toLowerCase() === 'weapon accessories';
+                        const weaponIndex = weaponIndexBySlotId.get(slot.id);
 
-                    return (
-                      <div
-                        key={slot.id}
-                        className="flex flex-wrap items-center justify-between gap-2 bg-muted p-2 rounded-md text-sm"
-                      >
-                        <div className="flex items-center gap-2">
-                          <span className="font-medium">{item.equipment_name}</span>
-                          <span className="text-xs text-muted-foreground capitalize">({item.equipment_type.replace('_', ' ')})</span>
-                        </div>
+                        const availableWeaponSlots = selectedEquipment
+                          .filter(s => s.id !== slot.id && weaponIndexBySlotId.has(s.id))
+                          .map(s => ({
+                            slot: s,
+                            eq: equipment.find(e => e.id === s.equipment_id) as any,
+                            weaponIndex: weaponIndexBySlotId.get(s.id)!
+                          }));
 
-                        <div className="flex items-center gap-2">
-                          {isWeaponAccessory && availableWeaponSlots.length > 0 && (
-                            <div className="flex items-center gap-1">
-                              <span className="text-xs text-muted-foreground">Attach to:</span>
-                              <select
-                                value={slot.target_fighter_default_id || ''}
-                                onChange={(e) => {
-                                  const targetId = e.target.value || null;
-                                  setSelectedEquipment(selectedEquipment.map(s => 
-                                    s.id === slot.id ? { ...s, target_fighter_default_id: targetId } : s
-                                  ));
-                                }}
-                                className="text-xs p-1 border rounded bg-background text-foreground"
-                                disabled={!selectedFighterTypeId}
-                              >
-                                <option value="">(Unattached / Standalone)</option>
-                                {availableWeaponSlots.map(({ slot: wSlot, eq: wEq, weaponIndex }) => (
-                                  <option key={wSlot.id} value={wSlot.id}>
-                                    {wEq.equipment_name} #{weaponIndex}
-                                  </option>
-                                ))}
-                              </select>
-                            </div>
-                          )}
+                        const isWeaponAccessory = item.equipment_category?.toLowerCase() === 'weapon accessories';
 
-                          <button
-                            type="button"
-                            onClick={() => {
-                              setSelectedEquipment(
-                                selectedEquipment
-                                  .filter(s => s.id !== slot.id)
-                                  .map(s => s.target_fighter_default_id === slot.id ? { ...s, target_fighter_default_id: null } : s)
-                              );
-                            }}
-                            className="hover:text-red-500 focus:outline-hidden p-1"
-                            disabled={!selectedFighterTypeId}
-                            title="Remove equipment"
+                        return (
+                          <div
+                            key={slot.id}
+                            className="flex flex-wrap items-center justify-between gap-2 bg-muted p-2 rounded-md text-sm"
                           >
-                            <HiX className="h-4 w-4" />
-                          </button>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
+                            <div className="flex items-center gap-2">
+                              <span className="font-medium">
+                                {item.equipment_name}
+                                {weaponIndex !== undefined && (
+                                  <span className="text-muted-foreground"> #{weaponIndex}</span>
+                                )}
+                              </span>
+                              <span className="text-xs text-muted-foreground capitalize">({item.equipment_type.replace('_', ' ')})</span>
+                            </div>
+
+                            <div className="flex items-center gap-2">
+                              {isWeaponAccessory && availableWeaponSlots.length > 0 && (
+                                <div className="flex items-center gap-1">
+                                  <span className="text-xs text-muted-foreground">Attach to:</span>
+                                  <select
+                                    value={slot.target_fighter_default_id || ''}
+                                    onChange={(e) => {
+                                      const targetId = e.target.value || null;
+                                      setSelectedEquipment(selectedEquipment.map(s =>
+                                        s.id === slot.id ? { ...s, target_fighter_default_id: targetId } : s
+                                      ));
+                                    }}
+                                    className="text-xs p-1 border rounded bg-background text-foreground"
+                                    disabled={!selectedFighterTypeId}
+                                  >
+                                    <option value="">(Unattached / Standalone)</option>
+                                    {availableWeaponSlots.map(({ slot: wSlot, eq: wEq, weaponIndex }) => (
+                                      <option key={wSlot.id} value={wSlot.id}>
+                                        {wEq.equipment_name} #{weaponIndex}
+                                      </option>
+                                    ))}
+                                  </select>
+                                </div>
+                              )}
+
+                              <button
+                                type="button"
+                                onClick={() => {
+                                  setSelectedEquipment(
+                                    selectedEquipment
+                                      .filter(s => s.id !== slot.id)
+                                      .map(s => s.target_fighter_default_id === slot.id ? { ...s, target_fighter_default_id: null } : s)
+                                  );
+                                }}
+                                className="hover:text-red-500 focus:outline-hidden p-1"
+                                disabled={!selectedFighterTypeId}
+                                title="Remove equipment"
+                              >
+                                <HiX className="h-4 w-4" />
+                              </button>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  );
+                })()}
               </div>
 
               <div className="mt-2">

--- a/components/admin/admin-edit-fighter-type.tsx
+++ b/components/admin/admin-edit-fighter-type.tsx
@@ -108,7 +108,11 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
   const [isSpyrer, setIsSpyrer] = useState(false);
   const [alignment, setAlignment] = useState<string>('');
   const [equipment, setEquipment] = useState<EquipmentWithId[]>([]);
-  const [selectedEquipment, setSelectedEquipment] = useState<string[]>([]);
+  const [selectedEquipment, setSelectedEquipment] = useState<{
+    id: string;
+    equipment_id: string;
+    target_fighter_default_id?: string | null;
+  }[]>([]);
   const [gangTypeFilter, setGangTypeFilter] = useState('');
   const [skills, setSkills] = useState<Skill[]>([]);
   const [selectedSkillType, setSelectedSkillType] = useState('');
@@ -480,7 +484,17 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
       setIsDramatisPersonae(!!data.is_dramatis_personae);
       setIsSpyrer(!!data.is_spyrer);
       setAlignment(data.alignment || '');
-      setSelectedEquipment(data.default_equipment || []);
+      const normalizedDefaults = (data.default_equipment || []).map((item: any) => {
+        if (typeof item === 'string') {
+          return { id: crypto.randomUUID(), equipment_id: item, target_fighter_default_id: null };
+        }
+        return {
+          id: item.id || crypto.randomUUID(),
+          equipment_id: item.equipment_id,
+          target_fighter_default_id: item.target_fighter_default_id || null
+        };
+      });
+      setSelectedEquipment(normalizedDefaults);
       setSelectedSkills(data.default_skills || []);
       // Reset fetched skills tracking when loading a new fighter type
       fetchedSkillDetailsRef.current.clear();
@@ -1900,7 +1914,10 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
                   onChange={(e) => {
                     const value = e.target.value;
                     if (value) {
-                      setSelectedEquipment([...selectedEquipment, value]);
+                      setSelectedEquipment([
+                        ...selectedEquipment,
+                        { id: crypto.randomUUID(), equipment_id: value, target_fighter_default_id: null }
+                      ]);
                     }
                     e.target.value = "";
                   }}
@@ -1916,27 +1933,74 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
                     ))}
                 </select>
 
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {selectedEquipment.map((equipId, index) => {
-                    const item = equipment.find(e => e.id === equipId);
+                <div className="mt-2 flex flex-col gap-2">
+                  {selectedEquipment.map((slot, index) => {
+                    const item = equipment.find(e => e.id === slot.equipment_id);
                     if (!item) return null;
+
+                    // Find available weapon slots that this item could be attached to
+                    const availableWeaponSlots = selectedEquipment
+                      .map((s, idx) => {
+                        const eq = equipment.find(e => e.id === s.equipment_id);
+                        return eq && eq.equipment_type === 'weapon' && s.id !== slot.id
+                          ? { slot: s, eq, weaponIndex: idx + 1 }
+                          : null;
+                      })
+                      .filter((w): w is { slot: typeof slot; eq: any; weaponIndex: number } => w !== null);
+
+                    const isWeaponAccessory = item.equipment_category?.toLowerCase() === 'weapon accessories';
 
                     return (
                       <div
-                        key={`${item.id}-${index}`}
-                        className={`flex items-center gap-1 px-2 py-1 rounded-full text-sm ${
-                          selectedFighterTypeId ? 'bg-muted' : 'bg-muted'
-                        }`}
+                        key={slot.id}
+                        className="flex flex-wrap items-center justify-between gap-2 bg-muted p-2 rounded-md text-sm"
                       >
-                        <span>{item.equipment_name}</span>
-                        <button
-                          type="button"
-                          onClick={() => setSelectedEquipment(selectedEquipment.filter((_, i) => i !== index))}
-                          className="hover:text-red-500 focus:outline-hidden"
-                          disabled={!selectedFighterTypeId}
-                        >
-                          <HiX className="h-4 w-4" />
-                        </button>
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium">{item.equipment_name}</span>
+                          <span className="text-xs text-muted-foreground capitalize">({item.equipment_type.replace('_', ' ')})</span>
+                        </div>
+
+                        <div className="flex items-center gap-2">
+                          {isWeaponAccessory && availableWeaponSlots.length > 0 && (
+                            <div className="flex items-center gap-1">
+                              <span className="text-xs text-muted-foreground">Attach to:</span>
+                              <select
+                                value={slot.target_fighter_default_id || ''}
+                                onChange={(e) => {
+                                  const targetId = e.target.value || null;
+                                  setSelectedEquipment(selectedEquipment.map(s => 
+                                    s.id === slot.id ? { ...s, target_fighter_default_id: targetId } : s
+                                  ));
+                                }}
+                                className="text-xs p-1 border rounded bg-background text-foreground"
+                                disabled={!selectedFighterTypeId}
+                              >
+                                <option value="">(Unattached / Standalone)</option>
+                                {availableWeaponSlots.map(({ slot: wSlot, eq: wEq, weaponIndex }) => (
+                                  <option key={wSlot.id} value={wSlot.id}>
+                                    {wEq.equipment_name} #{weaponIndex}
+                                  </option>
+                                ))}
+                              </select>
+                            </div>
+                          )}
+
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setSelectedEquipment(
+                                selectedEquipment
+                                  .filter(s => s.id !== slot.id)
+                                  .map(s => s.target_fighter_default_id === slot.id ? { ...s, target_fighter_default_id: null } : s)
+                              );
+                            }}
+                            className="hover:text-red-500 focus:outline-hidden p-1"
+                            disabled={!selectedFighterTypeId}
+                            title="Remove equipment"
+                          >
+                            <HiX className="h-4 w-4" />
+                          </button>
+                        </div>
                       </div>
                     );
                   })}

--- a/components/gang/fighter-add/FighterAddModal.tsx
+++ b/components/gang/fighter-add/FighterAddModal.tsx
@@ -291,7 +291,7 @@ export default function FighterAddModal({
       .filter((item: any) => item.equipment_type === 'weapon')
       .map((item: any) => {
         const attachedAccessories = defaultEquipment.filter(
-          (eq: any) => eq.target_fighter_default_id === item.id
+          (eq: any) => eq.target_fighter_default_id === item.default_id
         );
         const effectNames = attachedAccessories.map((eq: any) => eq.equipment_name);
         return {

--- a/components/gang/fighter-add/FighterAddModal.tsx
+++ b/components/gang/fighter-add/FighterAddModal.tsx
@@ -289,18 +289,25 @@ export default function FighterAddModal({
     const defaultEquipment = selectedType?.default_equipment || [];
     const optimisticWeapons = defaultEquipment
       .filter((item: any) => item.equipment_type === 'weapon')
-      .map((item: any) => ({
-        fighter_weapon_id: `temp-${item.id}`,
-        weapon_id: item.id,
-        weapon_name: item.equipment_name,
-        cost: item.cost || 0,
-        weapon_profiles: [],
-      }));
+      .map((item: any) => {
+        const attachedAccessories = defaultEquipment.filter(
+          (eq: any) => eq.target_fighter_default_id === item.id
+        );
+        const effectNames = attachedAccessories.map((eq: any) => eq.equipment_name);
+        return {
+          fighter_weapon_id: `temp-${item.id}`,
+          weapon_id: item.equipment_id || item.id,
+          weapon_name: item.equipment_name,
+          cost: item.cost || 0,
+          weapon_profiles: [],
+          effect_names: effectNames.length > 0 ? effectNames : undefined,
+        };
+      });
     const optimisticWargear = defaultEquipment
       .filter((item: any) => item.equipment_type === 'wargear')
       .map((item: any) => ({
         fighter_weapon_id: `temp-${item.id}`,
-        wargear_id: item.id,
+        wargear_id: item.equipment_id || item.id,
         wargear_name: item.equipment_name,
         cost: item.cost || 0,
       }));

--- a/supabase/functions/get_fighter_types_with_cost.sql
+++ b/supabase/functions/get_fighter_types_with_cost.sql
@@ -78,6 +78,8 @@ BEGIN
             SELECT COALESCE(jsonb_agg(
                 jsonb_build_object(
                     'id', e.id,
+                    'default_id', fd.id,
+                    'target_fighter_default_id', fd.target_fighter_default_id,
                     'equipment_name', e.equipment_name,
                     'equipment_type', e.equipment_type,
                     'equipment_category', e.equipment_category,

--- a/supabase/migrations/20260724215000_add_target_fighter_default_id.sql
+++ b/supabase/migrations/20260724215000_add_target_fighter_default_id.sql
@@ -1,0 +1,8 @@
+-- Adds target_fighter_default_id to fighter_defaults to support linking
+-- default wargear / weapon extensions (e.g. Infra sight) to specific default weapons.
+
+ALTER TABLE public.fighter_defaults 
+    ADD COLUMN IF NOT EXISTS target_fighter_default_id uuid REFERENCES public.fighter_defaults(id) ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS fighter_defaults_target_fighter_default_id_idx 
+    ON public.fighter_defaults (target_fighter_default_id);

--- a/supabase/schema/schema.public.sql
+++ b/supabase/schema/schema.public.sql
@@ -2624,6 +2624,8 @@ BEGIN
             SELECT COALESCE(jsonb_agg(
                 jsonb_build_object(
                     'id', e.id,
+                    'default_id', fd.id,
+                    'target_fighter_default_id', fd.target_fighter_default_id,
                     'equipment_name', e.equipment_name,
                     'equipment_type', e.equipment_type,
                     'equipment_category', e.equipment_category,
@@ -5332,7 +5334,8 @@ CREATE TABLE public.fighter_defaults (
     skill_id uuid,
     updated_at timestamp with time zone,
     custom_fighter_type_id uuid,
-    custom_equipment_id uuid
+    custom_equipment_id uuid,
+    target_fighter_default_id uuid
 );
 
 

--- a/utils/fighter-builder.ts
+++ b/utils/fighter-builder.ts
@@ -96,6 +96,7 @@ export interface AddFighterServerData {
     equipment_type: string;
     cost: number;
     weapon_profiles?: any[];
+    effect_names?: string[];
   }>;
   skills: Array<{
     skill_id: string;
@@ -168,7 +169,8 @@ export function buildWeaponsFromEquipment(equipment: AddFighterServerData['equip
       weapon_id: item.equipment_id,
       cost: item.cost,
       fighter_weapon_id: item.fighter_equipment_id,
-      weapon_profiles: item.weapon_profiles || []
+      weapon_profiles: item.weapon_profiles || [],
+      effect_names: item.effect_names
     }));
 }
 


### PR DESCRIPTION
## 📌 Context & Motivation

Predefined template fighter types (such as Bounty Hunters) configured in the Admin panel previously had weapon accessories (e.g., Infra-sight) rendered only as standalone wargear items, with no link to their parent weapon.

This PR enables linking default accessories directly to target weapons during template creation, ensuring that hired fighters automatically have their accessories attached to the correct weapon—matching the behavior and display of standard gangers.

---

## 🏗️ Architectural Rationale

- **Self-referencing FK on `fighter_defaults`**: added `target_fighter_default_id` referencing `fighter_defaults(id)`. Keeps template relationships normalized without extra join tables.
- **Runtime conversion via `fighter_effects`**: during fighter hiring (`add-fighter.ts`), the template link resolves to the newly-inserted `fighter_equipment` rows and is recorded as a `fighter_effects` record with `target_equipment_id` — the same mechanism the existing "attach accessory to weapon" purchase flow already uses, so the read-side card rendering (gang overview, fighter page) needed no new logic. Each `fighter_equipment` row is inserted with a client-generated id specifically so this resolution doesn't depend on Supabase/PostgREST returning bulk-insert rows in submission order.
- **Immediate hire-time display**: the fighter-creation response and the hiring modal's optimistic preview both needed to be taught to surface the same attachment (as `effect_names` on the weapon), so the link is visible right away instead of only after a page reload.
- **Preserving dual-display rules**: accessories remain listed under Wargear while also displaying as a modifier on the parent weapon row (in both the live card and the hiring modal preview) — this is intentional, not a duplicate.

---

## 🛠️ Summary of Changes

- **Database & Admin**
  Added `target_fighter_default_id` migration (`20260724215000_add_target_fighter_default_id.sql`) and exposed it from `get_fighter_types_with_cost`. Create/Edit Fighter Type now has a per-slot "Attach to" selector for Weapon Accessories, and default equipment (of any type) can be added multiple times — e.g. two Stub Guns, or the same accessory attached to two different weapons — with each duplicate weapon numbered in the list so admins can tell which one an accessory targets without counting.

- **Fighter Hiring Action** (`app/actions/add-fighter.ts`)
  Resolves each default accessory's target link to the newly-created weapon's `fighter_equipment` row and records it via `fighter_effects` (through the existing fixed-effect path, or a direct insert for accessories with no registered effect type). The fighter-creation response now carries the resulting attachment (`effect_names`) on the target weapon so it renders correctly without a reload. Also fixes two correctness issues found while building this: equipment `is_editable` was being hardcoded to `false` in the response instead of reflecting the real value, and a stale interface field that didn't match the underlying query.

- **Hire Preview Card** (`components/gang/fighter-add/FighterAddModal.tsx`, `utils/fighter-builder.ts`)
  The pre-hire optimistic preview now matches accessories to weapons using the real `fighter_defaults` id, and the server response is threaded through so the confirmed card matches the preview.

---

## 🧪 Testing Instructions for QA

### Regression checks
- [ ] Hire a fighter type with no linked default equipment at all — fighters still create normally, no attachment artifacts.
- [ ] On an already-existing fighter, buy a Weapon Accessory through the normal purchase flow and attach it to a weapon — that path (unrelated to this PR, but touching shared display code) still works as before.
- [ ] Hire a fighter type whose default equipment includes an item that should be user-editable after creation (e.g. anything with a text/rules-editable slot) — it shows as editable immediately, not just after a reload.