### PR TITLE
Restore is_editable on equipment-selection items in get_fighter_types_with_cost

### DIFF
--- a/supabase/functions/get_fighter_types_with_cost.sql
+++ b/supabase/functions/get_fighter_types_with_cost.sql
@@ -113,6 +113,7 @@ BEGIN
                                                             'cost', (item_data->>'cost')::numeric,
                                                             'quantity', (item_data->>'quantity')::integer,
                                                             'is_default', (item_data->>'is_default')::boolean,
+                                                            'is_editable', COALESCE(e.is_editable, false),
                                                             'replacement_mode', item_data->>'replacement_mode',
                                                             'replacements', COALESCE(
                                                                 (
@@ -123,7 +124,8 @@ BEGIN
                                                                             'equipment_type', re.equipment_type,
                                                                             'equipment_category', re.equipment_category,
                                                                             'cost', (repl->>'cost')::numeric,
-                                                                            'max_quantity', (repl->>'max_quantity')::integer
+                                                                            'max_quantity', (repl->>'max_quantity')::integer,
+                                                                            'is_editable', COALESCE(re.is_editable, false)
                                                                         )
                                                                     )
                                                                     FROM jsonb_array_elements(item_data->'replacements') AS repl
@@ -153,6 +155,7 @@ BEGIN
                                                         'cost', (item_data->>'cost')::numeric,
                                                         'quantity', (item_data->>'quantity')::integer,
                                                         'is_default', (item_data->>'is_default')::boolean,
+                                                        'is_editable', COALESCE(e.is_editable, false),
                                                         'replacement_mode', item_data->>'replacement_mode',
                                                         'replacements', COALESCE(
                                                             (
@@ -163,7 +166,8 @@ BEGIN
                                                                         'equipment_type', re.equipment_type,
                                                                         'equipment_category', re.equipment_category,
                                                                         'cost', (repl->>'cost')::numeric,
-                                                                        'max_quantity', (repl->>'max_quantity')::integer
+                                                                        'max_quantity', (repl->>'max_quantity')::integer,
+                                                                        'is_editable', COALESCE(re.is_editable, false)
                                                                     )
                                                                 )
                                                                 FROM jsonb_array_elements(item_data->'replacements') AS repl
@@ -200,6 +204,7 @@ BEGIN
                                                             'cost', (item_data->>'cost')::numeric,
                                                             'quantity', (item_data->>'quantity')::integer,
                                                             'is_default', (item_data->>'is_default')::boolean,
+                                                            'is_editable', COALESCE(e.is_editable, false),
                                                             'replacement_mode', item_data->>'replacement_mode',
                                                             'replacements', COALESCE(
                                                                 (
@@ -210,7 +215,8 @@ BEGIN
                                                                             'equipment_type', re.equipment_type,
                                                                             'equipment_category', re.equipment_category,
                                                                             'cost', (repl->>'cost')::numeric,
-                                                                            'max_quantity', (repl->>'max_quantity')::integer
+                                                                            'max_quantity', (repl->>'max_quantity')::integer,
+                                                                            'is_editable', COALESCE(re.is_editable, false)
                                                                         )
                                                                     )
                                                                     FROM jsonb_array_elements(item_data->'replacements') AS repl
@@ -240,6 +246,7 @@ BEGIN
                                                         'cost', (item_data->>'cost')::numeric,
                                                         'quantity', (item_data->>'quantity')::integer,
                                                         'is_default', (item_data->>'is_default')::boolean,
+                                                        'is_editable', COALESCE(e.is_editable, false),
                                                         'replacement_mode', item_data->>'replacement_mode',
                                                         'replacements', COALESCE(
                                                             (
@@ -250,7 +257,8 @@ BEGIN
                                                                         'equipment_type', re.equipment_type,
                                                                         'equipment_category', re.equipment_category,
                                                                         'cost', (repl->>'cost')::numeric,
-                                                                        'max_quantity', (repl->>'max_quantity')::integer
+                                                                        'max_quantity', (repl->>'max_quantity')::integer,
+                                                                        'is_editable', COALESCE(re.is_editable, false)
                                                                     )
                                                                 )
                                                                 FROM jsonb_array_elements(item_data->'replacements') AS repl
@@ -289,6 +297,7 @@ BEGIN
                                                             'cost', (item_data->>'cost')::numeric,
                                                             'quantity', (item_data->>'quantity')::integer,
                                                             'is_default', (item_data->>'is_default')::boolean,
+                                                            'is_editable', COALESCE(e.is_editable, false),
                                                             'replacement_mode', item_data->>'replacement_mode',
                                                             'replacements', COALESCE(
                                                                 (
@@ -299,7 +308,8 @@ BEGIN
                                                                             'equipment_type', re.equipment_type,
                                                                             'equipment_category', re.equipment_category,
                                                                             'cost', (repl->>'cost')::numeric,
-                                                                            'max_quantity', (repl->>'max_quantity')::integer
+                                                                            'max_quantity', (repl->>'max_quantity')::integer,
+                                                                            'is_editable', COALESCE(re.is_editable, false)
                                                                         )
                                                                     )
                                                                     FROM jsonb_array_elements(item_data->'replacements') AS repl
@@ -329,6 +339,7 @@ BEGIN
                                                         'cost', (item_data->>'cost')::numeric,
                                                         'quantity', (item_data->>'quantity')::integer,
                                                         'is_default', (item_data->>'is_default')::boolean,
+                                                        'is_editable', COALESCE(e.is_editable, false),
                                                         'replacement_mode', item_data->>'replacement_mode',
                                                         'replacements', COALESCE(
                                                             (
@@ -339,7 +350,8 @@ BEGIN
                                                                         'equipment_type', re.equipment_type,
                                                                         'equipment_category', re.equipment_category,
                                                                         'cost', (repl->>'cost')::numeric,
-                                                                        'max_quantity', (repl->>'max_quantity')::integer
+                                                                        'max_quantity', (repl->>'max_quantity')::integer,
+                                                                        'is_editable', COALESCE(re.is_editable, false)
                                                                     )
                                                                 )
                                                                 FROM jsonb_array_elements(item_data->'replacements') AS repl
@@ -376,6 +388,7 @@ BEGIN
                                                             'cost', (item_data->>'cost')::numeric,
                                                             'quantity', (item_data->>'quantity')::integer,
                                                             'is_default', (item_data->>'is_default')::boolean,
+                                                            'is_editable', COALESCE(e.is_editable, false),
                                                             'replacement_mode', item_data->>'replacement_mode',
                                                             'replacements', COALESCE(
                                                                 (
@@ -386,7 +399,8 @@ BEGIN
                                                                             'equipment_type', re.equipment_type,
                                                                             'equipment_category', re.equipment_category,
                                                                             'cost', (repl->>'cost')::numeric,
-                                                                            'max_quantity', (repl->>'max_quantity')::integer
+                                                                            'max_quantity', (repl->>'max_quantity')::integer,
+                                                                            'is_editable', COALESCE(re.is_editable, false)
                                                                         )
                                                                     )
                                                                     FROM jsonb_array_elements(item_data->'replacements') AS repl
@@ -416,6 +430,7 @@ BEGIN
                                                         'cost', (item_data->>'cost')::numeric,
                                                         'quantity', (item_data->>'quantity')::integer,
                                                         'is_default', (item_data->>'is_default')::boolean,
+                                                        'is_editable', COALESCE(e.is_editable, false),
                                                         'replacement_mode', item_data->>'replacement_mode',
                                                         'replacements', COALESCE(
                                                             (
@@ -426,7 +441,8 @@ BEGIN
                                                                         'equipment_type', re.equipment_type,
                                                                         'equipment_category', re.equipment_category,
                                                                         'cost', (repl->>'cost')::numeric,
-                                                                        'max_quantity', (repl->>'max_quantity')::integer
+                                                                        'max_quantity', (repl->>'max_quantity')::integer,
+                                                                        'is_editable', COALESCE(re.is_editable, false)
                                                                     )
                                                                 )
                                                                 FROM jsonb_array_elements(item_data->'replacements') AS repl
@@ -465,6 +481,7 @@ BEGIN
                                                             'cost', (item_data->>'cost')::numeric,
                                                             'quantity', (item_data->>'quantity')::integer,
                                                             'is_default', (item_data->>'is_default')::boolean,
+                                                            'is_editable', COALESCE(e.is_editable, false),
                                                             'replacement_mode', item_data->>'replacement_mode',
                                                             'replacements', COALESCE(
                                                                 (
@@ -475,7 +492,8 @@ BEGIN
                                                                             'equipment_type', re.equipment_type,
                                                                             'equipment_category', re.equipment_category,
                                                                             'cost', (repl->>'cost')::numeric,
-                                                                            'max_quantity', (repl->>'max_quantity')::integer
+                                                                            'max_quantity', (repl->>'max_quantity')::integer,
+                                                                            'is_editable', COALESCE(re.is_editable, false)
                                                                         )
                                                                     )
                                                                     FROM jsonb_array_elements(item_data->'replacements') AS repl
@@ -505,6 +523,7 @@ BEGIN
                                                         'cost', (item_data->>'cost')::numeric,
                                                         'quantity', (item_data->>'quantity')::integer,
                                                         'is_default', (item_data->>'is_default')::boolean,
+                                                        'is_editable', COALESCE(e.is_editable, false),
                                                         'replacement_mode', item_data->>'replacement_mode',
                                                         'replacements', COALESCE(
                                                             (
@@ -515,7 +534,8 @@ BEGIN
                                                                         'equipment_type', re.equipment_type,
                                                                         'equipment_category', re.equipment_category,
                                                                         'cost', (repl->>'cost')::numeric,
-                                                                        'max_quantity', (repl->>'max_quantity')::integer
+                                                                        'max_quantity', (repl->>'max_quantity')::integer,
+                                                                        'is_editable', COALESCE(re.is_editable, false)
                                                                     )
                                                                 )
                                                                 FROM jsonb_array_elements(item_data->'replacements') AS repl
@@ -552,6 +572,7 @@ BEGIN
                                                             'cost', (item_data->>'cost')::numeric,
                                                             'quantity', (item_data->>'quantity')::integer,
                                                             'is_default', (item_data->>'is_default')::boolean,
+                                                            'is_editable', COALESCE(e.is_editable, false),
                                                             'replacement_mode', item_data->>'replacement_mode',
                                                             'replacements', COALESCE(
                                                                 (
@@ -562,7 +583,8 @@ BEGIN
                                                                             'equipment_type', re.equipment_type,
                                                                             'equipment_category', re.equipment_category,
                                                                             'cost', (repl->>'cost')::numeric,
-                                                                            'max_quantity', (repl->>'max_quantity')::integer
+                                                                            'max_quantity', (repl->>'max_quantity')::integer,
+                                                                            'is_editable', COALESCE(re.is_editable, false)
                                                                         )
                                                                     )
                                                                     FROM jsonb_array_elements(item_data->'replacements') AS repl
@@ -592,6 +614,7 @@ BEGIN
                                                         'cost', (item_data->>'cost')::numeric,
                                                         'quantity', (item_data->>'quantity')::integer,
                                                         'is_default', (item_data->>'is_default')::boolean,
+                                                        'is_editable', COALESCE(e.is_editable, false),
                                                         'replacement_mode', item_data->>'replacement_mode',
                                                         'replacements', COALESCE(
                                                             (
@@ -602,7 +625,8 @@ BEGIN
                                                                         'equipment_type', re.equipment_type,
                                                                         'equipment_category', re.equipment_category,
                                                                         'cost', (repl->>'cost')::numeric,
-                                                                        'max_quantity', (repl->>'max_quantity')::integer
+                                                                        'max_quantity', (repl->>'max_quantity')::integer,
+                                                                        'is_editable', COALESCE(re.is_editable, false)
                                                                     )
                                                                 )
                                                                 FROM jsonb_array_elements(item_data->'replacements') AS repl
@@ -641,6 +665,7 @@ BEGIN
                                                             'cost', (item_data->>'cost')::numeric,
                                                             'quantity', (item_data->>'quantity')::integer,
                                                             'is_default', (item_data->>'is_default')::boolean,
+                                                            'is_editable', COALESCE(e.is_editable, false),
                                                             'replacement_mode', item_data->>'replacement_mode',
                                                             'replacements', COALESCE(
                                                                 (
@@ -651,7 +676,8 @@ BEGIN
                                                                             'equipment_type', re.equipment_type,
                                                                             'equipment_category', re.equipment_category,
                                                                             'cost', (repl->>'cost')::numeric,
-                                                                            'max_quantity', (repl->>'max_quantity')::integer
+                                                                            'max_quantity', (repl->>'max_quantity')::integer,
+                                                                            'is_editable', COALESCE(re.is_editable, false)
                                                                         )
                                                                     )
                                                                     FROM jsonb_array_elements(item_data->'replacements') AS repl
@@ -681,6 +707,7 @@ BEGIN
                                                         'cost', (item_data->>'cost')::numeric,
                                                         'quantity', (item_data->>'quantity')::integer,
                                                         'is_default', (item_data->>'is_default')::boolean,
+                                                        'is_editable', COALESCE(e.is_editable, false),
                                                         'replacement_mode', item_data->>'replacement_mode',
                                                         'replacements', COALESCE(
                                                             (
@@ -691,7 +718,8 @@ BEGIN
                                                                         'equipment_type', re.equipment_type,
                                                                         'equipment_category', re.equipment_category,
                                                                         'cost', (repl->>'cost')::numeric,
-                                                                        'max_quantity', (repl->>'max_quantity')::integer
+                                                                        'max_quantity', (repl->>'max_quantity')::integer,
+                                                                        'is_editable', COALESCE(re.is_editable, false)
                                                                     )
                                                                 )
                                                                 FROM jsonb_array_elements(item_data->'replacements') AS repl
@@ -728,6 +756,7 @@ BEGIN
                                                             'cost', (item_data->>'cost')::numeric,
                                                             'quantity', (item_data->>'quantity')::integer,
                                                             'is_default', (item_data->>'is_default')::boolean,
+                                                            'is_editable', COALESCE(e.is_editable, false),
                                                             'replacement_mode', item_data->>'replacement_mode',
                                                             'replacements', COALESCE(
                                                                 (
@@ -738,7 +767,8 @@ BEGIN
                                                                             'equipment_type', re.equipment_type,
                                                                             'equipment_category', re.equipment_category,
                                                                             'cost', (repl->>'cost')::numeric,
-                                                                            'max_quantity', (repl->>'max_quantity')::integer
+                                                                            'max_quantity', (repl->>'max_quantity')::integer,
+                                                                            'is_editable', COALESCE(re.is_editable, false)
                                                                         )
                                                                     )
                                                                     FROM jsonb_array_elements(item_data->'replacements') AS repl
@@ -768,6 +798,7 @@ BEGIN
                                                         'cost', (item_data->>'cost')::numeric,
                                                         'quantity', (item_data->>'quantity')::integer,
                                                         'is_default', (item_data->>'is_default')::boolean,
+                                                        'is_editable', COALESCE(e.is_editable, false),
                                                         'replacement_mode', item_data->>'replacement_mode',
                                                         'replacements', COALESCE(
                                                             (
@@ -778,7 +809,8 @@ BEGIN
                                                                         'equipment_type', re.equipment_type,
                                                                         'equipment_category', re.equipment_category,
                                                                         'cost', (repl->>'cost')::numeric,
-                                                                        'max_quantity', (repl->>'max_quantity')::integer
+                                                                        'max_quantity', (repl->>'max_quantity')::integer,
+                                                                        'is_editable', COALESCE(re.is_editable, false)
                                                                     )
                                                                 )
                                                                 FROM jsonb_array_elements(item_data->'replacements') AS repl


### PR DESCRIPTION
> **The RPC is already applied to production.** Merging this syncs the repo with the live
> function; it is not the step that ships the fix. Until it lands, `main` still carries the old
> SQL, so re-applying the function from `main` would reintroduce the bug.

## Problem

Adding a new Spyrer produced equipment without the editable flag, so the pencil "Edit Equipment"
button never rendered and the Tier 1/2/3 upgrade could not be chosen.

## Root cause

#1866 deleted `get_add_fighter_details` and repointed the Add Fighter modal at
`get_fighter_types_with_cost` (`app/api/fighter-types/route.ts`). The old RPC stamped
`is_editable` onto every equipment-selection option **and** every replacement; the new one emits
it only inside `default_equipment`.

```
get_fighter_types_with_cost → equipment_selection options carry no is_editable
  → utils/equipment-selection.ts        is_editable: item.is_editable || false  → false
  → components/gang/fighter-add/EquipmentSelection.tsx  → payload is_editable: false
  → app/actions/add-fighter.ts:650,671  → fighter_equipment.is_editable = false
  → components/fighter/fighter-equipment-list.tsx:698  {item.is_editable && <Button …>}  → nothing
```

It looked Spyrer-specific because hunting rigs come from `fighter_defaults` (unaffected), while
the tiered weapons come from selection groups. Fighter-creation inserts, split at the merge time:

| Equipment source | Since #1866 |
| --- | --- |
| `fighter_defaults` — hunting rigs, Sthenian claw | `is_editable` true: 84, 63, 40, 80, 38 — fine |
| `equipment_selection` — Bolt launcher, Orrus talons/fists, Naga blade, Yeld gauntlets | **true: 0 for every item** |

Bolt launcher: 2,337 correct / 80 wrong before → **0 correct / 126 wrong** after.

The equipment data itself was never wrong: all 27 `Spyrer Equipment` rows have
`equipment.is_editable = true` with their Tier effect types intact.

## Change

One file. `is_editable` added to all 16 `equipment_selection` item objects and their 16
replacement objects. Every block already joins the equipment table (`equipment e` for items,
`equipment re` for replacements), so this is purely additive — no join or CTE changes.

```sql
'is_default', (item_data->>'is_default')::boolean,
'is_editable', COALESCE(e.is_editable, false),        -- item objects (x16)

'max_quantity', (repl->>'max_quantity')::integer,
'is_editable', COALESCE(re.is_editable, false)        -- replacement objects (x16)
```

No TypeScript changes needed — `types/fighter-type.ts` already declares `is_editable?: boolean` on
`EquipmentOption` and `DefaultEquipment`, and `utils/equipment-selection.ts` already forwards it.

## Verification

Applied to the database guarded on the pre-patch body checksum and self-verified against the
post-patch checksum, inside a transaction set to roll back on either mismatch. The deployed body
was confirmed byte-identical to the pre-change file beforehand, so no out-of-band change was
clobbered; it now matches this branch byte-for-byte.

- *Orrus power talons* and its *Orrus power fists* replacement emit `"is_editable": true`.
- Across **every** fighter type: 184 selection options checked, **0** missing the flag and
  **0** mismatches against `equipment.is_editable`.
- The 29 now-editable options belong to exactly 9 fighter types, all Spyrers. No non-Spyrer
  equipment changed.
- Grants preserved (`authenticated`, `service_role`; `anon` still revoked).

UI click-through was not run — the review environment has no `.env.local`, so the app cannot
reach Supabase. Worth confirming by adding an Orrus Spyre Hunter and checking the pencil button
on the talons, including after swapping to power fists.

## Out of scope

- **No backfill.** ~7,041 existing `fighter_equipment` rows across 5,461 fighters still have
  `is_editable = false` where the linked equipment is editable; existing Spyrers keep the missing
  button.
- **Granted equipment** — `add-fighter.ts:1029-1037` omits `is_editable` and `:1091` hard-codes
  `false`. Same gap, separate path, untouched here.
- `custom_equipment.is_editable` is never set by the customise UI. Untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_018M6xE4m6SYmXsJwWiJwhnp)_