### PR TITLE
Copy is_editable onto granted equipment rows

### DIFF
--- a/app/actions/add-fighter.ts
+++ b/app/actions/add-fighter.ts
@@ -1011,7 +1011,7 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
                     // Fetch granted equipment details
                     const { data: grantedEquipmentDetails } = await supabase
                       .from('equipment')
-                      .select('id, equipment_name, cost')
+                      .select('id, equipment_name, cost, is_editable')
                       .in('id', allGrantedEquipmentIds);
 
                     if (grantedEquipmentDetails && grantedEquipmentDetails.length > 0) {
@@ -1033,7 +1033,8 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
                               purchase_cost: parentInfo.additionalCost,
                               granted_by_equipment_id: parentFighterEquip.id,
                               gang_id: params.gang_id,
-                              user_id: gangData.user_id
+                              user_id: gangData.user_id,
+                              is_editable: grantedEquip.is_editable || false
                             });
                           }
                         }
@@ -1048,6 +1049,7 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
                             equipment_id,
                             original_cost,
                             purchase_cost,
+                            is_editable,
                             equipment!equipment_id(
                               id,
                               equipment_name,
@@ -1088,7 +1090,7 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
                               equipment_category: 'unknown',
                               cost: item.purchase_cost,
                               weapon_profiles: itemWeaponProfiles,
-                              is_editable: false
+                              is_editable: item.is_editable || false
                             };
                           });
 

--- a/app/actions/equipment.ts
+++ b/app/actions/equipment.ts
@@ -533,7 +533,7 @@ export async function buyEquipmentForFighter(params: BuyEquipmentParams): Promis
         for (const option of optionsToGrant) {
           const { data: grantedEquip } = await supabase
             .from('equipment')
-            .select('id, equipment_name, cost')
+            .select('id, equipment_name, cost, is_editable')
             .eq('id', option.equipment_id)
             .single();
 
@@ -548,7 +548,8 @@ export async function buyEquipmentForFighter(params: BuyEquipmentParams): Promis
                 original_cost: grantedEquip.cost,
                 purchase_cost: option.additional_cost,
                 granted_by_equipment_id: newEquipmentId,
-                user_id: gang.user_id
+                user_id: gang.user_id,
+                is_editable: grantedEquip.is_editable || false
               });
 
             // Add to rating delta for granted equipment (fighters and assigned vehicles)


### PR DESCRIPTION
## Problem

`fighter_equipment.is_editable` is a denormalised copy of `equipment.is_editable`, set at insert
time. Neither `grants_equipment` insert path ever set it, so granted equipment always landed
non-editable and never showed the "Edit Equipment" button.

Concretely: **Web incisors**, granted by *Malcadon slashing claw* and *Malcadon toxin whip*, could
never have its tier chosen. **458 of 458** granted rows are non-editable.

## This is not a regression from #1866 / #1904

Worth stating clearly, since it surfaces on the same Spyrer gear as those:

- `app/actions/add-fighter.ts` **is not in #1866's diff at all** (the similarly-named file there was
  `components/gang/add-fighter.tsx`, the deleted client component).
- `is_editable` has **never** appeared in the granted-insert block in any revision of the file.
- Both write sites date from `e518e652` (2025-12-31), *"Added support so that equipment can add
  equipment when purchased"*.

Web incisors rows by creation path confirm it:

| Source | Before #1866 | After #1866 |
| --- | --- | --- |
| **Granted** (`grants_equipment`) | 0 true / **408 false** | 0 true / **50 false** |
| Not granted (selection / purchase) | 441 true / 2 false | 310 true / 0 false |

The granted path was never correct in either period. Non-granted rows are Trading Post purchases,
which always set the flag.

## Change

Two write sites, both previously omitting the column so the DB default (`false`) applied:

- **`add-fighter.ts`** — select `is_editable` alongside the granted equipment details, set it on the
  insert, include it in the post-insert select, and return the real value instead of a hard-coded
  `false` in the response mapping.
- **`equipment.ts`** — same for the purchase-time grant path.

Both use `grantedEquip.is_editable || false`, matching the existing convention at
`equipment.ts:432` / `:455`.

## Notes

- Only these two sites write `granted_by_equipment_id`; both are covered.
- Fixes new rows only. Historical rows need a separate backfill — that will also repair the 458
  granted Web incisors rows, since they match on `equipment_id` regardless of insert path.
- `copy-fighter.ts` had a related gap, addressed separately so the two can be reviewed
  independently. `copy-gang.ts` is unaffected (it spreads the whole source row).
- `tsc --noEmit` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_018M6xE4m6SYmXsJwWiJwhnp)_