### PR TITLE
Carry is_editable when copying a fighter

### DIFF
--- a/app/actions/copy-fighter.ts
+++ b/app/actions/copy-fighter.ts
@@ -96,6 +96,7 @@ export async function copyFighter(params: CopyFighterParams): Promise<CopyFighte
           purchase_cost,
           original_cost,
           is_master_crafted,
+          is_editable,
           vehicle_id
         ),
         fighter_skills(
@@ -400,6 +401,7 @@ export async function copyFighter(params: CopyFighterParams): Promise<CopyFighte
             purchase_cost: eq.purchase_cost,
             original_cost: eq.original_cost,
             is_master_crafted: eq.is_master_crafted || false,
+            is_editable: eq.is_editable || false,
             gang_id: params.target_gang_id,
             user_id: gang.user_id
           })
@@ -431,6 +433,7 @@ export async function copyFighter(params: CopyFighterParams): Promise<CopyFighte
             purchase_cost: eq.purchase_cost,
             original_cost: eq.original_cost,
             is_master_crafted: eq.is_master_crafted || false,
+            is_editable: eq.is_editable || false,
             gang_id: params.target_gang_id,
             user_id: gang.user_id
           })
@@ -649,7 +652,7 @@ export async function copyFighter(params: CopyFighterParams): Promise<CopyFighte
           .from('fighters')
           .select(`
             *,
-            fighter_equipment(id, equipment_id, custom_equipment_id, purchase_cost, original_cost, is_master_crafted),
+            fighter_equipment(id, equipment_id, custom_equipment_id, purchase_cost, original_cost, is_master_crafted, is_editable),
             fighter_skills(id, skill_id, custom_skill_id, credits_increase, xp_cost, is_advance),
             fighter_effects(
               id, effect_name, fighter_effect_type_id, type_specific_data,
@@ -735,6 +738,7 @@ export async function copyFighter(params: CopyFighterParams): Promise<CopyFighte
                 purchase_cost: eq.purchase_cost,
                 original_cost: eq.original_cost,
                 is_master_crafted: eq.is_master_crafted || false,
+                is_editable: eq.is_editable || false,
                 gang_id: params.target_gang_id,
                 user_id: gang.user_id
               })


### PR DESCRIPTION
## Problem

`copyFighter` rebuilds each `fighter_equipment` row from an explicit column list that includes
`is_master_crafted` but **not** `is_editable`. Both source selects omitted the column as well, so
the value wasn't even fetched.

Result: copying a fighter silently drops the "Edit Equipment" button on any editable gear — Spyrer
weapons and rigs, Bionics, Archaeo-Cyberteknika, Archaeotech device. The copy looks identical to the
original but its tiers can no longer be changed.

## Change

One file, five additions:

- Two source selects — the main `fighter_equipment(...)` block and the inline exotic-beast select —
  now fetch `is_editable`.
- Three insert sites — fighter equipment, vehicle equipment, and exotic beast equipment — now set
  `is_editable: eq.is_editable || false`, directly alongside the existing
  `is_master_crafted: eq.is_master_crafted || false`.

## Scope

`copy-fighter.ts` is a plain server action — there is no `copy_fighter` RPC, and the only
copy-related database function is `copy_custom_collection` (custom packs), which never touches
`fighter_equipment`. So the fix belongs in TypeScript.

`copy-gang.ts` needs no change: it selects `*` and spreads the whole source row (`{ ...item }`), so
the flag is already carried. `chem-alchemy.ts` only creates custom equipment, and
`custom_equipment.is_editable` is never set by the customise UI.

## Not a regression from #1866 / #1904

`app/actions/copy-fighter.ts` is not in #1866's diff, and `is_editable` has never appeared in any
revision of the file. The three insert sites came from `b03e30d7` (2025-10-05, *"Add feature to copy
fighters between gangs"*), extended by `2a2b2e35` (vehicles) and `e4c3c6e2` (exotic beasts). This is
a separate, older defect that happens to affect the same equipment.

## Notes

- Fixes new copies only; historical rows need the backfill.
- Worth landing before that backfill, otherwise each fighter copy re-seeds `false` rows.
- `tsc --noEmit` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_018M6xE4m6SYmXsJwWiJwhnp)_