### PR TITLE
Added edition support in admin page

### DIFF
--- a/app/api/admin/campaign-types/route.ts
+++ b/app/api/admin/campaign-types/route.ts
@@ -13,7 +13,7 @@ export async function GET() {
 
     const { data: campaignTypes, error } = await supabase
       .from('campaign_types')
-      .select('id, campaign_type_name, image_url, trading_posts, campaign_type_resources(id, resource_name)')
+      .select('id, campaign_type_name, image_url, trading_posts, edition_id, campaign_type_resources(id, resource_name)')
       .order('campaign_type_name', { ascending: true });
 
     if (error) throw error;
@@ -37,7 +37,7 @@ export async function POST(request: Request) {
     }
 
     const body = await request.json();
-    const { campaign_type_name, image_url, trading_posts, resources } = body;
+    const { campaign_type_name, image_url, trading_posts, resources, edition_id } = body;
 
     if (!campaign_type_name?.trim()) {
       return NextResponse.json(
@@ -90,7 +90,8 @@ export async function POST(request: Request) {
       .insert([{
         campaign_type_name: campaign_type_name.trim(),
         image_url: image_url?.trim() || null,
-        trading_posts: trading_posts ?? null
+        trading_posts: trading_posts ?? null,
+        edition_id: edition_id || null
       }])
       .select()
       .single();
@@ -128,7 +129,7 @@ export async function PATCH(request: Request) {
     }
 
     const body = await request.json();
-    const { id, campaign_type_name, image_url, trading_posts, resources } = body;
+    const { id, campaign_type_name, image_url, trading_posts, resources, edition_id } = body;
 
     if (!id) {
       return NextResponse.json(
@@ -183,6 +184,9 @@ export async function PATCH(request: Request) {
       }
       updateData.trading_posts = trading_posts;
     }
+    if (edition_id !== undefined) {
+      updateData.edition_id = edition_id || null;
+    }
 
     if (Object.keys(updateData).length === 0 && resources === undefined) {
       return NextResponse.json(
@@ -232,7 +236,7 @@ export async function PATCH(request: Request) {
 
     const { data: updatedCampaignType, error: fetchError } = await supabase
       .from('campaign_types')
-      .select('id, campaign_type_name, image_url, trading_posts, campaign_type_resources(id, resource_name)')
+      .select('id, campaign_type_name, image_url, trading_posts, edition_id, campaign_type_resources(id, resource_name)')
       .eq('id', id)
       .single();
     if (fetchError) throw fetchError;

--- a/app/api/admin/equipment/route.ts
+++ b/app/api/admin/equipment/route.ts
@@ -415,7 +415,8 @@ export async function POST(request: Request) {
       weapon_profiles,
       fighter_types,
       gang_adjusted_costs,
-      equipment_availabilities
+      equipment_availabilities,
+      edition_id
     } = data;
 
     // First get the category name from the ID
@@ -438,7 +439,8 @@ export async function POST(request: Request) {
         equipment_category: categoryData.category_name,
         equipment_category_id,
         equipment_type: equipment_type.toLowerCase(),
-        core_equipment
+        core_equipment,
+        edition_id: edition_id || null
       })
       .select()
       .single();
@@ -571,7 +573,8 @@ export async function PATCH(request: Request) {
       equipment_origin_availabilities,
       equipment_variant_availabilities,
       fighter_effects,
-      grants_equipment
+      grants_equipment,
+      edition_id
     } = data;
 
     // Update equipment
@@ -589,6 +592,7 @@ export async function PATCH(request: Request) {
         grants_equipment: grants_equipment || null,
         is_editable,
         is_consumable: is_consumable ?? false,
+        edition_id: edition_id || null,
         updated_at: new Date().toISOString()
       })
       .eq('id', id);

--- a/app/api/admin/fighter-effects/route.ts
+++ b/app/api/admin/fighter-effects/route.ts
@@ -78,6 +78,7 @@ export async function GET(request: NextRequest) {
             fighter_effect_category_id,
             type_specific_data,
             sort_order,
+            edition_id,
             fighter_effect_categories(id, category_name)
           `)
           .eq('type_specific_data->>equipment_id', equipmentId)
@@ -127,6 +128,7 @@ export async function GET(request: NextRequest) {
             fighter_effect_category_id,
             type_specific_data,
             sort_order,
+            edition_id,
             fighter_effect_categories(id, category_name)
           `);
           
@@ -191,6 +193,7 @@ export async function GET(request: NextRequest) {
           fighter_effect_category_id,
           type_specific_data,
           sort_order,
+          edition_id,
           fighter_effect_categories(id, category_name)
         `)
         .eq('fighter_effect_category_id', categoryId)
@@ -392,7 +395,8 @@ export async function POST(request: NextRequest) {
           effect_name: body.effect_name,
           fighter_effect_category_id: body.fighter_effect_category_id || null,
           type_specific_data: typeSpecificData,
-          sort_order: body.sort_order ?? null
+          sort_order: body.sort_order ?? null,
+          edition_id: body.edition_id || null
         })
         .select()
         .single();
@@ -409,7 +413,8 @@ export async function POST(request: NextRequest) {
               effect_name: body.effect_name,
               fighter_effect_category_id: body.fighter_effect_category_id || null,
               type_specific_data: JSON.stringify(typeSpecificData),
-              sort_order: body.sort_order ?? null
+              sort_order: body.sort_order ?? null,
+              edition_id: body.edition_id || null
             })
             .select()
             .single();
@@ -482,7 +487,8 @@ export async function PATCH(request: NextRequest) {
         effect_name: body.effect_name,
         fighter_effect_category_id: body.fighter_effect_category_id || null,
         ...(typeSpecificData !== undefined && { type_specific_data: typeSpecificData }),
-        ...(body.sort_order !== undefined && { sort_order: body.sort_order ?? null })
+        ...(body.sort_order !== undefined && { sort_order: body.sort_order ?? null }),
+        ...(body.edition_id !== undefined && { edition_id: body.edition_id || null })
       })
       .eq('id', id)
       .select()

--- a/app/api/admin/fighter-types/route.ts
+++ b/app/api/admin/fighter-types/route.ts
@@ -396,6 +396,7 @@ export async function GET(request: Request) {
         fighter_type,
         gang_type_id,
         gang_type,
+        edition_id,
         fighter_class,
         fighter_class_id,
         fighter_sub_type_id,
@@ -475,6 +476,19 @@ export async function PATCH(request: Request) {
 
     const data = await request.json();
 
+    // edition_id is derived from the gang type, never taken from the client
+    // (the composite FK on (gang_type_id, edition_id) rejects mismatches)
+    const { data: gangType, error: gangTypeError } = await supabase
+      .from('gang_types')
+      .select('edition_id')
+      .eq('gang_type_id', data.gang_type_id)
+      .single();
+
+    if (gangTypeError) {
+      console.error('Error fetching gang type:', gangTypeError);
+      throw gangTypeError;
+    }
+
     // Update fighter type
     const { error: updateError } = await supabase
       .from('fighter_types')
@@ -482,6 +496,7 @@ export async function PATCH(request: Request) {
         fighter_type: data.fighter_type,
         cost: data.cost,
         gang_type_id: data.gang_type_id,
+        edition_id: gangType.edition_id ?? null,
         fighter_class: data.fighter_class,
         fighter_class_id: data.fighter_class_id,
         fighter_sub_type_id: data.fighter_sub_type_id,
@@ -755,10 +770,11 @@ export async function POST(request: Request) {
 
     const data = await request.json();
 
-    // First fetch the gang type name
+    // First fetch the gang type name and edition (edition_id is derived from
+    // the gang type, never taken from the client)
     const { data: gangType, error: gangTypeError } = await supabase
       .from('gang_types')
-      .select('gang_type')
+      .select('gang_type, edition_id')
       .eq('gang_type_id', data.gangTypeId)
       .single();
 
@@ -778,6 +794,7 @@ export async function POST(request: Request) {
         fighter_type: data.fighterType,
         gang_type_id: data.gangTypeId,
         gang_type: gangType.gang_type,
+        edition_id: gangType.edition_id ?? null,
         fighter_class: data.fighterClass,
         fighter_class_id: data.fighterClassId,
         fighter_sub_type_id: data.fighterSubTypeId,

--- a/app/api/admin/gang-lineages/route.ts
+++ b/app/api/admin/gang-lineages/route.ts
@@ -37,10 +37,11 @@ export async function GET(request: Request) {
   const type = typeParam as LineageType;
   const table = getTableName(type);
   // edition_id only exists on gang_affiliation, not fighter_gang_legacy.
-  // Cast to a single literal so the supabase query parser can type the result.
+  // Cast to the wider literal so the supabase query parser can type the result;
+  // for the legacy branch edition_id is simply absent (undefined) at runtime.
   const lineageColumns = (type === 'affiliation'
     ? 'id, name, fighter_type_id, created_at, updated_at, edition_id'
-    : 'id, name, fighter_type_id, created_at, updated_at') as 'id, name, fighter_type_id, created_at, updated_at';
+    : 'id, name, fighter_type_id, created_at, updated_at') as 'id, name, fighter_type_id, created_at, updated_at, edition_id';
 
   try {
     if (id) {

--- a/app/api/admin/gang-lineages/route.ts
+++ b/app/api/admin/gang-lineages/route.ts
@@ -36,19 +36,18 @@ export async function GET(request: Request) {
 
   const type = typeParam as LineageType;
   const table = getTableName(type);
+  // edition_id only exists on gang_affiliation, not fighter_gang_legacy.
+  // Cast to a single literal so the supabase query parser can type the result.
+  const lineageColumns = (type === 'affiliation'
+    ? 'id, name, fighter_type_id, created_at, updated_at, edition_id'
+    : 'id, name, fighter_type_id, created_at, updated_at') as 'id, name, fighter_type_id, created_at, updated_at';
 
   try {
     if (id) {
       // Get specific lineage by type
       const { data: row, error } = await supabase
         .from(table)
-        .select(`
-          id,
-          name,
-          fighter_type_id,
-          created_at,
-          updated_at
-        `)
+        .select(lineageColumns)
         .eq('id', id)
         .single();
 
@@ -94,13 +93,7 @@ export async function GET(request: Request) {
       // Get all of type
       const { data: rows, error } = await supabase
         .from(table)
-        .select(`
-          id,
-          name,
-          fighter_type_id,
-          created_at,
-          updated_at
-        `)
+        .select(lineageColumns)
         .order('name', { ascending: true });
 
       if (error) throw error;
@@ -181,12 +174,13 @@ export async function POST(request: Request) {
 
     const table = getTableName(data.type as LineageType);
 
-    // Create the lineage in the specific table
+    // Create the lineage in the specific table (edition_id only exists on gang_affiliation)
     const { data: newLineage, error: insertError } = await supabase
       .from(table)
       .insert({
         name: data.name,
-        fighter_type_id: data.fighter_type_id
+        fighter_type_id: data.fighter_type_id,
+        ...(data.type === 'affiliation' && { edition_id: data.edition_id || null })
       })
       .select()
       .single();
@@ -259,6 +253,7 @@ export async function PATCH(request: Request) {
         .update({
           name: data.name,
           fighter_type_id: data.fighter_type_id,
+          ...(currentType === 'affiliation' && { edition_id: data.edition_id || null }),
           updated_at: new Date().toISOString()
         })
         .eq('id', id);
@@ -292,12 +287,13 @@ export async function PATCH(request: Request) {
     const oldFightersFk = currentType === 'legacy' ? 'fighter_gang_legacy_id' : 'gang_affiliation_id';
     const newFightersFk = newType === 'legacy' ? 'fighter_gang_legacy_id' : 'gang_affiliation_id';
 
-    // Create new record in new table
+    // Create new record in new table (edition_id only exists on gang_affiliation)
     const { data: insertedNew, error: insertNewErr } = await supabase
       .from(newTable)
       .insert({
         name: data.name,
-        fighter_type_id: data.fighter_type_id
+        fighter_type_id: data.fighter_type_id,
+        ...(newType === 'affiliation' && { edition_id: data.edition_id || null })
       })
       .select()
       .single();

--- a/app/api/admin/gang-types/route.ts
+++ b/app/api/admin/gang-types/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: Request) {
 
     const { data, error } = await supabase
       .from('gang_types')
-      .select('gang_type_id, gang_type')
+      .select('gang_type_id, gang_type, edition_id')
       .order('gang_type');
 
     if (error) throw error;

--- a/app/api/admin/scenarios/route.ts
+++ b/app/api/admin/scenarios/route.ts
@@ -13,7 +13,7 @@ export async function GET() {
 
     const { data: scenarios, error } = await supabase
       .from('scenarios')
-      .select('id, scenario_name, scenario_number')
+      .select('id, scenario_name, scenario_number, edition_id')
       .order('scenario_number', { ascending: true });
 
     if (error) throw error;
@@ -38,7 +38,7 @@ export async function POST(request: Request) {
     }
 
     const body = await request.json();
-    const { scenario_name, scenario_number } = body;
+    const { scenario_name, scenario_number, edition_id } = body;
 
     const trimmedName = scenario_name?.trim();
 
@@ -83,7 +83,8 @@ export async function POST(request: Request) {
       .insert([
         {
           scenario_name: trimmedName,
-          scenario_number: numericScenarioNumber
+          scenario_number: numericScenarioNumber,
+          edition_id: edition_id || null
         }
       ])
       .select()
@@ -111,7 +112,7 @@ export async function PATCH(request: Request) {
     }
 
     const body = await request.json();
-    const { id, scenario_name, scenario_number } = body;
+    const { id, scenario_name, scenario_number, edition_id } = body;
 
     const trimmedName = scenario_name?.trim();
 
@@ -156,7 +157,8 @@ export async function PATCH(request: Request) {
       .from('scenarios')
       .update({
         scenario_name: trimmedName,
-        scenario_number: numericScenarioNumber
+        scenario_number: numericScenarioNumber,
+        edition_id: edition_id || null
       })
       .eq('id', id)
       .select()

--- a/app/api/admin/skill-types/route.ts
+++ b/app/api/admin/skill-types/route.ts
@@ -13,14 +13,15 @@ export async function GET() {
 
     const { data, error } = await supabase
       .from('skill_types')
-      .select('id, name')
+      .select('id, name, edition_id')
       .order('name');
 
     if (error) throw error;
 
     const transformedData = data.map(type => ({
       id: type.id,
-      skill_type: type.name
+      skill_type: type.name,
+      edition_id: type.edition_id
     }));
 
     return NextResponse.json(transformedData);
@@ -44,7 +45,8 @@ export async function POST(request: Request) {
     const skillTypeData = await request.json();
 
     const formattedData = {
-      name: skillTypeData.name
+      name: skillTypeData.name,
+      edition_id: skillTypeData.edition_id || null
     };
 
     const { data, error } = await supabase
@@ -80,6 +82,7 @@ export async function PATCH(request: Request) {
     const formattedData = {
       name: skillTypeData.name,
       id: skillTypeData.id,
+      edition_id: skillTypeData.edition_id || null,
     };
 
     const { data, error } = await supabase

--- a/app/api/admin/territories/route.ts
+++ b/app/api/admin/territories/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: Request) {
 
     let query = supabase
       .from('territories')
-      .select('id, territory_name, campaign_type_id, playing_card')
+      .select('id, territory_name, campaign_type_id, playing_card, edition_id')
       .order('territory_name', { ascending: true });
 
     if (campaignTypeId) {
@@ -46,7 +46,7 @@ export async function POST(request: Request) {
     }
 
     const body = await request.json();
-    const { territory_name, campaign_type_id, playing_card } = body;
+    const { territory_name, campaign_type_id, playing_card, edition_id } = body;
     const normalisedPlayingCard = typeof playing_card === 'string' ? playing_card.trim() || null : null;
 
     if (!territory_name?.trim()) {
@@ -68,7 +68,8 @@ export async function POST(request: Request) {
       .insert([{
         territory_name: territory_name.trim(),
         campaign_type_id: campaign_type_id || null,
-        playing_card: normalisedPlayingCard
+        playing_card: normalisedPlayingCard,
+        edition_id: edition_id || null
       }])
       .select()
       .single();
@@ -94,7 +95,7 @@ export async function PATCH(request: Request) {
     }
 
     const body = await request.json();
-    const { id, territory_name, campaign_type_id, playing_card } = body;
+    const { id, territory_name, campaign_type_id, playing_card, edition_id } = body;
 
     if (!id) {
       return NextResponse.json(
@@ -119,6 +120,9 @@ export async function PATCH(request: Request) {
     }
     if (playing_card !== undefined) {
       updateData.playing_card = typeof playing_card === 'string' ? playing_card.trim() || null : null;
+    }
+    if (edition_id !== undefined) {
+      updateData.edition_id = edition_id || null;
     }
 
     if (Object.keys(updateData).length === 0) {

--- a/app/api/admin/vehicles/route.ts
+++ b/app/api/admin/vehicles/route.ts
@@ -41,6 +41,7 @@ interface VehicleFormData {
   engine_slots?: string;
   vehicle_type?: string;
   gang_type_id?: string;
+  edition_id?: string | null;
   special_rules?: string;
   equipment_list?: string[];
   gang_origin_equipment?: GangOriginEquipmentItem[];
@@ -192,7 +193,7 @@ export async function GET(request: Request) {
     if (fetch_type === 'vehicle_types') {
       const { data: vehicleTypes, error } = await supabase
         .from('vehicle_types')
-        .select('id, vehicle_type')
+        .select('id, vehicle_type, edition_id')
         .order('vehicle_type');
 
       if (error) throw error;
@@ -241,6 +242,7 @@ export async function POST(request: Request) {
       drive_slots: parseInt(vehicleData.drive_slots),
       engine_slots: parseInt(vehicleData.engine_slots),
       gang_type_id: vehicleData.gang_type_id === "0" ? null : parseInt(vehicleData.gang_type_id),
+      edition_id: vehicleData.edition_id || null,
       hardpoints: vehicleData.hardpoints || [],
       // Initialize occupied slots to 0
       body_slots_occupied: 0,
@@ -365,6 +367,7 @@ export async function PATCH(request: Request) {
       drive_slots: parseInt(vehicleData.drive_slots || "0"),
       engine_slots: parseInt(vehicleData.engine_slots || "0"),
       gang_type_id: vehicleData.gang_type_id === "0" ? null : vehicleData.gang_type_id,
+      edition_id: vehicleData.edition_id || null,
       handling: vehicleData.handling,
       save: vehicleData.save,
       vehicle_type: vehicleData.vehicle_type,

--- a/app/api/editions/route.ts
+++ b/app/api/editions/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server'
+import { createClient } from "@/utils/supabase/server";
+import { getUserIdFromClaims } from "@/utils/auth";
+
+export async function GET() {
+  const supabase = await createClient();
+
+  try {
+    const userId = await getUserIdFromClaims(supabase);
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { data, error } = await supabase
+      .from('editions')
+      .select('id, name, slug, is_current, released_at')
+      .order('released_at', { ascending: false, nullsFirst: false })
+      .order('name');
+
+    if (error) throw error;
+
+    return NextResponse.json(data)
+  } catch (error) {
+    console.error('Error fetching editions:', error)
+    return NextResponse.json({ error: 'Error fetching editions' }, { status: 500 })
+  }
+}

--- a/components/admin/admin-campaign-management.tsx
+++ b/components/admin/admin-campaign-management.tsx
@@ -10,6 +10,7 @@ import { toast } from 'sonner';
 import { HiX } from "react-icons/hi";
 import Modal from '@/components/ui/modal';
 import type { CampaignType, CampaignTypeResource } from '@/types/campaign';
+import { EditionSelect } from '@/components/edition-select';
 
 enum OperationType {
   POST = 'POST',
@@ -23,6 +24,7 @@ interface Territory {
   territory_name: string;
   campaign_type_id?: string | null;
   playing_card?: string | null;
+  edition_id?: string | null;
 }
 
 interface CampaignTriumph {
@@ -117,6 +119,7 @@ export function AdminCampaignManagementModal({
   const [selectedCampaignTypeId, setSelectedCampaignTypeId] = useState('');
   const [campaignTypeName, setCampaignTypeName] = useState('');
   const [imageUrl, setImageUrl] = useState('');
+  const [campaignTypeEditionId, setCampaignTypeEditionId] = useState('');
   const [isCreateModeCampaignType, setIsCreateModeCampaignType] = useState(false);
   
   // Relationship management for campaign types
@@ -137,6 +140,7 @@ export function AdminCampaignManagementModal({
   const [territoryName, setTerritoryName] = useState('');
   const [territoryCampaignTypeId, setTerritoryCampaignTypeId] = useState('');
   const [territoryCardValue, setTerritoryCardValue] = useState('');
+  const [territoryEditionId, setTerritoryEditionId] = useState('');
   const [isCreateModeTerritory, setIsCreateModeTerritory] = useState(false);
   
   // Triumphs form state
@@ -185,6 +189,48 @@ export function AdminCampaignManagementModal({
     }
   }
 
+  // Edition is the top-level filter per section: only rows of the chosen
+  // edition are offered for editing, and created/saved rows keep that edition
+  const filteredCampaignTypes = campaignTypeEditionId
+    ? campaignTypes.filter(ct => ct.edition_id === campaignTypeEditionId)
+    : campaignTypes;
+
+  const filteredTerritories = territoryEditionId
+    ? territories.filter(t => t.edition_id === territoryEditionId)
+    : territories;
+
+  const handleCampaignTypeEditionChange = (newEditionId: string) => {
+    setCampaignTypeEditionId(newEditionId);
+    if (newEditionId && selectedCampaignTypeId) {
+      const selected = campaignTypes.find(ct => ct.id === selectedCampaignTypeId);
+      if (selected && selected.edition_id !== newEditionId) {
+        setSelectedCampaignTypeId('');
+        setCampaignTypeName('');
+        setImageUrl('');
+        setIsCreateModeCampaignType(false);
+        setRelatedTerritories([]);
+        setRelatedTriumphs([]);
+        setRelatedTradingPostIds([]);
+        setCampaignTypeResources([]);
+        setNewResourceName('');
+      }
+    }
+  };
+
+  const handleTerritoryEditionChange = (newEditionId: string) => {
+    setTerritoryEditionId(newEditionId);
+    if (newEditionId && selectedTerritoryId) {
+      const selected = territories.find(t => t.id === selectedTerritoryId);
+      if (selected && selected.edition_id !== newEditionId) {
+        setSelectedTerritoryId('');
+        setTerritoryName('');
+        setTerritoryCampaignTypeId('');
+        setTerritoryCardValue('');
+        setIsCreateModeTerritory(false);
+      }
+    }
+  };
+
   const invalidateAllData = () => Promise.all([
     queryClient.invalidateQueries({ queryKey: ['admin-campaign-types'] }),
     queryClient.invalidateQueries({ queryKey: ['admin-territories'] }),
@@ -199,6 +245,7 @@ export function AdminCampaignManagementModal({
     if (selected) {
       setCampaignTypeName(selected.campaign_type_name);
       setImageUrl(selected.image_url || '');
+      setCampaignTypeEditionId(selected.edition_id ?? '');
       setRelatedTradingPostIds(selected.trading_posts || []);
       setCampaignTypeResources(selected.campaign_type_resources ?? []);
       setNewResourceName('');
@@ -247,6 +294,7 @@ export function AdminCampaignManagementModal({
             campaign_type_name: campaignTypeName.trim(),
             image_url: imageUrl.trim() || null,
             trading_posts: relatedTradingPostIds.length > 0 ? relatedTradingPostIds : null,
+            edition_id: campaignTypeEditionId || null,
             resources: campaignTypeResources.map(r => r.resource_name)
           });
           break;
@@ -257,6 +305,7 @@ export function AdminCampaignManagementModal({
             campaign_type_name: campaignTypeName.trim(),
             image_url: imageUrl.trim() || null,
             trading_posts: relatedTradingPostIds.length > 0 ? relatedTradingPostIds : null,
+            edition_id: campaignTypeEditionId || null,
             resources: campaignTypeResources.map(r => r.resource_name)
           });
           break;
@@ -386,6 +435,7 @@ export function AdminCampaignManagementModal({
       setTerritoryName(selected.territory_name);
       setTerritoryCampaignTypeId(selected.campaign_type_id || '');
       setTerritoryCardValue(selected.playing_card || '');
+      setTerritoryEditionId(selected.edition_id ?? '');
     }
   };
 
@@ -415,7 +465,8 @@ export function AdminCampaignManagementModal({
           body = JSON.stringify({
             territory_name: territoryName.trim(),
             campaign_type_id: territoryCampaignTypeId || null,
-            playing_card: territoryCardValue.trim() || null
+            playing_card: territoryCardValue.trim() || null,
+            edition_id: territoryEditionId || null
           });
           break;
         case OperationType.UPDATE:
@@ -424,7 +475,8 @@ export function AdminCampaignManagementModal({
             id: selectedTerritoryId,
             territory_name: territoryName.trim(),
             campaign_type_id: territoryCampaignTypeId || null,
-            playing_card: territoryCardValue.trim() || null
+            playing_card: territoryCardValue.trim() || null,
+            edition_id: territoryEditionId || null
           });
           break;
         default:
@@ -626,7 +678,7 @@ export function AdminCampaignManagementModal({
   };
 
   const activeForm = getActiveFormState();
-  const territorySelectOptions = territories.map((territory) => {
+  const territorySelectOptions = filteredTerritories.map((territory) => {
     const playingCardValue = territory.playing_card?.trim();
     const hasPlayingCardValue = Boolean(playingCardValue);
     const campaignTypeName = campaignTypes.find(
@@ -703,6 +755,12 @@ export function AdminCampaignManagementModal({
             {/* Campaign Types Section */}
             {selectedCategory === 'campaign-types' && (
               <>
+                <EditionSelect
+                  value={campaignTypeEditionId}
+                  onChange={handleCampaignTypeEditionChange}
+                  defaultToCurrent
+                />
+
                 <div>
                   <div className="flex justify-between items-center mb-1">
                     <label className="block text-sm font-medium text-muted-foreground">
@@ -723,7 +781,7 @@ export function AdminCampaignManagementModal({
                     disabled={isLoading}
                   >
                     <option value="">Select a campaign type to edit</option>
-                    {campaignTypes.map((type) => (
+                    {filteredCampaignTypes.map((type) => (
                       <option key={type.id} value={type.id}>
                         {type.campaign_type_name}
                       </option>
@@ -932,6 +990,12 @@ export function AdminCampaignManagementModal({
             {/* Territories Section */}
             {selectedCategory === 'territories' && (
               <>
+                <EditionSelect
+                  value={territoryEditionId}
+                  onChange={handleTerritoryEditionChange}
+                  defaultToCurrent
+                />
+
                 <div>
                   <div className="flex justify-between items-center mb-1">
                     <label className="block text-sm font-medium text-muted-foreground">
@@ -1004,6 +1068,7 @@ export function AdminCampaignManagementModal({
                     disabled={!isCreateModeTerritory && !selectedTerritoryId}
                   />
                 </div>
+
               </>
             )}
 

--- a/components/admin/admin-create-equipment.tsx
+++ b/components/admin/admin-create-equipment.tsx
@@ -8,6 +8,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { AvailabilityPicker, combineAvailability } from '@/components/ui/availability-picker';
 import { toast } from 'sonner';
 import { WeaponProfileInput, EquipmentAvailability, GangAdjustedCost } from "@/types/equipment";
+import { EditionSelect } from '@/components/edition-select';
 import { HiX } from "react-icons/hi";
 import { LuTrash2 } from 'react-icons/lu'
 
@@ -28,6 +29,7 @@ export function AdminCreateEquipmentModal({ onClose, onSubmit }: AdminCreateEqui
   const [variants] = useState('');
   const [equipmentCategory, setEquipmentCategory] = useState('');
   const [equipmentType, setEquipmentType] = useState<EquipmentType | ''>('');
+  const [editionId, setEditionId] = useState('');
   const [coreEquipment, setCoreEquipment] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [weaponProfiles, setWeaponProfiles] = useState<WeaponProfileInput[]>([{
@@ -162,6 +164,7 @@ export function AdminCreateEquipmentModal({ onClose, onSubmit }: AdminCreateEqui
           equipment_category_id: equipmentCategory,
           equipment_type: equipmentType,
           core_equipment: coreEquipment,
+          edition_id: editionId || null,
           weapon_profiles: cleanedWeaponProfiles,
           gang_adjusted_costs: gangAdjustedCosts.map(d => ({
             gang_type_id: d.gang_type_id,
@@ -278,6 +281,8 @@ export function AdminCreateEquipmentModal({ onClose, onSubmit }: AdminCreateEqui
                 ))}
               </select>
             </div>
+
+            <EditionSelect value={editionId} onChange={setEditionId} defaultToCurrent />
 
             <div>
               <label className="block text-sm font-medium text-muted-foreground mb-1">

--- a/components/admin/admin-create-fighter-type.tsx
+++ b/components/admin/admin-create-fighter-type.tsx
@@ -8,6 +8,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from 'sonner';
 import { HiX } from "react-icons/hi";
 import { GangType, Equipment } from "@/types/gang";
+import { EditionSelect } from '@/components/edition-select';
 import { skillSetRank } from "@/utils/skillSetRank";
 import { equipmentCategoryRank } from "@/utils/equipmentCategoryRank";
 
@@ -49,6 +50,7 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
   const [baseCost, setBaseCost] = useState('');
   const [delegationCost, setDelegationCost] = useState('');
   const [selectedGangType, setSelectedGangType] = useState('');
+  const [editionId, setEditionId] = useState('');
   const [selectedFighterClass, setSelectedFighterClass] = useState<FighterClass | ''>('');
   const [isLoading, setIsLoading] = useState(false);
   
@@ -96,6 +98,22 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
     },
     staleTime: 5 * 60 * 1000,
   });
+
+  // The fighter type's edition is implied by its gang type (derived server-side);
+  // the edition select only filters the gang type options
+  const filteredGangTypes = editionId
+    ? gangTypes.filter(type => type.edition_id === editionId)
+    : gangTypes;
+
+  const handleEditionChange = (newEditionId: string) => {
+    setEditionId(newEditionId);
+    if (newEditionId && selectedGangType) {
+      const gangType = gangTypes.find(type => type.gang_type_id === selectedGangType);
+      if (gangType && gangType.edition_id !== newEditionId) {
+        setSelectedGangType('');
+      }
+    }
+  };
 
   const { data: equipment = [] } = useQuery<EquipmentWithId[]>({
     queryKey: ['admin-equipment-list'],
@@ -304,6 +322,8 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
 
         <div className="px-[10px] py-4 overflow-y-auto grow">
           <div className="space-y-4">
+            <EditionSelect value={editionId} onChange={handleEditionChange} defaultToCurrent />
+
             <div>
               <label className="block text-sm font-medium text-muted-foreground mb-1">
                 Gang Type *
@@ -314,7 +334,7 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
                 className="w-full p-2 border rounded-md"
               >
                 <option value="">Select gang type</option>
-                {gangTypes.map((type) => (
+                {filteredGangTypes.map((type) => (
                   <option key={type.gang_type_id} value={type.gang_type_id}>
                     {type.gang_type}
                   </option>

--- a/components/admin/admin-create-skill.tsx
+++ b/components/admin/admin-create-skill.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { toast } from 'sonner';
 import { skillSetRank } from "@/utils/skillSetRank";
 import { gangOriginRank } from "@/utils/gangOriginRank";
+import { EditionSelect } from '@/components/edition-select';
 
 interface AdminCreateSkillModalProps {
   onClose: () => void;
@@ -19,6 +20,7 @@ export function AdminCreateSkillModal({ onClose, onSubmit }: AdminCreateSkillMod
   const [skillType, setSkillType] = useState('');
   const [skillTypeName, setSkillTypeName] = useState('');
   const [gangOrigin, setGangOrigin] = useState('');
+  const [editionId, setEditionId] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
   const { data: skillTypeList = [] } = useQuery<Array<{id: string, skill_type: string}>>({
@@ -98,7 +100,8 @@ export function AdminCreateSkillModal({ onClose, onSubmit }: AdminCreateSkillMod
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          name: skillTypeName
+          name: skillTypeName,
+          edition_id: editionId || null
         }),
       });
 
@@ -268,6 +271,11 @@ export function AdminCreateSkillModal({ onClose, onSubmit }: AdminCreateSkillMod
                 <p className="text-xs text-amber-600 mt-1">Clear the Skill Set selection to enter a Skill Set Name.</p>
               )}
             </div>
+
+            {/* Skills inherit their edition from the skill set; only new skill sets need one */}
+            {skillTypeName !== '' && (
+              <EditionSelect value={editionId} onChange={setEditionId} defaultToCurrent />
+            )}
           </div>
         </div>
 

--- a/components/admin/admin-create-vehicle-type.tsx
+++ b/components/admin/admin-create-vehicle-type.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import Modal from "@/components/ui/modal";
 import { HiX } from "react-icons/hi";
 import { gangOriginRank } from "@/utils/gangOriginRank";
+import { EditionSelect } from '@/components/edition-select';
 
 interface AdminCreateVehicleTypeModalProps {
   onClose: () => void;
@@ -336,6 +337,7 @@ export function AdminCreateVehicleTypeModal({ onClose, onSubmit }: AdminCreateVe
     vehicle_type: '',
     gang_type_id: ''
   });
+  const [editionId, setEditionId] = useState('');
 
   const handleVehicleFormChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     setVehicleForm(prev => ({
@@ -361,6 +363,7 @@ export function AdminCreateVehicleTypeModal({ onClose, onSubmit }: AdminCreateVe
       vehicle_type: '',
       gang_type_id: ''
     });
+    setEditionId('');
     setEquipmentListSelections([]);
     setGangOriginEquipment([]);
     setGangTypeEquipment([]);
@@ -376,6 +379,7 @@ export function AdminCreateVehicleTypeModal({ onClose, onSubmit }: AdminCreateVe
         body: JSON.stringify({
           ...vehicleForm,
           gang_type_id: vehicleForm.gang_type_id === "0" ? null : parseInt(vehicleForm.gang_type_id),
+          edition_id: editionId || null,
           cost: parseInt(vehicleForm.cost),
           movement: parseInt(vehicleForm.movement),
           front: parseInt(vehicleForm.front),
@@ -470,6 +474,10 @@ export function AdminCreateVehicleTypeModal({ onClose, onSubmit }: AdminCreateVe
                   </option>
                 ))}
               </select>
+            </div>
+
+            <div className="col-span-3">
+              <EditionSelect value={editionId} onChange={setEditionId} defaultToCurrent />
             </div>
 
             {/* Numeric inputs */}

--- a/components/admin/admin-edit-equipment.tsx
+++ b/components/admin/admin-edit-equipment.tsx
@@ -14,6 +14,7 @@ import { fighterClassRank } from "@/utils/fighterClassRank";
 import { gangOriginRank } from "@/utils/gangOriginRank";
 import { gangVariantRank } from "@/utils/gangVariantRank";
 import { AdminFighterEffects } from "./admin-fighter-effects";
+import { EditionSelect } from '@/components/edition-select';
 import { AdminTradingPost } from "./admin-trading-post";
 import { LuTrash2 } from 'react-icons/lu';
 import Modal from "@/components/ui/modal";
@@ -35,6 +36,7 @@ interface Equipment {
   equipment_category: string;
   equipment_type: EquipmentType;
   core_equipment: boolean;
+  edition_id?: string | null;
   weapon_profiles?: WeaponProfileInput[];
   fighter_types?: string[];
   gang_adjusted_costs?: GangAdjustedCost[];
@@ -51,6 +53,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
   const [variants, setVariants] = useState('');
   const [equipmentCategory, setEquipmentCategory] = useState('');
   const [equipmentType, setEquipmentType] = useState<EquipmentType | ''>('');
+  const [editionId, setEditionId] = useState('');
   const [coreEquipment, setCoreEquipment] = useState(false);
   const [isEditable, setIsEditable] = useState(false);
   const [isConsumable, setIsConsumable] = useState(false);
@@ -126,6 +129,22 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
     staleTime: 5 * 60 * 1000,
   });
 
+  // Edition is the top-level filter: only equipment of the chosen edition is
+  // offered for editing, and the saved row keeps that edition
+  const filteredEquipmentList = editionId
+    ? equipmentList.filter(item => item.edition_id === editionId)
+    : equipmentList;
+
+  const handleEditionChange = (newEditionId: string) => {
+    setEditionId(newEditionId);
+    if (newEditionId && selectedEquipmentId) {
+      const selected = equipmentList.find(item => item.id === selectedEquipmentId);
+      if (selected && selected.edition_id !== newEditionId) {
+        setSelectedEquipmentId('');
+      }
+    }
+  };
+
   const { data: equipmentDetails, isLoading: isEquipmentDetailsLoading } = useQuery<any>({
     queryKey: ['admin-equipment-details', selectedEquipmentId],
     queryFn: async () => {
@@ -186,6 +205,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
       setVariants(equipmentDetails.variants || '');
       setEquipmentCategory(equipmentDetails.equipment_category_id);
       setEquipmentType(equipmentDetails.equipment_type);
+      setEditionId(equipmentDetails.edition_id ?? '');
       setCoreEquipment(equipmentDetails.core_equipment || false);
       setIsEditable(equipmentDetails.is_editable || false);
       setIsConsumable(equipmentDetails.is_consumable || false);
@@ -393,6 +413,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
         equipment_category_id: equipmentCategory,
         equipment_type: equipmentType,
         core_equipment: coreEquipment,
+        edition_id: editionId || null,
         is_editable: isEditable,
         is_consumable: isConsumable,
         grants_equipment: normalizedGrantsEquipment,
@@ -504,6 +525,10 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
         <div className="px-[10px] py-4 overflow-y-auto flex-1">
           <div className="grid grid-cols-3 gap-4">
             <div className="col-span-3">
+              <EditionSelect value={editionId} onChange={handleEditionChange} defaultToCurrent />
+            </div>
+
+            <div className="col-span-3">
               <label className="block text-sm font-medium text-muted-foreground mb-1">
                 Select Category *
               </label>
@@ -535,7 +560,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                 disabled={!categoryFilter}
               >
                 <option value="">Select equipment</option>
-                {equipmentList
+                {filteredEquipmentList
                   .sort((a, b) => a.equipment_name.localeCompare(b.equipment_name))
                   .map((item: Equipment) => (
                     <option key={item.id} value={item.id}>

--- a/components/admin/admin-edit-fighter-type.tsx
+++ b/components/admin/admin-edit-fighter-type.tsx
@@ -14,6 +14,7 @@ import { Equipment } from '@/types/equipment';
 import { skillSetRank } from "@/utils/skillSetRank";
 import { equipmentCategoryRank } from "@/utils/equipmentCategoryRank";
 import { AdminFighterEquipmentSelection, EquipmentSelection, guiToDataModel, dataModelToGui } from "@/components/admin/admin-fighter-equipment-selection";
+import { EditionSelect } from '@/components/edition-select';
 import Modal from '@/components/ui/modal';
 
 interface FighterSubType {
@@ -110,6 +111,7 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
   const [equipment, setEquipment] = useState<EquipmentWithId[]>([]);
   const [selectedEquipment, setSelectedEquipment] = useState<string[]>([]);
   const [gangTypeFilter, setGangTypeFilter] = useState('');
+  const [editionId, setEditionId] = useState('');
   const [skills, setSkills] = useState<Skill[]>([]);
   const [selectedSkillType, setSelectedSkillType] = useState('');
   const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
@@ -299,6 +301,24 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
     },
     staleTime: 5 * 60 * 1000,
   });
+
+  // Edition only filters the gang-type dropdown; the fighter type's edition is
+  // derived server-side from its gang type
+  const filteredGangTypes = editionId
+    ? gangTypes.filter(type => type.edition_id === editionId)
+    : gangTypes;
+
+  const handleEditionChange = (newEditionId: string) => {
+    setEditionId(newEditionId);
+    if (newEditionId && gangTypeFilter) {
+      const gangType = gangTypes.find(type => type.gang_type_id === gangTypeFilter);
+      if (gangType && gangType.edition_id !== newEditionId) {
+        setGangTypeFilter('');
+        setSelectedFighterTypeId('');
+        setSelectedSubTypeId('');
+      }
+    }
+  };
 
   const { data: gangAffiliations = [] } = useQuery<GangAffiliation[]>({
     queryKey: ['admin-lineages', 'affiliation'],
@@ -1302,6 +1322,8 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
 
         <div className="px-[10px] py-4 overflow-y-auto grow">
           <div className="space-y-4">
+            <EditionSelect value={editionId} onChange={handleEditionChange} defaultToCurrent />
+
             <div>
               <label className="block text-sm font-medium text-muted-foreground mb-1">
                 Filter by Gang Type
@@ -1317,7 +1339,7 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
                 className="w-full p-2 border rounded-md"
               >
                 <option value="">All Gang Types</option>
-                {gangTypes.map((type) => (
+                {filteredGangTypes.map((type) => (
                   <option key={type.gang_type_id} value={type.gang_type_id}>
                     {type.gang_type}
                   </option>

--- a/components/admin/admin-edit-skill.tsx
+++ b/components/admin/admin-edit-skill.tsx
@@ -8,6 +8,7 @@ import { toast } from 'sonner';
 import { skillSetRank } from "@/utils/skillSetRank";
 import { gangOriginRank } from "@/utils/gangOriginRank";
 import { AdminFighterEffects } from './admin-fighter-effects';
+import { EditionSelect } from '@/components/edition-select';
 
 enum OperationType {
   POST = 'POST',
@@ -150,12 +151,13 @@ export function AdminEditSkillModal({ onClose, onSubmit }: AdminEditSkillModalPr
   const [skillType, setSkillType] = useState('');
   const [skillTypeName, setSkillTypeName] = useState('');
   const [gangOrigin, setGangOrigin] = useState('');
+  const [editionId, setEditionId] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [skillEffects, setSkillEffects] = useState<any[]>([]);
   const [skillsCategoryId, setSkillsCategoryId] = useState('');
   const [effectCategories, setEffectCategories] = useState<any[]>([]);
 
-  const { data: skillTypeList = [] } = useQuery<Array<{id: string, skill_type: string}>>({
+  const { data: skillTypeList = [] } = useQuery<Array<{id: string, skill_type: string, edition_id?: string | null}>>({
     queryKey: ['admin-skill-types'],
     queryFn: async () => {
       const response = await fetch('/api/admin/skill-types');
@@ -175,6 +177,26 @@ export function AdminEditSkillModal({ onClose, onSubmit }: AdminEditSkillModalPr
     staleTime: 5 * 60 * 1000,
   });
 
+
+  // Edition is the top-level filter: only skill sets of the chosen edition are
+  // offered for editing, and the saved skill set keeps that edition
+  const filteredSkillTypeList = editionId
+    ? skillTypeList.filter(type => type.edition_id === editionId)
+    : skillTypeList;
+
+  const handleEditionChange = (newEditionId: string) => {
+    setEditionId(newEditionId);
+    if (newEditionId && skillType) {
+      const selectedType = skillTypeList.find(t => t.id === skillType);
+      if (selectedType && selectedType.edition_id !== newEditionId) {
+        setSkillType('');
+        setSkillTypeName('');
+        setSkillName('');
+        setSkillId('');
+        setSkillList([]);
+      }
+    }
+  };
 
   const [prevSkillId, setPrevSkillId] = useState(skillId);
   const [prevSkillNameList, setPrevSkillNameList] = useState(skillNameList);
@@ -261,6 +283,7 @@ export function AdminEditSkillModal({ onClose, onSubmit }: AdminEditSkillModalPr
         body = JSON.stringify({
           name: skillTypeName,
           id: skillType,
+          edition_id: editionId || null,
         });
         break;
       case OperationType.DELETE:
@@ -397,6 +420,8 @@ const handleSubmitSkill = async (operation: OperationType) => {
 
         <div className="px-[10px] py-4">
           <div className="grid grid-cols-1 gap-4">
+            <EditionSelect value={editionId} onChange={handleEditionChange} defaultToCurrent />
+
             <div className="col-span-1">
               <label className="block text-sm font-medium text-muted-foreground mb-1">
                 Skill Set *
@@ -414,6 +439,8 @@ const handleSubmitSkill = async (operation: OperationType) => {
                       searchSkillType(e.target.value);
                     }
                     setSkillTypeName(selectedSkillType);
+                    const selectedType = skillTypeList.find(t => t.id === e.target.value);
+                    setEditionId(selectedType?.edition_id ?? '');
                   }
                 }
                 className="w-full p-2 border rounded-md"
@@ -421,7 +448,7 @@ const handleSubmitSkill = async (operation: OperationType) => {
                 <option value="">Select a skill set</option>
 
                 {Object.entries(
-                  skillTypeList
+                  filteredSkillTypeList
                     .sort((a, b) => {
                       const rankA = skillSetRank[a.skill_type.toLowerCase()] ?? Infinity;
                       const rankB = skillSetRank[b.skill_type.toLowerCase()] ?? Infinity;
@@ -574,6 +601,7 @@ const handleSubmitSkill = async (operation: OperationType) => {
                 disabled={skillName == '' && skillType == ''}
               />
             </div>
+
           </div>
         </div>
 

--- a/components/admin/admin-edit-vehicle-type.tsx
+++ b/components/admin/admin-edit-vehicle-type.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/badge";
 import Modal from "@/components/ui/modal";
 import { HiX } from "react-icons/hi";
 import { gangOriginRank } from "@/utils/gangOriginRank";
+import { EditionSelect } from '@/components/edition-select';
 
 interface AdminEditVehicleTypeModalProps {
   onClose: () => void;
@@ -436,7 +437,7 @@ export function AdminEditVehicleTypeModal({ onClose, onSubmit }: AdminEditVehicl
     staleTime: 5 * 60 * 1000,
   });
 
-  const { data: vehicleTypes = [] } = useQuery<{ id: number; vehicle_type: string }[]>({
+  const { data: vehicleTypes = [] } = useQuery<{ id: number; vehicle_type: string; edition_id?: string | null }[]>({
     queryKey: ['admin-vehicle-types'],
     queryFn: async () => {
       const response = await fetch('/api/admin/vehicles?fetch_type=vehicle_types');
@@ -482,12 +483,29 @@ export function AdminEditVehicleTypeModal({ onClose, onSubmit }: AdminEditVehicl
     vehicle_type: '',
     gang_type_id: ''
   });
+  const [editionId, setEditionId] = useState('');
 
   const handleVehicleFormChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     setVehicleForm(prev => ({
       ...prev,
       [e.target.name]: e.target.value
     }));
+  };
+
+  // Edition is the top-level filter: only vehicle types of the chosen edition
+  // are offered for editing, and the saved row keeps that edition
+  const filteredVehicleTypes = editionId
+    ? vehicleTypes.filter(vehicle => vehicle.edition_id === editionId)
+    : vehicleTypes;
+
+  const handleEditionChange = (newEditionId: string) => {
+    setEditionId(newEditionId);
+    if (newEditionId && selectedVehicle) {
+      const vehicle = vehicleTypes.find(v => v.id.toString() === selectedVehicle);
+      if (vehicle && vehicle.edition_id !== newEditionId) {
+        resetVehicleForm();
+      }
+    }
   };
 
   const fetchVehicleDetails = async (vehicleId: string) => {
@@ -535,6 +553,7 @@ export function AdminEditVehicleTypeModal({ onClose, onSubmit }: AdminEditVehicl
         vehicle_type: vehicleData.vehicle_type || '',
         gang_type_id: vehicleData.gang_type_id ? vehicleData.gang_type_id.toString() : "0"
       });
+      setEditionId(vehicleData.edition_id ?? '');
 
     } catch (error) {
       console.error('Error fetching vehicle details:', error);
@@ -588,6 +607,7 @@ export function AdminEditVehicleTypeModal({ onClose, onSubmit }: AdminEditVehicl
         },
         body: JSON.stringify({
           ...vehicleForm,
+          edition_id: editionId || null,
           special_rules: vehicleForm.special_rules
             .split(',')
             .map(rule => rule.trim())
@@ -638,6 +658,10 @@ export function AdminEditVehicleTypeModal({ onClose, onSubmit }: AdminEditVehicl
         content={
           <div className="space-y-4">
             <div className="grid grid-cols-3 gap-4">
+            <div className="col-span-3">
+              <EditionSelect value={editionId} onChange={handleEditionChange} defaultToCurrent />
+            </div>
+
             {/* Vehicle Type Selection Dropdown */}
             <div className="col-span-3">
               <label className="block text-sm font-medium text-muted-foreground">
@@ -656,7 +680,7 @@ export function AdminEditVehicleTypeModal({ onClose, onSubmit }: AdminEditVehicl
                 required
               >
                 <option value="">Select a vehicle type to edit</option>
-                {vehicleTypes.map((vehicle) => (
+                {filteredVehicleTypes.map((vehicle) => (
                   <option key={vehicle.id} value={vehicle.id}>
                     {vehicle.vehicle_type}
                   </option>

--- a/components/admin/admin-gang-lineage.tsx
+++ b/components/admin/admin-gang-lineage.tsx
@@ -8,6 +8,7 @@ import { toast } from 'sonner';
 import { LuTrash2, LuPlus } from "react-icons/lu";
 import { HiX } from "react-icons/hi";
 import Modal from '@/components/ui/modal';
+import { EditionSelect } from '@/components/edition-select';
 
 type LineageType = 'legacy' | 'affiliation';
 
@@ -15,6 +16,7 @@ interface GangLineage {
   id: string;
   name: string;
   fighter_type_id: string;
+  edition_id?: string | null;
   type: LineageType | string;
   created_at: string;
   updated_at?: string;
@@ -63,6 +65,7 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
   const [selectedGangTypeId, setSelectedGangTypeId] = useState('');
   const [associatedFighterTypeId, setAssociatedFighterTypeId] = useState('');
   const [lineageType, setLineageType] = useState<LineageType | ''>('');
+  const [editionId, setEditionId] = useState('');
   const [fighterTypeAccess, setFighterTypeAccess] = useState<string[]>([]);
   
   
@@ -164,6 +167,7 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
       setSelectedGangLineage(gangLineageDetailsData);
       setGangLineageName(gangLineageDetailsData.name);
       setLineageType(gangLineageDetailsData.type);
+      setEditionId(gangLineageDetailsData.edition_id ?? '');
       setFighterTypeAccess(gangLineageDetailsData.fighter_type_access || []);
       if (gangLineageDetailsData.associated_fighter_type) {
         setSelectedGangTypeId(gangLineageDetailsData.associated_fighter_type.gang_type_id || '');
@@ -171,6 +175,22 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
       setAssociatedFighterTypeId(gangLineageDetailsData.fighter_type_id);
     }
   }
+
+  // Edition is the top-level filter for affiliations (legacies have no edition):
+  // only affiliations of the chosen edition are offered, and saved rows keep it
+  const editionFilteredLineages = selectedType === 'affiliation' && editionId
+    ? filteredGangLineages.filter(lineage => lineage.edition_id === editionId)
+    : filteredGangLineages;
+
+  const handleEditionChange = (newEditionId: string) => {
+    setEditionId(newEditionId);
+    if (newEditionId && selectedGangLineageId) {
+      const lineage = filteredGangLineages.find(l => l.id === selectedGangLineageId);
+      if (lineage && lineage.edition_id !== newEditionId) {
+        setSelectedGangLineageId('');
+      }
+    }
+  };
 
   // Derived: filter fighter types by selected gang type
   const filteredFighterTypes = useMemo(
@@ -211,6 +231,7 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
           name: gangLineageName,
           fighter_type_id: associatedFighterTypeId,
           type: lineageType,
+          edition_id: editionId || null,
           fighter_type_access: fighterTypeAccess
         }),
       });
@@ -252,6 +273,7 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
           name: gangLineageName,
           fighter_type_id: associatedFighterTypeId,
           type: lineageType,
+          edition_id: editionId || null,
           fighter_type_access: fighterTypeAccess
         }),
       });
@@ -357,6 +379,11 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
           <option value="affiliation">Affiliation</option>
         </select>
       </div>
+
+      {/* Only gang_affiliation carries an edition; legacies do not */}
+      {lineageType === 'affiliation' && (
+        <EditionSelect value={editionId} onChange={setEditionId} defaultToCurrent />
+      )}
 
       <div>
         <label className="block text-sm font-medium text-muted-foreground mb-1">
@@ -534,6 +561,11 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
                 </select>
               </div>
 
+              {/* Only gang_affiliation carries an edition; legacies do not */}
+              {selectedType === 'affiliation' && (
+                <EditionSelect value={editionId} onChange={handleEditionChange} defaultToCurrent />
+              )}
+
               <div>
                 <label className="block text-sm font-medium text-muted-foreground mb-1">
                   Select Gang Affiliation or Legacy
@@ -545,14 +577,14 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
                   disabled={isLoading || !selectedType}
                 >
                   <option value="">
-                    {!selectedType 
-                      ? "Select a type first" 
-                      : filteredGangLineages.length === 0 
-                        ? "No lineages available" 
+                    {!selectedType
+                      ? "Select a type first"
+                      : editionFilteredLineages.length === 0
+                        ? "No lineages available"
                         : "Select a gang affiliation or legacy"
                     }
                   </option>
-                  {filteredGangLineages.map((lineage) => (
+                  {editionFilteredLineages.map((lineage) => (
                     <option key={lineage.id} value={lineage.id}>
                       {lineage.name}
                     </option>

--- a/components/admin/admin-injuries.tsx
+++ b/components/admin/admin-injuries.tsx
@@ -7,6 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from 'sonner';
 import { AdminFighterEffects } from "./admin-fighter-effects";
+import { EditionSelect } from '@/components/edition-select';
 import {
   FighterEffectType,
   FighterEffectCategory,
@@ -30,6 +31,7 @@ export function AdminInjuriesGlitchesModal({ onClose, onSubmit }: AdminInjuriesG
   const [selectedCategory, setSelectedCategory] = useState<'injuries' | 'rig-glitches'>('injuries');
   const [selectedEffectId, setSelectedEffectId] = useState('');
   const [effectName, setEffectName] = useState('');
+  const [editionId, setEditionId] = useState('');
   const [isCreateMode, setIsCreateMode] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [fighterEffects, setFighterEffects] = useState<FighterEffectType[]>([]);
@@ -73,6 +75,22 @@ export function AdminInjuriesGlitchesModal({ onClose, onSubmit }: AdminInjuriesG
   // Computed disabled state for form fields
   const isFormDisabled = (!isCreateMode && !selectedEffectId) || isLoading;
 
+  // Edition is the top-level filter: only effects of the chosen edition are
+  // offered for editing, and created/saved effects keep that edition
+  const filteredEffects = editionId
+    ? effects.filter(effect => effect.edition_id === editionId)
+    : effects;
+
+  const handleEditionChange = (newEditionId: string) => {
+    setEditionId(newEditionId);
+    if (newEditionId && selectedEffectId) {
+      const effect = effects.find(e => e.id === selectedEffectId);
+      if (effect && effect.edition_id !== newEditionId) {
+        handleEffectSelect('');
+      }
+    }
+  };
+
   const handleCategoryChange = (newCategory: 'injuries' | 'rig-glitches') => {
     setSelectedCategory(newCategory);
     setSelectedEffectId('');
@@ -92,6 +110,7 @@ export function AdminInjuriesGlitchesModal({ onClose, onSubmit }: AdminInjuriesG
     const effect = effects.find(e => e.id === effectId);
     if (effect) {
       setEffectName(effect.effect_name);
+      setEditionId(effect.edition_id ?? '');
       setIsCreateMode(false);
       // Set the effect for AdminFighterEffects to display modifiers
       setFighterEffects([effect]);
@@ -161,7 +180,8 @@ export function AdminInjuriesGlitchesModal({ onClose, onSubmit }: AdminInjuriesG
           body = JSON.stringify({
             effect_name: effectName,
             fighter_effect_category_id: category.id,
-            type_specific_data: typeSpecificData
+            type_specific_data: typeSpecificData,
+            edition_id: editionId || null
           });
           break;
         case OperationType.UPDATE:
@@ -170,7 +190,8 @@ export function AdminInjuriesGlitchesModal({ onClose, onSubmit }: AdminInjuriesG
           body = JSON.stringify({
             effect_name: effectName,
             fighter_effect_category_id: category.id,
-            type_specific_data: typeSpecificData
+            type_specific_data: typeSpecificData,
+            edition_id: editionId || null
           });
           break;
         case OperationType.DELETE:
@@ -325,6 +346,8 @@ export function AdminInjuriesGlitchesModal({ onClose, onSubmit }: AdminInjuriesG
 
         <div className="px-[10px] py-4">
           <div className="space-y-4">
+            <EditionSelect value={editionId} onChange={handleEditionChange} defaultToCurrent />
+
             {/* Category Selector */}
             <div>
               <label className="block text-sm font-medium text-muted-foreground mb-1">
@@ -362,7 +385,7 @@ export function AdminInjuriesGlitchesModal({ onClose, onSubmit }: AdminInjuriesG
                 disabled={isLoading}
               >
                 <option value="">Select an effect to edit</option>
-                {effects.map((effect) => (
+                {filteredEffects.map((effect) => (
                   <option key={effect.id} value={effect.id}>
                     {effect.effect_name}
                   </option>

--- a/components/admin/admin-scenarios-modal.tsx
+++ b/components/admin/admin-scenarios-modal.tsx
@@ -5,6 +5,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { toast } from 'sonner';
+import { EditionSelect } from '@/components/edition-select';
 
 enum OperationType {
   POST = 'POST',
@@ -16,6 +17,7 @@ interface Scenario {
   id: string;
   scenario_name: string;
   scenario_number: number;
+  edition_id: string | null;
 }
 
 interface AdminScenariosModalProps {
@@ -29,6 +31,7 @@ export function AdminScenariosModal({ onClose, onSubmit }: AdminScenariosModalPr
   const [selectedScenarioId, setSelectedScenarioId] = useState('');
   const [scenarioName, setScenarioName] = useState('');
   const [scenarioNumber, setScenarioNumber] = useState<number | ''>('');
+  const [editionId, setEditionId] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isCreateMode, setIsCreateMode] = useState(false);
 
@@ -44,12 +47,32 @@ export function AdminScenariosModal({ onClose, onSubmit }: AdminScenariosModalPr
 
   const isLoading = isLoadingScenarios || isSubmitting;
 
+  // Edition is the top-level filter: only scenarios of the chosen edition are
+  // offered for editing, and created/saved scenarios keep that edition
+  const filteredScenarios = editionId
+    ? scenarios.filter(s => s.edition_id === editionId)
+    : scenarios;
+
+  const handleEditionChange = (newEditionId: string) => {
+    setEditionId(newEditionId);
+    if (newEditionId && selectedScenarioId) {
+      const scenario = scenarios.find(s => s.id === selectedScenarioId);
+      if (scenario && scenario.edition_id !== newEditionId) {
+        setSelectedScenarioId('');
+        setScenarioName('');
+        setScenarioNumber('');
+        setIsCreateMode(false);
+      }
+    }
+  };
+
   const handleScenarioSelect = (scenarioId: string) => {
     setSelectedScenarioId(scenarioId);
     const scenario = scenarios.find(s => s.id === scenarioId);
     if (scenario) {
       setScenarioName(scenario.scenario_name);
       setScenarioNumber(scenario.scenario_number);
+      setEditionId(scenario.edition_id ?? '');
       setIsCreateMode(false);
     } else {
       // If empty selection, just exit create mode and clear fields
@@ -86,6 +109,7 @@ export function AdminScenariosModal({ onClose, onSubmit }: AdminScenariosModalPr
           body = JSON.stringify({
             scenario_name: scenarioName,
             scenario_number: Number(scenarioNumber),
+            edition_id: editionId || null,
           });
           break;
         case OperationType.UPDATE:
@@ -94,6 +118,7 @@ export function AdminScenariosModal({ onClose, onSubmit }: AdminScenariosModalPr
             id: selectedScenarioId,
             scenario_name: scenarioName,
             scenario_number: Number(scenarioNumber),
+            edition_id: editionId || null,
           });
           break;
         case OperationType.DELETE:
@@ -161,6 +186,8 @@ export function AdminScenariosModal({ onClose, onSubmit }: AdminScenariosModalPr
 
         <div className="px-[10px] py-4">
           <div className="space-y-4">
+            <EditionSelect value={editionId} onChange={handleEditionChange} defaultToCurrent />
+
             <div>
               <div className="flex justify-between items-center mb-1">
                 <label className="block text-sm font-medium text-muted-foreground">
@@ -180,7 +207,7 @@ export function AdminScenariosModal({ onClose, onSubmit }: AdminScenariosModalPr
                 className="w-full p-2 border rounded-md"
               >
                 <option value="">Select a scenario to edit</option>
-                {scenarios
+                {filteredScenarios
                   .sort((a, b) => a.scenario_number - b.scenario_number)
                   .map((scenario) => (
                     <option key={scenario.id} value={scenario.id}>

--- a/components/edition-select.tsx
+++ b/components/edition-select.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Edition } from '@/types/edition';
 
@@ -22,8 +22,13 @@ export function EditionSelect({ value, onChange, defaultToCurrent = false, label
     staleTime: 5 * 60 * 1000,
   });
 
+  // Default only once, when editions first load — never after, so an explicit
+  // blank selection ("all editions" in filter contexts) sticks
+  const hasDefaulted = useRef(false);
   useEffect(() => {
-    if (!defaultToCurrent || value || editions.length === 0) return;
+    if (hasDefaulted.current || editions.length === 0) return;
+    hasDefaulted.current = true;
+    if (!defaultToCurrent || value) return;
     const current = editions.find(edition => edition.is_current);
     if (current) onChange(current.id);
   }, [defaultToCurrent, value, editions, onChange]);

--- a/components/edition-select.tsx
+++ b/components/edition-select.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Edition } from '@/types/edition';
+
+interface EditionSelectProps {
+  value: string;
+  onChange: (editionId: string) => void;
+  defaultToCurrent?: boolean;
+  label?: string;
+}
+
+export function EditionSelect({ value, onChange, defaultToCurrent = false, label = 'Edition' }: EditionSelectProps) {
+  const { data: editions = [] } = useQuery<Edition[]>({
+    queryKey: ['editions'],
+    queryFn: async () => {
+      const response = await fetch('/api/editions');
+      if (!response.ok) throw new Error('Failed to fetch editions');
+      return response.json();
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+  useEffect(() => {
+    if (!defaultToCurrent || value || editions.length === 0) return;
+    const current = editions.find(edition => edition.is_current);
+    if (current) onChange(current.id);
+  }, [defaultToCurrent, value, editions, onChange]);
+
+  return (
+    <div>
+      <label className="block text-sm font-medium text-muted-foreground mb-1">
+        {label}
+      </label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full p-2 border rounded-md"
+      >
+        <option value="">Select edition</option>
+        {editions.map((edition) => (
+          <option key={edition.id} value={edition.id}>
+            {edition.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/supabase/migrations/20260730120000_add_fighter_types_edition_id.sql
+++ b/supabase/migrations/20260730120000_add_fighter_types_edition_id.sql
@@ -1,0 +1,57 @@
+-- fighter_types gets a real edition_id even though it is derivable via
+-- gang_type_id; the composite FK below prevents the two from drifting apart.
+-- The value is always derived server-side from the chosen gang type, never
+-- accepted from clients.
+
+-- 1. FK target: unique over (gang_type_id, edition_id). gang_type_id alone is
+--    already unique so this adds no new restriction; a nullable edition_id is a
+--    valid FK target (MATCH SIMPLE skips NULL rows on the referencing side).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'gang_types_gang_type_id_edition_id_key'
+      AND conrelid = 'public.gang_types'::regclass
+  ) THEN
+    ALTER TABLE public.gang_types
+      ADD CONSTRAINT gang_types_gang_type_id_edition_id_key
+      UNIQUE (gang_type_id, edition_id);
+  END IF;
+END $$;
+
+-- 2. Column + direct editions FK + index, mirroring the other root tables.
+ALTER TABLE public.fighter_types
+  ADD COLUMN IF NOT EXISTS edition_id uuid
+    REFERENCES public.editions(id) ON DELETE RESTRICT;
+
+CREATE INDEX IF NOT EXISTS fighter_types_edition_id_idx
+  ON public.fighter_types (edition_id);
+
+-- 3. Backfill from the parent gang type BEFORE adding the composite FK.
+UPDATE public.fighter_types ft
+SET edition_id = gt.edition_id
+FROM public.gang_types gt
+WHERE gt.gang_type_id = ft.gang_type_id
+  AND ft.edition_id IS NULL;
+
+-- 4. Composite FK: whenever fighter_types.edition_id is set, it must equal the
+--    parent gang type's edition. ON UPDATE CASCADE keeps children in sync if a
+--    gang type is ever moved to another edition. Rows whose edition_id is still
+--    NULL stay unenforced (MATCH SIMPLE) until the column goes NOT NULL.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'fighter_types_gang_type_edition_fkey'
+      AND conrelid = 'public.fighter_types'::regclass
+  ) THEN
+    ALTER TABLE public.fighter_types
+      ADD CONSTRAINT fighter_types_gang_type_edition_fkey
+      FOREIGN KEY (gang_type_id, edition_id)
+      REFERENCES public.gang_types (gang_type_id, edition_id)
+      ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+COMMENT ON COLUMN public.fighter_types.edition_id IS
+  'Denormalized from gang_types via the composite FK on (gang_type_id, edition_id); derived server-side from the chosen gang type, never accepted from clients.';

--- a/types/campaign.ts
+++ b/types/campaign.ts
@@ -171,5 +171,6 @@ export interface CampaignType {
   campaign_type_name: string;
   image_url?: string | null;
   trading_posts?: string[] | null;
+  edition_id?: string | null;
   campaign_type_resources?: CampaignTypeResource[];
 }

--- a/types/edition.ts
+++ b/types/edition.ts
@@ -1,0 +1,7 @@
+export interface Edition {
+  id: string;
+  name: string;
+  slug: string;
+  is_current: boolean;
+  released_at: string | null;
+}

--- a/types/fighter-effect.ts
+++ b/types/fighter-effect.ts
@@ -92,6 +92,7 @@ export interface FighterEffectType {
   type_specific_data: TypeSpecificData | null;
   modifiers: FighterEffectTypeModifier[];
   sort_order?: number | null;
+  edition_id?: string | null;
   fighter_effect_categories?: FighterEffectCategory;
 }
 

--- a/types/gang.ts
+++ b/types/gang.ts
@@ -14,6 +14,7 @@ export interface GangType {
   gang_type: string;
   alignment: string;
   note?: string;
+  edition_id?: string | null;
   gang_origin_category_id?: string;
   available_origins?: GangOrigin[];
 }


### PR DESCRIPTION
PR to add support for editions in the admin page. A new edition selection component was added, types and API routes adjusted. The selection uses is_current to pre-select the current edition.