### PR TITLE
Drop the legacy single-value fighter class columns

### DIFF
--- a/components/gang/gang.tsx
+++ b/components/gang/gang.tsx
@@ -312,7 +312,7 @@ export default function Gang({
     );
   }, [fighters]);
 
-  // Fighters composition for tooltip: group by fighter_type and fighter_class
+  // Fighters composition for tooltip: group by fighter_type and fighter_classes
   const fighterTypeClassCounts = useMemo(() => {
     const counts = new Map<string, { label: string; count: number; classKey: string }>();
     for (const fighter of activeFighters) {

--- a/supabase/functions/get_available_skills.sql
+++ b/supabase/functions/get_available_skills.sql
@@ -145,7 +145,6 @@ BEGIN
     )
     SELECT jsonb_build_object(
         'fighter_id', get_available_skills.fighter_id,
-        'fighter_class', v_fighter_classes->>0,
         'fighter_classes', v_fighter_classes,
         'skills', COALESCE(
             jsonb_agg(
@@ -153,7 +152,6 @@ BEGIN
                     'skill_id', a.skill_id,
                     'skill_name', a.skill_name,
                     'is_custom', a.is_custom,
-                    'fighter_class', v_fighter_classes->>0,
                     'skill_type_id', a.skill_type_id,
                     'skill_type_name', a.skill_type_name,
                     'effective_access_level', a.effective_access_level,

--- a/supabase/functions/get_fighter_available_advancements.sql
+++ b/supabase/functions/get_fighter_available_advancements.sql
@@ -23,7 +23,7 @@ BEGIN
     RAISE EXCEPTION 'Fighter not found with ID %', get_fighter_available_advancements.fighter_id;
   END IF;
   
-  -- Determine if the fighter uses flat costs based on fighter_class
+  -- Determine if the fighter uses flat costs based on their classes
   -- Only Gangers and Exotic Beasts use flat costs
   v_uses_flat_cost :=
     v_fighter_classes ?| array['Ganger', 'Exotic Beast'];
@@ -128,7 +128,6 @@ BEGIN
   SELECT jsonb_build_object(
     'fighter_id', get_fighter_available_advancements.fighter_id,
     'current_xp', v_fighter_xp,
-    'fighter_class', v_fighter_classes->>0,
     'fighter_classes', v_fighter_classes,
     'uses_flat_cost', v_uses_flat_cost,
     -- Ganger/Exotic Beast: Specialist table row (random Primary skill) — same flat costs as other ganger advances

--- a/supabase/functions/get_fighter_types_with_cost.sql
+++ b/supabase/functions/get_fighter_types_with_cost.sql
@@ -13,12 +13,6 @@ CREATE OR REPLACE FUNCTION get_fighter_types_with_cost(
 RETURNS TABLE (
     id uuid,
     fighter_type text,
-    -- Legacy single-value columns, kept so the previous frontend build keeps
-    -- working while this RPC is deployed ahead of the app. Derived from
-    -- fighter_classes rather than the old join; dropped in the follow-up that
-    -- drops the underlying columns.
-    fighter_class text,
-    fighter_class_id uuid,
     fighter_classes jsonb,
     gang_type text,
     cost numeric,
@@ -57,11 +51,6 @@ BEGIN
     SELECT
         ft.id,
         ft.fighter_type,
-        -- COALESCE to '' so the previous build's unguarded
-        -- fighter_class.toLowerCase() cannot throw on a row with an empty
-        -- fighter_classes array (such rows were hidden by the old INNER JOIN).
-        COALESCE(ft.fighter_classes->>0, '') AS fighter_class,
-        ft.fighter_class_id,
         ft.fighter_classes,
         ft.gang_type,
         -- Use adjusted_cost if available, otherwise use original cost

--- a/supabase/functions/get_gang_details.sql
+++ b/supabase/functions/get_gang_details.sql
@@ -53,7 +53,6 @@ BEGIN
            f.label,
            f.fighter_type,
            f.fighter_type_id,
-           f.fighter_class,
            f.fighter_classes,
            f.fighter_sub_type_id,
            f.xp,
@@ -585,7 +584,6 @@ BEGIN
            f.label,
            f.fighter_type,
            f.fighter_type_id,
-           f.fighter_class,
            f.fighter_classes,
            json_build_object(
              'fighter_sub_type', fst.sub_type_name,
@@ -732,7 +730,6 @@ BEGIN
                'fighter_name', cf.fighter_name,
                'label', cf.label,
                'fighter_type', cf.fighter_type,
-               'fighter_class', cf.fighter_class,
                'fighter_classes', cf.fighter_classes,
                'fighter_sub_type', cf.fighter_sub_type,
                'alliance_crew_name', cf.alliance_crew_name,

--- a/supabase/migrations/20260802180000_drop_legacy_fighter_class_columns.sql
+++ b/supabase/migrations/20260802180000_drop_legacy_fighter_class_columns.sql
@@ -28,10 +28,14 @@ BEGIN
       SELECT 1 FROM information_schema.columns
       WHERE table_schema = 'public' AND table_name = t AND column_name = 'fighter_class'
     ) THEN
+      -- NULLIF mirrors 20260801120000's backfill, which treated an empty string
+      -- as "no class". Without it a row holding '' would block the drop forever:
+      -- the guard would flag it, but re-running that backfill skips '' too, so
+      -- there would be no way to clear it.
       EXECUTE format(
         'SELECT count(*) FROM public.%I
           WHERE fighter_classes = ''[]''::jsonb
-            AND (fighter_class IS NOT NULL OR fighter_class_id IS NOT NULL)', t
+            AND (NULLIF(fighter_class, '''') IS NOT NULL OR fighter_class_id IS NOT NULL)', t
       ) INTO v_n;
 
       IF v_n > 0 THEN
@@ -49,8 +53,8 @@ BEGIN
   ) THEN
     EXECUTE
       'SELECT count(*) FROM public.fighter_ooa_records
-        WHERE (causing_fighter_classes = ''[]''::jsonb AND causing_fighter_class IS NOT NULL)
-           OR (injured_fighter_classes = ''[]''::jsonb AND injured_fighter_class IS NOT NULL)'
+        WHERE (causing_fighter_classes = ''[]''::jsonb AND NULLIF(causing_fighter_class, '''') IS NOT NULL)
+           OR (injured_fighter_classes = ''[]''::jsonb AND NULLIF(injured_fighter_class, '''') IS NOT NULL)'
       INTO v_n;
 
     IF v_n > 0 THEN
@@ -70,7 +74,26 @@ END $$;
 -- supabase/functions/, has no callers (get_fighter_types_with_cost supersedes
 -- it), and INNER JOINs fighter_classes on ft.fighter_class_id — so it would be
 -- permanently broken by the drops below. Recoverable from the schema snapshot.
-DROP FUNCTION IF EXISTS public.get_add_fighter_details(uuid, uuid);
+--
+-- The signature is resolved from pg_proc rather than written out. Because the
+-- function is untracked, its argument list is only known from the schema
+-- snapshot; hardcoding it would mean a drifted signature silently matched
+-- nothing under IF EXISTS, leaving the broken function behind. This drops
+-- whatever overloads actually exist, and no-ops cleanly when there are none.
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT oid::regprocedure AS signature
+    FROM pg_proc
+    WHERE pronamespace = 'public'::regnamespace
+      AND proname = 'get_add_fighter_details'
+  LOOP
+    EXECUTE format('DROP FUNCTION %s', r.signature);
+    RAISE NOTICE 'Dropped function %', r.signature::text;
+  END LOOP;
+END $$;
 
 -- 3. Drop the legacy class columns.
 -- Each column's own index and FK go with it; that is not a cascade and removes

--- a/supabase/migrations/20260802180000_drop_legacy_fighter_class_columns.sql
+++ b/supabase/migrations/20260802180000_drop_legacy_fighter_class_columns.sql
@@ -1,0 +1,113 @@
+-- Phase 2: remove the single-value fighter class columns.
+--
+-- 20260801120000 added fighter_classes jsonb, backfilled it, and moved all
+-- application code onto the array. The old columns stayed behind so a rollback
+-- remained possible while the new frontend rolled out. That window has closed.
+--
+-- This migration deletes no rows. It contains only guards, DROP FUNCTION,
+-- DROP COLUMN, DROP INDEX/CONSTRAINT and COMMENT statements, and deliberately
+-- uses no CASCADE anywhere: plain DROP (RESTRICT) means that if anything
+-- unexpectedly depends on one of these columns, the statement fails loudly
+-- rather than quietly removing the dependent object too.
+
+-- 1. Refuse to drop anything if it would destroy the only copy of a class.
+-- A row is at risk when a legacy column still holds a value but the Phase 1
+-- backfill left fighter_classes empty.
+-- The checks run through dynamic SQL behind a column-existence test so that
+-- re-running this migration after the columns are gone is a no-op rather than a
+-- "column does not exist" error.
+DO $$
+DECLARE
+  t        text;
+  v_n      bigint;
+  v_total  bigint := 0;
+  v_detail text   := '';
+BEGIN
+  FOREACH t IN ARRAY ARRAY['fighters', 'fighter_types', 'custom_fighter_types'] LOOP
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = t AND column_name = 'fighter_class'
+    ) THEN
+      EXECUTE format(
+        'SELECT count(*) FROM public.%I
+          WHERE fighter_classes = ''[]''::jsonb
+            AND (fighter_class IS NOT NULL OR fighter_class_id IS NOT NULL)', t
+      ) INTO v_n;
+
+      IF v_n > 0 THEN
+        v_total  := v_total + v_n;
+        v_detail := v_detail || format('%s: %s; ', t, v_n);
+      END IF;
+    END IF;
+  END LOOP;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'fighter_ooa_records'
+      AND column_name = 'causing_fighter_class'
+  ) THEN
+    EXECUTE
+      'SELECT count(*) FROM public.fighter_ooa_records
+        WHERE (causing_fighter_classes = ''[]''::jsonb AND causing_fighter_class IS NOT NULL)
+           OR (injured_fighter_classes = ''[]''::jsonb AND injured_fighter_class IS NOT NULL)'
+      INTO v_n;
+
+    IF v_n > 0 THEN
+      v_total  := v_total + v_n;
+      v_detail := v_detail || format('fighter_ooa_records: %s; ', v_n);
+    END IF;
+  END IF;
+
+  IF v_total > 0 THEN
+    RAISE EXCEPTION
+      'Refusing to drop legacy class columns: % row(s) hold a class only in the old columns (%). Re-run the 20260801120000 backfill first.',
+      v_total, v_detail;
+  END IF;
+END $$;
+
+-- 2. Drop the orphaned pre-JSONB function. It is not tracked in
+-- supabase/functions/, has no callers (get_fighter_types_with_cost supersedes
+-- it), and INNER JOINs fighter_classes on ft.fighter_class_id — so it would be
+-- permanently broken by the drops below. Recoverable from the schema snapshot.
+DROP FUNCTION IF EXISTS public.get_add_fighter_details(uuid, uuid);
+
+-- 3. Drop the legacy class columns.
+-- Each column's own index and FK go with it; that is not a cascade and removes
+-- no rows. Note skill_access_archetypes.fighter_class_id is deliberately NOT
+-- touched: it is a real FK to the fighter_classes table, used by archetypes.
+ALTER TABLE public.fighters
+  DROP COLUMN IF EXISTS fighter_class,
+  DROP COLUMN IF EXISTS fighter_class_id;
+
+ALTER TABLE public.fighter_types
+  DROP COLUMN IF EXISTS fighter_class,
+  DROP COLUMN IF EXISTS fighter_class_id;
+
+ALTER TABLE public.custom_fighter_types
+  DROP COLUMN IF EXISTS fighter_class,
+  DROP COLUMN IF EXISTS fighter_class_id;
+
+ALTER TABLE public.fighter_ooa_records
+  DROP COLUMN IF EXISTS causing_fighter_class,
+  DROP COLUMN IF EXISTS injured_fighter_class;
+
+-- 4. Drop fighter_classes.slug and the objects that exist only for it.
+-- Nothing ever read slug. Its one real job — one row per class per edition —
+-- moved to fighter_classes_edition_class_name_idx in 20260801120000.
+DROP INDEX IF EXISTS public.fighter_classes_edition_slug_idx;
+
+ALTER TABLE public.fighter_classes
+  DROP CONSTRAINT IF EXISTS fighter_classes_slug_format_chk;
+
+ALTER TABLE public.fighter_classes
+  DROP COLUMN IF EXISTS slug;
+
+-- 5. Record where class identity lives now. The old slug column comment said to
+-- match on slug and never on class_name; that column is gone and the advice is
+-- inverted.
+COMMENT ON TABLE public.fighter_classes IS
+  'Fighter roles (Leader, Champion, Ganger, ...). The new edition rulebook calls these "Subtypes"; the display label is resolved per edition in app code. NOT related to fighter_sub_types. One row per class per edition, matched across editions on class_name.';
+
+COMMENT ON COLUMN public.fighter_classes.class_name IS
+  'Class identity. Unique per edition (fighter_classes_edition_class_name_idx) and the value stored in fighters/fighter_types.fighter_classes; match on this across editions.';

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -72,16 +72,16 @@ ON CONFLICT (gang_type_id) DO NOTHING;
 -- 6. FIGHTER CLASSES
 -- ============================================================================
 -- Reference list of valid class names; fighters/fighter_types store the names
--- themselves in their fighter_classes JSONB array. slug is NOT NULL and is the
--- stable key that matches a class across editions.
-INSERT INTO public.fighter_classes (id, class_name, slug, created_at) VALUES
-('e4988356-d580-4f85-8d27-ec604d917d53', 'Leader', 'leader', now()),
-('fe93ecdb-390b-4b31-8650-a25a90d427a5', 'Champion', 'champion', now()),
-('d53f7381-09c2-48f3-b324-2199c5128684', 'Ganger', 'ganger', now()),
-('fcd056a9-b219-48d8-ad61-e838091cc4da', 'Juve', 'juve', now()),
-('d11d15a8-07ea-4a5a-beae-35ddea16e544', 'Specialist', 'specialist', now()),
-('bb723bee-883c-4e84-9136-be30ed195023', 'Exotic Beast', 'exotic_beast', now()),
-('9e310c58-5276-4758-bc9f-be010ac69457', 'Bounty Hunter', 'bounty_hunter', now())
+-- themselves in their fighter_classes JSONB array. class_name is the identity,
+-- unique per edition.
+INSERT INTO public.fighter_classes (id, class_name, created_at) VALUES
+('e4988356-d580-4f85-8d27-ec604d917d53', 'Leader', now()),
+('fe93ecdb-390b-4b31-8650-a25a90d427a5', 'Champion', now()),
+('d53f7381-09c2-48f3-b324-2199c5128684', 'Ganger', now()),
+('fcd056a9-b219-48d8-ad61-e838091cc4da', 'Juve', now()),
+('d11d15a8-07ea-4a5a-beae-35ddea16e544', 'Specialist', now()),
+('bb723bee-883c-4e84-9136-be30ed195023', 'Exotic Beast', now()),
+('9e310c58-5276-4758-bc9f-be010ac69457', 'Bounty Hunter', now())
 ON CONFLICT (id) DO NOTHING;
 
 -- Migrations backfill existing classes onto n23, but that runs before this file,
@@ -94,11 +94,12 @@ WHERE edition_id IS NULL;
 
 -- Beast and Pet are N26 classes, so they are scoped to that edition rather than
 -- left edition-less: fighter_classes holds one row per class per edition. The
--- edition id is resolved by slug because migrations seed it with a generated uuid.
-INSERT INTO public.fighter_classes (class_name, slug, edition_id)
-SELECT v.class_name, v.slug, e.id
+-- edition id is resolved by its slug because migrations seed it with a
+-- generated uuid.
+INSERT INTO public.fighter_classes (class_name, edition_id)
+SELECT v.class_name, e.id
 FROM public.editions e
-CROSS JOIN (VALUES ('Beast', 'beast'), ('Pet', 'pet')) AS v(class_name, slug)
+CROSS JOIN (VALUES ('Beast'), ('Pet')) AS v(class_name)
 WHERE e.slug = 'n26'
   AND NOT EXISTS (
     SELECT 1 FROM public.fighter_classes fc
@@ -243,57 +244,57 @@ ON CONFLICT (id) DO NOTHING;
 -- 16. FIGHTER TYPES CONFIGURATION (ORLOCK AND CAWDOR)
 -- ============================================================================
 -- House Orlock Fighter Types
-INSERT INTO public.fighter_types (id, gang_type_id, gang_type, fighter_type, cost, movement, weapon_skill, ballistic_skill, strength, toughness, wounds, initiative, leadership, cool, willpower, intelligence, attacks, fighter_class, fighter_class_id, fighter_classes, free_skill, is_gang_addition, created_at) VALUES
-('01111111-1111-1111-1111-111111111111', 'b86a0a06-4f47-4c78-8d04-fb7b7042c14e', 'House Orlock', 'Road Boss', 120, 5, 3, 3, 3, 4, 2, 4, 4, 5, 5, 5, 2, 'Leader', 'e4988356-d580-4f85-8d27-ec604d917d53', '["Leader"]', true, false, now()),
-('02222222-2222-2222-2222-222222222222', 'b86a0a06-4f47-4c78-8d04-fb7b7042c14e', 'House Orlock', 'Road Captain', 95, 5, 3, 3, 3, 4, 2, 4, 5, 6, 6, 6, 2, 'Champion', 'fe93ecdb-390b-4b31-8650-a25a90d427a5', '["Champion"]', true, false, now()),
-('03333333-3333-3333-3333-333333333333', 'b86a0a06-4f47-4c78-8d04-fb7b7042c14e', 'House Orlock', 'Wrecker', 60, 5, 4, 4, 3, 3, 1, 4, 6, 7, 7, 7, 1, 'Specialist', 'd11d15a8-07ea-4a5a-beae-35ddea16e544', '["Specialist"]', false, false, now()),
-('04444444-4444-4444-4444-444444444444', 'b86a0a06-4f47-4c78-8d04-fb7b7042c14e', 'House Orlock', 'Gunner', 55, 5, 4, 4, 3, 3, 1, 4, 6, 7, 7, 7, 1, 'Ganger', 'd53f7381-09c2-48f3-b324-2199c5128684', '["Ganger"]', false, false, now()),
-('05555555-5555-5555-5555-555555555555', 'b86a0a06-4f47-4c78-8d04-fb7b7042c14e', 'House Orlock', 'Greenhorn', 30, 6, 5, 5, 3, 3, 1, 3, 7, 8, 8, 8, 1, 'Juve', 'fcd056a9-b219-48d8-ad61-e838091cc4da', '["Juve"]', false, false, now())
+INSERT INTO public.fighter_types (id, gang_type_id, gang_type, fighter_type, cost, movement, weapon_skill, ballistic_skill, strength, toughness, wounds, initiative, leadership, cool, willpower, intelligence, attacks, fighter_classes, free_skill, is_gang_addition, created_at) VALUES
+('01111111-1111-1111-1111-111111111111', 'b86a0a06-4f47-4c78-8d04-fb7b7042c14e', 'House Orlock', 'Road Boss', 120, 5, 3, 3, 3, 4, 2, 4, 4, 5, 5, 5, 2, '["Leader"]', true, false, now()),
+('02222222-2222-2222-2222-222222222222', 'b86a0a06-4f47-4c78-8d04-fb7b7042c14e', 'House Orlock', 'Road Captain', 95, 5, 3, 3, 3, 4, 2, 4, 5, 6, 6, 6, 2, '["Champion"]', true, false, now()),
+('03333333-3333-3333-3333-333333333333', 'b86a0a06-4f47-4c78-8d04-fb7b7042c14e', 'House Orlock', 'Wrecker', 60, 5, 4, 4, 3, 3, 1, 4, 6, 7, 7, 7, 1, '["Specialist"]', false, false, now()),
+('04444444-4444-4444-4444-444444444444', 'b86a0a06-4f47-4c78-8d04-fb7b7042c14e', 'House Orlock', 'Gunner', 55, 5, 4, 4, 3, 3, 1, 4, 6, 7, 7, 7, 1, '["Ganger"]', false, false, now()),
+('05555555-5555-5555-5555-555555555555', 'b86a0a06-4f47-4c78-8d04-fb7b7042c14e', 'House Orlock', 'Greenhorn', 30, 6, 5, 5, 3, 3, 1, 3, 7, 8, 8, 8, 1, '["Juve"]', false, false, now())
 ON CONFLICT (id) DO NOTHING;
 
 -- House Cawdor Fighter Types
-INSERT INTO public.fighter_types (id, gang_type_id, gang_type, fighter_type, cost, movement, weapon_skill, ballistic_skill, strength, toughness, wounds, initiative, leadership, cool, willpower, intelligence, attacks, fighter_class, fighter_class_id, fighter_classes, free_skill, is_gang_addition, created_at) VALUES
-('c1111111-1111-1111-1111-111111111111', 'c0a579a9-ac5e-4289-96db-43f87537847b', 'House Cawdor', 'Word Keeper', 120, 5, 3, 3, 3, 4, 2, 4, 4, 5, 5, 5, 2, 'Leader', 'e4988356-d580-4f85-8d27-ec604d917d53', '["Leader"]', true, false, now()),
-('c2222222-2222-2222-2222-222222222222', 'c0a579a9-ac5e-4289-96db-43f87537847b', 'House Cawdor', 'Priest/Deacon', 95, 5, 3, 3, 3, 4, 2, 4, 5, 6, 6, 6, 2, 'Champion', 'fe93ecdb-390b-4b31-8650-a25a90d427a5', '["Champion"]', true, false, now()),
-('c3333333-3333-3333-3333-333333333333', 'c0a579a9-ac5e-4289-96db-43f87537847b', 'House Cawdor', 'Firebrand', 60, 5, 4, 4, 3, 3, 1, 4, 6, 7, 7, 7, 1, 'Specialist', 'd11d15a8-07ea-4a5a-beae-35ddea16e544', '["Specialist"]', false, false, now()),
-('c4444444-4444-4444-4444-444444444444', 'c0a579a9-ac5e-4289-96db-43f87537847b', 'House Cawdor', 'Brethren', 55, 5, 4, 4, 3, 3, 1, 4, 6, 7, 7, 7, 1, 'Ganger', 'd53f7381-09c2-48f3-b324-2199c5128684', '["Ganger"]', false, false, now()),
-('c5555555-5555-5555-5555-555555555555', 'c0a579a9-ac5e-4289-96db-43f87537847b', 'House Cawdor', 'Bonepicker', 30, 6, 5, 5, 3, 3, 1, 3, 7, 8, 8, 8, 1, 'Juve', 'fcd056a9-b219-48d8-ad61-e838091cc4da', '["Juve"]', false, false, now()),
-('c6666666-6666-6666-6666-666666666666', 'c0a579a9-ac5e-4289-96db-43f87537847b', 'House Cawdor', 'Sheenbird', 90, 6, 4, 5, 3, 3, 1, 3, 7, 7, 8, 8, 2, 'Exotic Beast', 'bb723bee-883c-4e84-9136-be30ed195023', '["Exotic Beast"]', false, false, now())
+INSERT INTO public.fighter_types (id, gang_type_id, gang_type, fighter_type, cost, movement, weapon_skill, ballistic_skill, strength, toughness, wounds, initiative, leadership, cool, willpower, intelligence, attacks, fighter_classes, free_skill, is_gang_addition, created_at) VALUES
+('c1111111-1111-1111-1111-111111111111', 'c0a579a9-ac5e-4289-96db-43f87537847b', 'House Cawdor', 'Word Keeper', 120, 5, 3, 3, 3, 4, 2, 4, 4, 5, 5, 5, 2, '["Leader"]', true, false, now()),
+('c2222222-2222-2222-2222-222222222222', 'c0a579a9-ac5e-4289-96db-43f87537847b', 'House Cawdor', 'Priest/Deacon', 95, 5, 3, 3, 3, 4, 2, 4, 5, 6, 6, 6, 2, '["Champion"]', true, false, now()),
+('c3333333-3333-3333-3333-333333333333', 'c0a579a9-ac5e-4289-96db-43f87537847b', 'House Cawdor', 'Firebrand', 60, 5, 4, 4, 3, 3, 1, 4, 6, 7, 7, 7, 1, '["Specialist"]', false, false, now()),
+('c4444444-4444-4444-4444-444444444444', 'c0a579a9-ac5e-4289-96db-43f87537847b', 'House Cawdor', 'Brethren', 55, 5, 4, 4, 3, 3, 1, 4, 6, 7, 7, 7, 1, '["Ganger"]', false, false, now()),
+('c5555555-5555-5555-5555-555555555555', 'c0a579a9-ac5e-4289-96db-43f87537847b', 'House Cawdor', 'Bonepicker', 30, 6, 5, 5, 3, 3, 1, 3, 7, 8, 8, 8, 1, '["Juve"]', false, false, now()),
+('c6666666-6666-6666-6666-666666666666', 'c0a579a9-ac5e-4289-96db-43f87537847b', 'House Cawdor', 'Sheenbird', 90, 6, 4, 5, 3, 3, 1, 3, 7, 7, 8, 8, 2, '["Exotic Beast"]', false, false, now())
 ON CONFLICT (id) DO NOTHING;
 
 -- House Delaque Fighter Types
-INSERT INTO public.fighter_types (id, gang_type_id, gang_type, fighter_type, cost, movement, weapon_skill, ballistic_skill, strength, toughness, wounds, initiative, leadership, cool, willpower, intelligence, attacks, fighter_class, fighter_class_id, fighter_classes, free_skill, is_gang_addition, created_at) VALUES
-('d1111111-1111-1111-1111-111111111111', '2c67ccbc-e103-433c-9535-bc6f9435fa38', 'House Delaque', 'Master of Shadows', 120, 5, 3, 3, 3, 3, 2, 3, 4, 5, 5, 5, 2, 'Leader', 'e4988356-d580-4f85-8d27-ec604d917d53', '["Leader"]', true, false, now()),
-('d2222222-2222-2222-2222-222222222222', '2c67ccbc-e103-433c-9535-bc6f9435fa38', 'House Delaque', 'Phantom', 95, 5, 3, 3, 3, 3, 2, 3, 5, 6, 6, 6, 2, 'Champion', 'fe93ecdb-390b-4b31-8650-a25a90d427a5', '["Champion"]', true, false, now()),
-('d3333333-3333-3333-3333-333333333333', '2c67ccbc-e103-433c-9535-bc6f9435fa38', 'House Delaque', 'Ghost (Specialist)', 50, 5, 4, 4, 3, 3, 1, 4, 6, 7, 7, 7, 1, 'Specialist', 'd11d15a8-07ea-4a5a-beae-35ddea16e544', '["Specialist"]', false, false, now()),
-('d4444444-4444-4444-4444-444444444444', '2c67ccbc-e103-433c-9535-bc6f9435fa38', 'House Delaque', 'Ghost', 50, 5, 4, 4, 3, 3, 1, 4, 6, 7, 7, 7, 1, 'Ganger', 'd53f7381-09c2-48f3-b324-2199c5128684', '["Ganger"]', false, false, now()),
-('d5555555-5555-5555-5555-555555555555', '2c67ccbc-e103-433c-9535-bc6f9435fa38', 'House Delaque', 'Shadow', 30, 6, 4, 5, 3, 3, 1, 3, 7, 8, 8, 8, 1, 'Juve', 'fcd056a9-b219-48d8-ad61-e838091cc4da', '["Juve"]', false, false, now())
+INSERT INTO public.fighter_types (id, gang_type_id, gang_type, fighter_type, cost, movement, weapon_skill, ballistic_skill, strength, toughness, wounds, initiative, leadership, cool, willpower, intelligence, attacks, fighter_classes, free_skill, is_gang_addition, created_at) VALUES
+('d1111111-1111-1111-1111-111111111111', '2c67ccbc-e103-433c-9535-bc6f9435fa38', 'House Delaque', 'Master of Shadows', 120, 5, 3, 3, 3, 3, 2, 3, 4, 5, 5, 5, 2, '["Leader"]', true, false, now()),
+('d2222222-2222-2222-2222-222222222222', '2c67ccbc-e103-433c-9535-bc6f9435fa38', 'House Delaque', 'Phantom', 95, 5, 3, 3, 3, 3, 2, 3, 5, 6, 6, 6, 2, '["Champion"]', true, false, now()),
+('d3333333-3333-3333-3333-333333333333', '2c67ccbc-e103-433c-9535-bc6f9435fa38', 'House Delaque', 'Ghost (Specialist)', 50, 5, 4, 4, 3, 3, 1, 4, 6, 7, 7, 7, 1, '["Specialist"]', false, false, now()),
+('d4444444-4444-4444-4444-444444444444', '2c67ccbc-e103-433c-9535-bc6f9435fa38', 'House Delaque', 'Ghost', 50, 5, 4, 4, 3, 3, 1, 4, 6, 7, 7, 7, 1, '["Ganger"]', false, false, now()),
+('d5555555-5555-5555-5555-555555555555', '2c67ccbc-e103-433c-9535-bc6f9435fa38', 'House Delaque', 'Shadow', 30, 6, 4, 5, 3, 3, 1, 3, 7, 8, 8, 8, 1, '["Juve"]', false, false, now())
 ON CONFLICT (id) DO NOTHING;
 
 -- House Escher Fighter Types
-INSERT INTO public.fighter_types (id, gang_type_id, gang_type, fighter_type, cost, movement, weapon_skill, ballistic_skill, strength, toughness, wounds, initiative, leadership, cool, willpower, intelligence, attacks, fighter_class, fighter_class_id, fighter_classes, free_skill, is_gang_addition, created_at) VALUES
-('e1111111-1111-1111-1111-111111111111', 'd66feb66-7a3b-4306-9d0b-58725b72ee0d', 'House Escher', 'Gang Queen', 120, 5, 3, 3, 3, 3, 2, 3, 4, 5, 6, 6, 2, 'Leader', 'e4988356-d580-4f85-8d27-ec604d917d53', '["Leader"]', true, false, now()),
-('e2222222-2222-2222-2222-222222222222', 'd66feb66-7a3b-4306-9d0b-58725b72ee0d', 'House Escher', 'Matriarch', 95, 5, 3, 3, 3, 3, 2, 3, 5, 6, 7, 7, 2, 'Champion', 'fe93ecdb-390b-4b31-8650-a25a90d427a5', '["Champion"]', true, false, now()),
-('e3333333-3333-3333-3333-333333333333', 'd66feb66-7a3b-4306-9d0b-58725b72ee0d', 'House Escher', 'Sister (Specialist)', 50, 5, 4, 4, 3, 3, 1, 3, 6, 7, 8, 7, 1, 'Specialist', 'd11d15a8-07ea-4a5a-beae-35ddea16e544', '["Specialist"]', false, false, now()),
-('e4444444-4444-4444-4444-444444444444', 'd66feb66-7a3b-4306-9d0b-58725b72ee0d', 'House Escher', 'Sister', 50, 5, 4, 4, 3, 3, 1, 3, 6, 7, 8, 7, 1, 'Ganger', 'd53f7381-09c2-48f3-b324-2199c5128684', '["Ganger"]', false, false, now()),
-('e5555555-5555-5555-5555-555555555555', 'd66feb66-7a3b-4306-9d0b-58725b72ee0d', 'House Escher', 'Little Sister', 30, 6, 4, 5, 3, 3, 1, 3, 7, 8, 8, 8, 1, 'Juve', 'fcd056a9-b219-48d8-ad61-e838091cc4da', '["Juve"]', false, false, now())
+INSERT INTO public.fighter_types (id, gang_type_id, gang_type, fighter_type, cost, movement, weapon_skill, ballistic_skill, strength, toughness, wounds, initiative, leadership, cool, willpower, intelligence, attacks, fighter_classes, free_skill, is_gang_addition, created_at) VALUES
+('e1111111-1111-1111-1111-111111111111', 'd66feb66-7a3b-4306-9d0b-58725b72ee0d', 'House Escher', 'Gang Queen', 120, 5, 3, 3, 3, 3, 2, 3, 4, 5, 6, 6, 2, '["Leader"]', true, false, now()),
+('e2222222-2222-2222-2222-222222222222', 'd66feb66-7a3b-4306-9d0b-58725b72ee0d', 'House Escher', 'Matriarch', 95, 5, 3, 3, 3, 3, 2, 3, 5, 6, 7, 7, 2, '["Champion"]', true, false, now()),
+('e3333333-3333-3333-3333-333333333333', 'd66feb66-7a3b-4306-9d0b-58725b72ee0d', 'House Escher', 'Sister (Specialist)', 50, 5, 4, 4, 3, 3, 1, 3, 6, 7, 8, 7, 1, '["Specialist"]', false, false, now()),
+('e4444444-4444-4444-4444-444444444444', 'd66feb66-7a3b-4306-9d0b-58725b72ee0d', 'House Escher', 'Sister', 50, 5, 4, 4, 3, 3, 1, 3, 6, 7, 8, 7, 1, '["Ganger"]', false, false, now()),
+('e5555555-5555-5555-5555-555555555555', 'd66feb66-7a3b-4306-9d0b-58725b72ee0d', 'House Escher', 'Little Sister', 30, 6, 4, 5, 3, 3, 1, 3, 7, 8, 8, 8, 1, '["Juve"]', false, false, now())
 ON CONFLICT (id) DO NOTHING;
 
 -- House Goliath Fighter Types
-INSERT INTO public.fighter_types (id, gang_type_id, gang_type, fighter_type, cost, movement, weapon_skill, ballistic_skill, strength, toughness, wounds, initiative, leadership, cool, willpower, intelligence, attacks, fighter_class, fighter_class_id, fighter_classes, free_skill, is_gang_addition, created_at) VALUES
-('81111111-1111-1111-1111-111111111111', 'ad325025-d293-4078-b14b-4306be45f1c8', 'House Goliath', 'Forge Tyrant', 120, 4, 3, 3, 4, 4, 2, 4, 4, 5, 6, 6, 2, 'Leader', 'e4988356-d580-4f85-8d27-ec604d917d53', '["Leader"]', true, false, now()),
-('82222222-2222-2222-2222-222222222222', 'ad325025-d293-4078-b14b-4306be45f1c8', 'House Goliath', 'Forge Boss', 95, 4, 3, 3, 4, 4, 2, 4, 5, 6, 7, 7, 2, 'Champion', 'fe93ecdb-390b-4b31-8650-a25a90d427a5', '["Champion"]', true, false, now()),
-('83333333-3333-3333-3333-333333333333', 'ad325025-d293-4078-b14b-4306be45f1c8', 'House Goliath', 'Bully (Specialist)', 60, 4, 4, 4, 4, 4, 1, 4, 6, 7, 8, 7, 1, 'Specialist', 'd11d15a8-07ea-4a5a-beae-35ddea16e544', '["Specialist"]', false, false, now()),
-('84444444-4444-4444-4444-444444444444', 'ad325025-d293-4078-b14b-4306be45f1c8', 'House Goliath', 'Bully', 60, 4, 4, 4, 4, 4, 1, 4, 6, 7, 8, 7, 1, 'Ganger', 'd53f7381-09c2-48f3-b324-2199c5128684', '["Ganger"]', false, false, now()),
-('85555555-5555-5555-5555-555555555555', 'ad325025-d293-4078-b14b-4306be45f1c8', 'House Goliath', 'Grit', 35, 5, 4, 5, 3, 3, 1, 4, 7, 8, 8, 8, 1, 'Juve', 'fcd056a9-b219-48d8-ad61-e838091cc4da', '["Juve"]', false, false, now())
+INSERT INTO public.fighter_types (id, gang_type_id, gang_type, fighter_type, cost, movement, weapon_skill, ballistic_skill, strength, toughness, wounds, initiative, leadership, cool, willpower, intelligence, attacks, fighter_classes, free_skill, is_gang_addition, created_at) VALUES
+('81111111-1111-1111-1111-111111111111', 'ad325025-d293-4078-b14b-4306be45f1c8', 'House Goliath', 'Forge Tyrant', 120, 4, 3, 3, 4, 4, 2, 4, 4, 5, 6, 6, 2, '["Leader"]', true, false, now()),
+('82222222-2222-2222-2222-222222222222', 'ad325025-d293-4078-b14b-4306be45f1c8', 'House Goliath', 'Forge Boss', 95, 4, 3, 3, 4, 4, 2, 4, 5, 6, 7, 7, 2, '["Champion"]', true, false, now()),
+('83333333-3333-3333-3333-333333333333', 'ad325025-d293-4078-b14b-4306be45f1c8', 'House Goliath', 'Bully (Specialist)', 60, 4, 4, 4, 4, 4, 1, 4, 6, 7, 8, 7, 1, '["Specialist"]', false, false, now()),
+('84444444-4444-4444-4444-444444444444', 'ad325025-d293-4078-b14b-4306be45f1c8', 'House Goliath', 'Bully', 60, 4, 4, 4, 4, 4, 1, 4, 6, 7, 8, 7, 1, '["Ganger"]', false, false, now()),
+('85555555-5555-5555-5555-555555555555', 'ad325025-d293-4078-b14b-4306be45f1c8', 'House Goliath', 'Grit', 35, 5, 4, 5, 3, 3, 1, 4, 7, 8, 8, 8, 1, '["Juve"]', false, false, now())
 ON CONFLICT (id) DO NOTHING;
 
 -- Hired Guns (Dramatis Personae / Bounty Hunters)
 -- is_gang_addition = true is what surfaces her in every gang's "Gang Additions" tab:
 -- get_fighter_types_with_cost filters gang additions on that flag alone and ignores
 -- gang_type_id. Needs four columns the house rows above don't use.
-INSERT INTO public.fighter_types (id, gang_type_id, gang_type, fighter_type, cost, movement, weapon_skill, ballistic_skill, strength, toughness, wounds, initiative, leadership, cool, willpower, intelligence, attacks, fighter_class, fighter_class_id, fighter_classes, free_skill, is_gang_addition, special_rules, limitation, alignment, is_dramatis_personae, created_at) VALUES
-('7eaf0b51-6e82-4b8d-861c-e870927f665e', '6145eb6e-84a6-4fbd-b1d3-87348505db42', 'Hired Guns', 'Arbelesta Raen Catallus', 250, 5, 6, 2, 3, 3, 2, 3, 7, 7, 6, 6, 1, 'Bounty Hunter', '9e310c58-5276-4758-bc9f-be010ac69457', '["Bounty Hunter"]', false, true, ARRAY['"Unique Partnership"', '"Bounty Hunter"', '"Slotted"']::jsonb[], 1, 'Law Abiding', true, now())
+INSERT INTO public.fighter_types (id, gang_type_id, gang_type, fighter_type, cost, movement, weapon_skill, ballistic_skill, strength, toughness, wounds, initiative, leadership, cool, willpower, intelligence, attacks, fighter_classes, free_skill, is_gang_addition, special_rules, limitation, alignment, is_dramatis_personae, created_at) VALUES
+('7eaf0b51-6e82-4b8d-861c-e870927f665e', '6145eb6e-84a6-4fbd-b1d3-87348505db42', 'Hired Guns', 'Arbelesta Raen Catallus', 250, 5, 6, 2, 3, 3, 2, 3, 7, 7, 6, 6, 1, '["Bounty Hunter"]', false, true, ARRAY['"Unique Partnership"', '"Bounty Hunter"', '"Slotted"']::jsonb[], 1, 'Law Abiding', true, now())
 ON CONFLICT (id) DO NOTHING;
 
 -- ============================================================================


### PR DESCRIPTION
Phase 2 of the multiple-classes change, following #1910.

Phase 1 added `fighter_classes jsonb`, backfilled it, and moved all application code onto the array. The old columns stayed behind — and the RPCs kept emitting a legacy `fighter_class` key — so the previously deployed frontend kept working while the new build rolled out. That compatibility window has closed.

## What this drops

| Table | Columns |
|---|---|
| `fighters` | `fighter_class`, `fighter_class_id` |
| `fighter_types` | `fighter_class`, `fighter_class_id` |
| `custom_fighter_types` | `fighter_class`, `fighter_class_id` |
| `fighter_ooa_records` | `causing_fighter_class`, `injured_fighter_class` |
| `fighter_classes` | `slug`, its format check, and `fighter_classes_edition_slug_idx` |

Nothing ever read `fighter_classes.slug`. The one thing it enforced — one row per class per edition — moved onto `class_name` via `fighter_classes_edition_class_name_idx` in #1910.

Also drops **`get_add_fighter_details`**: an untracked pre-JSONB function that is absent from `supabase/functions/`, has no callers (a comment at `app/api/fighter-types/route.ts:200` records that `get_fighter_types_with_cost` supersedes it), and INNER JOINs `fighter_classes fc ON fc.id = ft.fighter_class_id` — so it would otherwise be left permanently broken.

**`skill_access_archetypes.fighter_class_id` is deliberately untouched.** It is a real FK to the `fighter_classes` table and still drives the archetype feature.

## Safety

The migration **deletes no rows** and uses **no `CASCADE` anywhere**. Plain `DROP` under the default `RESTRICT` means that if anything unexpectedly depends on a column, the statement fails loudly rather than quietly removing the dependent object too. (`DROP COLUMN` still removes that column's own index and FK — that is not a cascade and destroys no rows.)

A guard runs first and refuses to drop anything while any row still holds a class only in a legacy column. It uses dynamic SQL behind an `information_schema` existence test, so re-running after the drop is a clean no-op rather than a `column does not exist` error.

## RPC changes

`get_available_skills`, `get_fighter_available_advancements` and `get_gang_details` stop emitting the legacy `fighter_class` key. `get_fighter_types_with_cost` additionally drops it from its `RETURNS TABLE` — a signature change, so PostgREST needs a schema-cache reload after deploy. `copy_custom_collection` needed no change.

`seed.sql` is updated to match the post-drop schema.

## Deploy order

The app half is already live from #1910, so the drop is manual and last:

1. Merge → CI deploys the four updated RPCs. Safe: the live app reads only `fighter_classes`, and the columns still exist at this point.
2. Confirm the RPCs are live and the app is healthy.
3. Apply `20260802180000_drop_legacy_fighter_class_columns.sql` manually.
4. Reload the PostgREST schema cache — `NOTIFY pgrst, 'reload schema'` or the dashboard button.

Do not drop before step 1: the currently deployed RPCs still select `f.fighter_class` and would fail at runtime the moment the column disappears.

Worth running before step 3 — must return zero, or the guard will (correctly) refuse:

```sql
SELECT 'fighters' t, count(*) FROM fighters
  WHERE fighter_classes = '[]' AND (fighter_class IS NOT NULL OR fighter_class_id IS NOT NULL)
UNION ALL SELECT 'fighter_types', count(*) FROM fighter_types
  WHERE fighter_classes = '[]' AND (fighter_class IS NOT NULL OR fighter_class_id IS NOT NULL)
UNION ALL SELECT 'custom', count(*) FROM custom_fighter_types
  WHERE fighter_classes = '[]' AND (fighter_class IS NOT NULL OR fighter_class_id IS NOT NULL);
```

## Verification

Exercised against a local PostgreSQL 16 on a schema reproducing the real cascading FKs (`fighters.fighter_type_id → fighter_types ON DELETE CASCADE`, `fighters.gang_id → gangs ON DELETE CASCADE`):

- Row counts identical before and after across all six tables — nothing cascaded
- Target columns gone; `skill_access_archetypes.fighter_class_id` and `editions.slug` intact
- Second run exits 0 with every statement skipped (idempotent)
- Against two at-risk rows the guard refuses with `2 row(s) hold a class only in the old columns (fighters: 1; fighter_ooa_records: 1)` and leaves all 8 legacy columns in place

`tsc --noEmit` and `eslint` clean. The RPC bodies themselves have not been executed against real data — worth smoke-testing add fighter, promotion, advancements, skills modal, custom-collection copy, and an Outcasts Leader's archetypes after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKU5BRzYFsiwW82UbkrTgF

---
_Generated by [Claude Code](https://claude.ai/code/session_01EKU5BRzYFsiwW82UbkrTgF)_