### PR TITLE
Support multi-class fighters in N26+ editions

### DIFF
--- a/components/admin/admin-create-fighter-type.tsx
+++ b/components/admin/admin-create-fighter-type.tsx
@@ -9,7 +9,7 @@ import { toast } from 'sonner';
 import { HiX } from "react-icons/hi";
 import { GangType, Equipment } from "@/types/gang";
 import { EditionSelect, useEditions } from '@/components/edition-select';
-import { hasSaveCharacteristic } from '@/types/edition';
+import { isLegacyEdition } from '@/types/edition';
 import { skillSetRank } from "@/utils/skillSetRank";
 import { equipmentCategoryRank } from "@/utils/equipmentCategoryRank";
 
@@ -52,7 +52,7 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
   const [delegationCost, setDelegationCost] = useState('');
   const [selectedGangType, setSelectedGangType] = useState('');
   const [editionId, setEditionId] = useState('');
-  const [selectedFighterClass, setSelectedFighterClass] = useState<FighterClass | ''>('');
+  const [selectedFighterClasses, setSelectedFighterClasses] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   
   const [movement, setMovement] = useState('');
@@ -89,7 +89,7 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
 
   
 
-  const isCrew = selectedFighterClass && selectedFighterClass.class_name === 'Crew';
+  const isCrew = selectedFighterClasses.includes('Crew');
 
   const { data: gangTypes = [] } = useQuery<GangType[]>({
     queryKey: ['admin-gang-types'],
@@ -104,7 +104,18 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
   // The fighter type's edition is implied by its gang type (derived server-side);
   // the edition select only filters the gang type options
   const { data: editions = [] } = useEditions();
-  const showSave = hasSaveCharacteristic(editions.find(edition => edition.id === editionId)?.slug);
+  const editionSlug = editions.find(edition => edition.id === editionId)?.slug;
+  const showSave = !isLegacyEdition(editionSlug);
+  // N26 onward a fighter can hold several classes at once; N23 has exactly one
+  const allowMultipleClasses = !isLegacyEdition(editionSlug);
+
+  const toggleFighterClass = (className: string, checked: boolean) => {
+    const selected = new Set(selectedFighterClasses);
+    if (checked) selected.add(className); else selected.delete(className);
+    // Keep the reference-list order so the stored array doesn't depend on the
+    // order the boxes happened to be ticked in
+    setSelectedFighterClasses(fighterClasses.map(fc => fc.class_name).filter(name => selected.has(name)));
+  };
 
   const filteredGangTypes = editionId
     ? gangTypes.filter(type => type.edition_id === editionId)
@@ -112,6 +123,11 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
 
   const handleEditionChange = (newEditionId: string) => {
     setEditionId(newEditionId);
+    // A single-class edition must not leave extra classes selected but hidden
+    // behind the dropdown, where they would still be submitted
+    if (isLegacyEdition(editions.find(edition => edition.id === newEditionId)?.slug)) {
+      setSelectedFighterClasses(prev => prev.slice(0, 1));
+    }
     if (newEditionId && selectedGangType) {
       const gangType = gangTypes.find(type => type.gang_type_id === selectedGangType);
       if (gangType && gangType.edition_id !== newEditionId) {
@@ -169,10 +185,10 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
 
   const handleSubmit = async () => {
     // Check if selected fighter class is Crew
-    const isCrew = selectedFighterClass && selectedFighterClass.class_name === 'Crew';
+    const isCrew = selectedFighterClasses.includes('Crew');
 
     // Modify validation for Crew class
-    if (!selectedGangType || !selectedFighterClass || !fighterType) {
+    if (!selectedGangType || selectedFighterClasses.length === 0 || !fighterType) {
       toast.error("Please fill in all required fields");
       return false;
     }
@@ -238,7 +254,7 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
         fighterType,
         baseCost: parseInt(baseCost),
         gangTypeId: selectedGangType,
-        fighterClasses: [selectedFighterClass.class_name],
+        fighterClasses: selectedFighterClasses,
         fighterSubTypeId: subTypeId,
         fighterSubType: subTypeName.trim() || null,
         movement: movement ? parseInt(movement) : null,
@@ -365,21 +381,32 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
                 <label className="block text-sm font-medium text-muted-foreground mb-1">
                   Fighter Class *
                 </label>
-                <select
-                  value={selectedFighterClass ? selectedFighterClass.id : ''}
-                  onChange={(e) => {
-                    const selectedClass = fighterClasses.find(fc => fc.id === e.target.value);
-                    setSelectedFighterClass(selectedClass || '');
-                  }}
-                  className="w-full p-2 border rounded-md"
-                >
-                  <option value="">Select fighter class</option>
-                  {fighterClasses.map((fighterClass) => (
-                    <option key={fighterClass.id} value={fighterClass.id}>
-                      {fighterClass.class_name}
-                    </option>
-                  ))}
-                </select>
+                {allowMultipleClasses ? (
+                  <div className="border rounded-md p-2 grid grid-cols-2 gap-x-4 gap-y-2">
+                    {fighterClasses.map((fighterClass) => (
+                      <label key={fighterClass.id} className="flex items-center gap-2 text-sm cursor-pointer">
+                        <Checkbox
+                          checked={selectedFighterClasses.includes(fighterClass.class_name)}
+                          onCheckedChange={(checked) => toggleFighterClass(fighterClass.class_name, checked === true)}
+                        />
+                        <span>{fighterClass.class_name}</span>
+                      </label>
+                    ))}
+                  </div>
+                ) : (
+                  <select
+                    value={selectedFighterClasses[0] ?? ''}
+                    onChange={(e) => setSelectedFighterClasses(e.target.value ? [e.target.value] : [])}
+                    className="w-full p-2 border rounded-md"
+                  >
+                    <option value="">Select fighter class</option>
+                    {fighterClasses.map((fighterClass) => (
+                      <option key={fighterClass.id} value={fighterClass.class_name}>
+                        {fighterClass.class_name}
+                      </option>
+                    ))}
+                  </select>
+                )}
               </div>
             </div>
 
@@ -1055,12 +1082,12 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
           <Button
             onClick={handleSubmit}
             disabled={
-              !baseCost || 
-              !selectedGangType || 
-              !selectedFighterClass || 
+              !baseCost ||
+              !selectedGangType ||
+              selectedFighterClasses.length === 0 ||
               !fighterType ||
               !ballisticSkill ||
-              (!selectedFighterClass || selectedFighterClass.class_name !== 'Crew') && (
+              !isCrew && (
                 !movement ||
                 !weaponSkill ||
                 !strength ||

--- a/components/admin/admin-edit-fighter-type.tsx
+++ b/components/admin/admin-edit-fighter-type.tsx
@@ -914,6 +914,13 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
         throw new Error('Missing required fields');
       }
 
+      // Nothing downstream rejects an empty array — the column defaults to '[]'
+      // and the API passes it straight through — so a classless fighter type
+      // would silently reach the SQL functions that branch on class name.
+      if (selectedFighterClasses.length === 0) {
+        throw new Error('Please select at least one fighter class');
+      }
+
       // Special handling for subTypeId and subTypeName
       let finalSubTypeId: string | null = null;
       let finalSubTypeName: string | null = null;
@@ -2346,7 +2353,7 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
           </Button>
           <Button
             onClick={handleSubmit}
-            disabled={!selectedSubTypeId || isLoading}
+            disabled={!selectedSubTypeId || selectedFighterClasses.length === 0 || isLoading}
             className="px-4 py-2 bg-neutral-900 text-white rounded-sm hover:bg-gray-800"
           >
             {isLoading ? 'Updating...' : 'Update Fighter Type'}

--- a/components/admin/admin-edit-fighter-type.tsx
+++ b/components/admin/admin-edit-fighter-type.tsx
@@ -15,7 +15,7 @@ import { skillSetRank } from "@/utils/skillSetRank";
 import { equipmentCategoryRank } from "@/utils/equipmentCategoryRank";
 import { AdminFighterEquipmentSelection, EquipmentSelection, guiToDataModel, dataModelToGui } from "@/components/admin/admin-fighter-equipment-selection";
 import { EditionSelect, useEditions } from '@/components/edition-select';
-import { hasSaveCharacteristic } from '@/types/edition';
+import { isLegacyEdition } from '@/types/edition';
 import Modal from '@/components/ui/modal';
 
 interface FighterSubType {
@@ -61,6 +61,17 @@ interface FighterTypeCombo {
   gang_type_id: string;
 }
 
+/**
+ * Renders a fighter type's classes as the single string that identifies it in
+ * the "Select Fighter Type to Edit" dropdown. Combos are packed into a
+ * `type|class|gang_type_id` string, and "|" never appears in a class name, so
+ * joining on ", " keeps the combo parseable while distinguishing fighter types
+ * that share a first class but differ later in the list.
+ */
+function formatFighterClasses(fighterClasses?: string[] | null): string {
+  return (fighterClasses ?? []).join(', ');
+}
+
 interface FighterTypeGangCost {
   id?: string;
   fighter_type_id: string;
@@ -85,7 +96,7 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
   const [fighterType, setFighterType] = useState('');
   const [baseCost, setBaseCost] = useState('');
   const [delegationCost, setDelegationCost] = useState('');
-  const [selectedFighterClass, setSelectedFighterClass] = useState<string>('');
+  const [selectedFighterClasses, setSelectedFighterClasses] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedSubTypeId, setSelectedSubTypeId] = useState<string>('');
   const [availableSubTypes, setAvailableSubTypes] = useState<FighterSubType[]>([]);
@@ -307,7 +318,18 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
   // Edition only filters the gang-type dropdown; the fighter type's edition is
   // derived server-side from its gang type
   const { data: editions = [] } = useEditions();
-  const showSave = hasSaveCharacteristic(editions.find(edition => edition.id === editionId)?.slug);
+  const editionSlug = editions.find(edition => edition.id === editionId)?.slug;
+  const showSave = !isLegacyEdition(editionSlug);
+  // N26 onward a fighter can hold several classes at once; N23 has exactly one
+  const allowMultipleClasses = !isLegacyEdition(editionSlug);
+
+  const toggleFighterClass = (className: string, checked: boolean) => {
+    const selected = new Set(selectedFighterClasses);
+    if (checked) selected.add(className); else selected.delete(className);
+    // Keep the reference-list order so the stored array doesn't depend on the
+    // order the boxes happened to be ticked in
+    setSelectedFighterClasses(fighterClasses.map(fc => fc.class_name).filter(name => selected.has(name)));
+  };
 
   const filteredGangTypes = editionId
     ? gangTypes.filter(type => type.edition_id === editionId)
@@ -315,6 +337,11 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
 
   const handleEditionChange = (newEditionId: string) => {
     setEditionId(newEditionId);
+    // A single-class edition must not leave extra classes selected but hidden
+    // behind the dropdown, where they would still be submitted
+    if (isLegacyEdition(editions.find(edition => edition.id === newEditionId)?.slug)) {
+      setSelectedFighterClasses(prev => prev.slice(0, 1));
+    }
     if (newEditionId && gangTypeFilter) {
       const gangType = gangTypes.find(type => type.gang_type_id === gangTypeFilter);
       if (gangType && gangType.edition_id !== newEditionId) {
@@ -360,15 +387,16 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
   const fighterTypeCombos = useMemo(() => {
     const uniqueCombinations: FighterTypeCombo[] = [];
     fighterTypes.forEach(fighter => {
+      const classLabel = formatFighterClasses(fighter.fighter_classes);
       const existingCombo = uniqueCombinations.find(
         combo => combo.type === fighter.fighter_type &&
-                combo.class === (fighter.fighter_classes?.[0] || '') &&
+                combo.class === classLabel &&
                 combo.gang_type_id === fighter.gang_type_id
       );
       if (!existingCombo) {
         uniqueCombinations.push({
           type: fighter.fighter_type,
-          class: fighter.fighter_classes?.[0] || '',
+          class: classLabel,
           gang_type_id: fighter.gang_type_id
         });
       }
@@ -486,7 +514,7 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
       setFighterType(data.fighter_type || '');
       setBaseCost(data.cost?.toString() || '0');
       setDelegationCost(data.delegation_cost?.toString() || '');
-      setSelectedFighterClass(data.fighter_classes?.[0] || '');
+      setSelectedFighterClasses(Array.isArray(data.fighter_classes) ? data.fighter_classes : []);
       setMovement(data.movement?.toString() || '0');
       setWeaponSkill(data.weapon_skill?.toString() || '0');
       setBallisticSkill(data.ballistic_skill?.toString() || '0');
@@ -626,10 +654,13 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
         return;
       }
       
-      // Find all fighters that match this type+class+gang_type
-      const matchingFighters = fighterTypes.filter(f => 
-        f.fighter_type === fighterType && 
-        f.fighter_classes?.includes(fighterClass) &&
+      // Find all fighters that match this type+class+gang_type. The whole class
+      // list has to match, not just contain the first one: with multi-class
+      // fighter types a "Ganger" combo would otherwise also swallow every
+      // "Ganger, Specialist" type and mix their sub-types together.
+      const matchingFighters = fighterTypes.filter(f =>
+        f.fighter_type === fighterType &&
+        formatFighterClasses(f.fighter_classes) === fighterClass &&
         f.gang_type_id === gangTypeId
       );
       
@@ -710,7 +741,7 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
         // Use any fighter from the matching set to get basic type info
         const fighter = matchingFighters[0];
         setFighterType(fighter.fighter_type);
-        setSelectedFighterClass(fighter.fighter_classes?.[0] || '');
+        setSelectedFighterClasses(fighter.fighter_classes ?? []);
       }
     } catch (error) {
       console.error('Error processing fighter type combo:', error);
@@ -877,8 +908,6 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
         .split(',')
         .map(rule => rule.trim())
         .filter(rule => rule.length > 0);
-
-      const fighterClass = fighterClasses.find(fc => fc.class_name === selectedFighterClass);
 
       // Validate required fields
       if (!fighterType || !fighterToUpdate?.gang_type_id) {
@@ -1056,7 +1085,7 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
         fighter_type: fighterType,
         cost: parseInt(baseCost),
         gang_type_id: fighterToUpdate.gang_type_id,
-        fighter_classes: selectedFighterClass ? [selectedFighterClass] : [],
+        fighter_classes: selectedFighterClasses,
         fighter_sub_type_id: finalSubTypeId,
         fighter_sub_type: finalSubTypeName,
         movement: parseInt(movement),
@@ -1457,21 +1486,32 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
                   <label className="block text-sm font-medium text-muted-foreground mb-1">
                     Fighter Class *
                   </label>
-                  <select
-                    value={selectedFighterClass}
-                    onChange={(e) => {
-                      console.log('Selected fighter class:', e.target.value);
-                      setSelectedFighterClass(e.target.value);
-                    }}
-                    className="w-full p-2 border rounded-md"
-                  >
-                    <option value="">Select fighter class</option>
-                    {fighterClasses.map((fighterClass) => (
-                      <option key={fighterClass.id} value={fighterClass.class_name}>
-                        {fighterClass.class_name}
-                      </option>
-                    ))}
-                  </select>
+                  {allowMultipleClasses ? (
+                    <div className="border rounded-md p-2 grid grid-cols-2 gap-x-4 gap-y-2">
+                      {fighterClasses.map((fighterClass) => (
+                        <label key={fighterClass.id} className="flex items-center gap-2 text-sm cursor-pointer">
+                          <Checkbox
+                            checked={selectedFighterClasses.includes(fighterClass.class_name)}
+                            onCheckedChange={(checked) => toggleFighterClass(fighterClass.class_name, checked === true)}
+                          />
+                          <span>{fighterClass.class_name}</span>
+                        </label>
+                      ))}
+                    </div>
+                  ) : (
+                    <select
+                      value={selectedFighterClasses[0] ?? ''}
+                      onChange={(e) => setSelectedFighterClasses(e.target.value ? [e.target.value] : [])}
+                      className="w-full p-2 border rounded-md"
+                    >
+                      <option value="">Select fighter class</option>
+                      {fighterClasses.map((fighterClass) => (
+                        <option key={fighterClass.id} value={fighterClass.class_name}>
+                          {fighterClass.class_name}
+                        </option>
+                      ))}
+                    </select>
+                  )}
                 </div>
 
                 <div>

--- a/components/fighter/fighter-details-card.tsx
+++ b/components/fighter/fighter-details-card.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
 import { FighterDetailsStatsTable } from '../ui/fighter-details-stats-table';
-import { hasSaveCharacteristic } from '@/types/edition';
+import { isLegacyEdition } from '@/types/edition';
 import { memo } from 'react';
 import { calculateAdjustedStats } from '@/utils/effect-modifiers';
 import { FighterProps, FighterEffect, Vehicle } from '@/types/fighter';
@@ -399,7 +399,7 @@ export const FighterDetailsCard = memo(function FighterDetailsCard({
       'W': modifiedStats.wounds,
       'I': `${modifiedStats.initiative}+`,
       'A': modifiedStats.attacks,
-      ...(hasSaveCharacteristic(edition_slug) && { 'Sv': modifiedStats.save != null ? `${modifiedStats.save}+` : '-' }),
+      ...(!isLegacyEdition(edition_slug) && { 'Sv': modifiedStats.save != null ? `${modifiedStats.save}+` : '-' }),
       'Ld': `${modifiedStats.leadership}+`,
       'Cl': `${modifiedStats.cool}+`,
       'Wil': `${modifiedStats.willpower}+`,

--- a/components/gang/fighter-card.tsx
+++ b/components/gang/fighter-card.tsx
@@ -4,7 +4,7 @@ import { StatsTable, StatsType } from '../ui/fighter-card-stats-table';
 import WeaponTable from './fighter-card-weapon-table';
 import { Equipment } from '@/types/equipment';
 import { FighterProps, FighterEffect, Vehicle, VehicleEquipment, FighterSkills } from '@/types/fighter';
-import { hasSaveCharacteristic } from '@/types/edition';
+import { isLegacyEdition } from '@/types/edition';
 import { calculateAdjustedStats, applySpecialRulesModifiers } from '@/utils/effect-modifiers';
 import { injuryAggregationLabel } from '@/utils/bitterEnmityDisplay';
 import { TbMeatOff } from "react-icons/tb";
@@ -437,7 +437,7 @@ const FighterCard = memo(function FighterCard({
       'W': adjustedStats.wounds,
       'I': `${adjustedStats.initiative}+`,
       'A': adjustedStats.attacks,
-      ...(hasSaveCharacteristic(edition_slug) && { 'Sv': adjustedStats.save != null ? `${adjustedStats.save}+` : '-' }),
+      ...(!isLegacyEdition(edition_slug) && { 'Sv': adjustedStats.save != null ? `${adjustedStats.save}+` : '-' }),
       'Ld': `${adjustedStats.leadership}+`,
       'Cl': `${adjustedStats.cool}+`,
       'Wil': `${adjustedStats.willpower}+`,

--- a/components/gang/print-gang.tsx
+++ b/components/gang/print-gang.tsx
@@ -10,7 +10,7 @@ import { sortFightersByPositioning } from "@/utils/fighter-positioning";
 import { injuryAggregationLabel } from "@/utils/bitterEnmityDisplay";
 import WeaponTable from "./fighter-card-weapon-table";
 import { StatsTable, StatsType } from "../ui/fighter-card-stats-table";
-import { hasSaveCharacteristic } from "@/types/edition";
+import { isLegacyEdition } from "@/types/edition";
 import { MdCheckBoxOutlineBlank } from "react-icons/md";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
@@ -667,7 +667,7 @@ export default function PrintGang({ gang }: PrintGangProps) {
                       'W': adjustedStats.wounds,
                       'I': `${adjustedStats.initiative}+`,
                       'A': adjustedStats.attacks,
-                      ...(hasSaveCharacteristic(fighter.edition_slug) && {
+                      ...(!isLegacyEdition(fighter.edition_slug) && {
                         'Sv': adjustedStats.save != null ? `${adjustedStats.save}+` : '-'
                       }),
                       'Ld': `${adjustedStats.leadership}+`,

--- a/types/edition.ts
+++ b/types/edition.ts
@@ -2,13 +2,16 @@
 export const EDITION_N23 = 'n23';
 
 /**
- * Editions from N26 onward have a Save (Sv) characteristic; N23 does not.
- * Gates on the legacy edition rather than a specific new one, so future
- * editions inherit modern behaviour without a code change.
- * An unknown/unset edition is treated as legacy.
+ * N23 is the one legacy ruleset; everything from N26 onward is "modern" and
+ * differs from it in the same ways — a Save (Sv) characteristic, fighters
+ * holding several classes at once, and so on.
+ *
+ * Gates on the legacy edition rather than on a specific new one, so future
+ * editions inherit modern behaviour without a code change. An unknown/unset
+ * edition is treated as legacy.
  */
-export function hasSaveCharacteristic(editionSlug?: string | null): boolean {
-  return !!editionSlug && editionSlug !== EDITION_N23;
+export function isLegacyEdition(editionSlug?: string | null): boolean {
+  return !editionSlug || editionSlug === EDITION_N23;
 }
 
 export interface Edition {


### PR DESCRIPTION
## Summary
This PR extends fighter class selection to support multiple classes per fighter in N26+ editions, while maintaining single-class selection for the legacy N23 edition. It also refactors edition-checking logic to be more semantically clear.

## Key Changes

- **Multi-class support**: Changed fighter class state from a single string to an array (`selectedFighterClasses: string[]`) in both admin create and edit modals
- **Edition-aware UI**: Fighter class selection now renders as:
  - Checkboxes (multi-select) for N26+ editions
  - Dropdown (single-select) for N23 edition
- **Edition detection refactor**: Renamed `hasSaveCharacteristic()` to `isLegacyEdition()` for clearer intent and inverted logic throughout the codebase
- **Class matching logic**: Updated fighter type combo matching to compare full class lists rather than just the first class, preventing multi-class types from being incorrectly grouped with single-class variants
- **Edition switching safeguard**: When switching to N23 edition, automatically truncates selected classes to the first one to prevent hidden multi-class data from being submitted
- **Class formatting**: Added `formatFighterClasses()` helper to consistently render class arrays as comma-separated strings for display and comparison

## Implementation Details

- The `toggleFighterClass()` function maintains reference-list order when updating selections, ensuring consistent storage regardless of checkbox interaction order
- Fighter type combo deduplication now uses the full formatted class string as the identifier
- All four affected components (admin create/edit modals, fighter details card, gang card, print view) updated to use the new `isLegacyEdition()` function
- Backward compatibility maintained: existing single-class fighters load correctly into the multi-class UI

https://claude.ai/code/session_0144qXPkaumZUc8fTgpxH2QS