### PR TITLE
feat(db): add starting_xp to fighter type tables

### DIFF
--- a/supabase/migrations/20260803150605_add_starting_xp_columns.sql
+++ b/supabase/migrations/20260803150605_add_starting_xp_columns.sql
@@ -1,0 +1,17 @@
+-- Starting XP for fighter types (N26 "Advance Models" rules).
+-- A fighter type may grant XP at recruitment. When a fighter is added, this
+-- value seeds the fighter's XP on the fighters table. The starting_xp column is
+-- kept on the type as the reference value. Existing rows default to 0. Stored as
+-- numeric to match the other stat/cost columns on these tables (cost, save,
+-- fighters.xp).
+ALTER TABLE public.fighter_types
+  ADD COLUMN IF NOT EXISTS starting_xp numeric NOT NULL DEFAULT 0;
+
+ALTER TABLE public.custom_fighter_types
+  ADD COLUMN IF NOT EXISTS starting_xp numeric NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.fighter_types.starting_xp IS
+  'XP a fighter of this type starts with at recruitment. Copied to fighters.xp when the fighter is added.';
+
+COMMENT ON COLUMN public.custom_fighter_types.starting_xp IS
+  'XP a fighter of this custom type starts with at recruitment. Copied to fighters.xp when the fighter is added.';


### PR DESCRIPTION
## What

Adds a `starting_xp` column (`numeric NOT NULL DEFAULT 0`) to `fighter_types` and `custom_fighter_types`.

A fighter type may grant XP at recruitment (N26 "Advance Models"). When a fighter is added, this value seeds the fighter's XP (`fighters.xp`); the type column stays as the reference. No column is added to `fighters` — recruitment logic reads the type's `starting_xp` and writes the existing `fighters.xp`.

## Scope

- **DB-only** first step; the add-fighter wiring lands in a later PR.
- Migration: `supabase/migrations/20260803150605_add_starting_xp_columns.sql`.
- Existing rows default to `0`; `IF NOT EXISTS` makes it idempotent.

## Testing

Applied against a local Supabase instance via `psql` (migrations don't auto-run locally) and verified:
- Both columns created as `numeric`, `NOT NULL`, `DEFAULT 0`.
- Existing rows all `0` (no nulls); omitting the value on insert defaults to `0`; inserting `NULL` is rejected.
- Re-running the migration is a no-op (idempotent).

## Notes

- The schema snapshot (`schema.public.sql`) will pick up the column on the next daily CI refresh after this is applied to the remote.

Co-Authored-By: Claude Opus 4.8