### PR TITLE
Add is_vehicle column to fighter tables and copy new fighter fields in collection copy

### DIFF
--- a/supabase/functions/copy_custom_collection.sql
+++ b/supabase/functions/copy_custom_collection.sql
@@ -166,12 +166,14 @@ BEGIN
                                            weapon_skill, ballistic_skill, strength, toughness, wounds, initiative,
                                            attacks, leadership, cool, willpower, intelligence, gang_type_id,
                                            special_rules, free_skill,
-                                           fighter_subtypes, custom_gang_type_id, description)
+                                           fighter_subtypes, custom_gang_type_id, description, edition_id, save,
+                                           starting_xp, is_vehicle)
   SELECT (v_map_ft ->> cft.id::text)::uuid, now(), v_user, cft.fighter_type, cft.gang_type, cft.cost, cft.movement,
          cft.weapon_skill, cft.ballistic_skill, cft.strength, cft.toughness, cft.wounds, cft.initiative,
          cft.attacks, cft.leadership, cft.cool, cft.willpower, cft.intelligence, cft.gang_type_id,
          cft.special_rules, cft.free_skill,
-         cft.fighter_subtypes, (v_map_gt ->> cft.custom_gang_type_id::text)::uuid, cft.description
+         cft.fighter_subtypes, (v_map_gt ->> cft.custom_gang_type_id::text)::uuid, cft.description, cft.edition_id,
+         cft.save, cft.starting_xp, cft.is_vehicle
   FROM public.custom_fighter_types cft WHERE cft.id = ANY(v_ft);
 
   INSERT INTO public.fighter_type_skill_access (id, fighter_type_id, skill_type_id, access_level,

--- a/supabase/migrations/20260806170000_add_is_vehicle_to_fighter_types.sql
+++ b/supabase/migrations/20260806170000_add_is_vehicle_to_fighter_types.sql
@@ -1,0 +1,10 @@
+-- N26 represents vehicles alongside other fighter types. Existing fighter types
+-- remain non-vehicles unless their seed data explicitly opts in.
+ALTER TABLE public.fighter_types
+  ADD COLUMN is_vehicle boolean NOT NULL DEFAULT false;
+
+ALTER TABLE public.custom_fighter_types
+  ADD COLUMN is_vehicle boolean NOT NULL DEFAULT false;
+
+ALTER TABLE public.fighters
+  ADD COLUMN is_vehicle boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
### Motivation
- Add explicit vehicle support for fighter types and ensure custom fighter data retains new fields when copying collections.
- Ensure copied custom fighter types include newly-introduced attributes like edition, save, starting XP, and vehicle flag.

### Description
- Add migration `20260806170000_add_is_vehicle_to_fighter_types.sql` that adds `is_vehicle boolean NOT NULL DEFAULT false` to `fighter_types`, `custom_fighter_types`, and `fighters`.
- Update `supabase/functions/copy_custom_collection.sql` to include `edition_id`, `save`, `starting_xp`, and `is_vehicle` in the `INSERT INTO public.custom_fighter_types ... SELECT ...` so those fields are preserved when copying custom collections.
- Keep existing ID mapping logic and other field mappings unchanged while extending the SELECT to pull the new columns from `custom_fighter_types`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a747682e8648332af99b0fb6143f3fc)