### PR TITLE
Make the Add XP modal edition-aware for N26

### DIFF
--- a/app/actions/logs/log-helpers.ts
+++ b/app/actions/logs/log-helpers.ts
@@ -1,26 +1,21 @@
-/** XP case id → display label (must match fighter-xp-modal xpCountCases) */
-export const XP_CASE_LABELS: Record<string, string> = {
-  seriousInjury: 'Cause Serious Injury',
-  outOfAction: 'Cause OOA',
-  leaderChampionBonus: 'Leader/Champion',
-  vehicleWrecked: 'Wreck Vehicle',
-  rally: 'Successful Rally',
-  assistance: 'Provide Assistance',
-  misc: 'Misc.',
-  battleParticipation: 'Battle Participation',
-};
+import { XP_CASES } from '@/utils/xpCases';
 
-/** XP per case (id → XP each) - must match fighter-xp-modal */
-export const XP_CASE_VALUES: Record<string, number> = {
-  seriousInjury: 1,
-  outOfAction: 2,
-  leaderChampionBonus: 1,
-  vehicleWrecked: 2,
-  rally: 1,
-  assistance: 1,
-  misc: 1,
-  battleParticipation: 1,
-};
+/**
+ * XP case id → display label / XP each, derived from the single award registry
+ * in utils/xpCases.ts.
+ *
+ * Deliberately typed Record<string, …> rather than Record<XpCaseId, …>: these
+ * are indexed with ids read back from persisted log payloads, which may predate
+ * the union or outlive an award being retired from every edition's list. Both
+ * lookups below fall back rather than assuming a hit.
+ */
+export const XP_CASE_LABELS: Record<string, string> = Object.fromEntries(
+  Object.entries(XP_CASES).map(([id, def]) => [id, def.label])
+);
+
+export const XP_CASE_VALUES: Record<string, number> = Object.fromEntries(
+  Object.entries(XP_CASES).map(([id, def]) => [id, def.xp])
+);
 
 export function formatXpBreakdown(breakdown: Record<string, number>, miscNote?: string): string {
   return Object.entries(breakdown)

--- a/components/battle-session/participant-card.tsx
+++ b/components/battle-session/participant-card.tsx
@@ -339,6 +339,7 @@ function FighterActionModal({
           currentKillCount={fighterData.kill_count}
           gangId={gangId}
           campaignId={campaignId ?? undefined}
+          editionSlug={editionSlug}
           onClose={() => setShowXpModal(false)}
           onXpUpdated={(newXp) => {
             const delta = newXp - (fighterData?.xp ?? 0);

--- a/components/fighter/fighter-page.tsx
+++ b/components/fighter/fighter-page.tsx
@@ -1271,6 +1271,7 @@ export default function FighterPage({
               is_spyrer={fighterData.fighter.is_spyrer}
               gangId={fighterData.gang?.id}
               campaignId={fighterData.fighter?.campaigns?.[0]?.campaign_id}
+              editionSlug={fighterData.gang?.edition_slug ?? fighterData.fighter?.edition_slug ?? null}
               onClose={() => handleModalToggle('addXp', false)}
               onXpUpdated={handleXpUpdated}
             />

--- a/components/fighter/fighter-xp-modal.tsx
+++ b/components/fighter/fighter-xp-modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -13,6 +13,7 @@ import { updateFighterXpWithOoa } from '@/app/actions/edit-fighter';
 import { fetchCampaignGangsAndFighters } from '@/utils/api/fighter-ooa-records';
 import { buildGangComboboxOption } from '@/utils/gang-combobox-option';
 import { useCampaignGangFighterOptions } from '@/utils/campaign-gang-fighter-options';
+import { XP_CASES, xpAwardsFor, type XpCaseDef, type XpCaseId } from '@/utils/xpCases';
 import { toast } from 'sonner';
 
 type OoaEventType = 'out_of_action' | 'vehicle_wrecked';
@@ -28,12 +29,7 @@ const TARGET_CASES: TargetCaseConfig[] = [
   { id: 'vehicleWrecked', eventType: 'vehicle_wrecked', crewOnly: true },
 ];
 
-interface XpCase {
-  id: string;
-  label: string;
-  xp: number;
-  onSelectText?: (count: number) => string;
-}
+type XpCase = XpCaseDef & { id: XpCaseId };
 
 interface FighterXpModalProps {
   isOpen: boolean;
@@ -49,6 +45,12 @@ interface FighterXpModalProps {
   gangId?: string;
   /** The campaign to scope target gangs to (the fighter gang's first campaign). */
   campaignId?: string;
+  /**
+   * The gang's (or battle session's) edition, which decides the award list.
+   * Taken from the gang rather than the fighter type: a fighter-derived slug is
+   * null for custom fighter types. Unset/unknown → manual XP entry only.
+   */
+  editionSlug?: string | null;
   onClose: () => void;
   onXpUpdated: (newXp: number, newTotalXp: number, newKills: number, newKillCount?: number) => void;
 }
@@ -64,6 +66,7 @@ export function FighterXpModal({
   helperFighterName,
   gangId,
   campaignId,
+  editionSlug,
   onClose,
   onXpUpdated
 }: FighterXpModalProps) {
@@ -78,20 +81,16 @@ export function FighterXpModal({
   // Internal state for XP amount and errors
   const [xpAmount, setXpAmount] = useState('');
   const [xpError, setXpError] = useState('');
-  // Define XP "events" for the checkbox list
-  const xpCountCases: XpCase[] = [
-    { id: 'seriousInjury', label: 'Cause Serious Injury', xp: 1 },
-    { id: 'outOfAction', label: 'Cause OOA', xp: 2, onSelectText: (count) => `Adds ${count} to the OOA count` },
-    { id: 'leaderChampionBonus', label: 'Leader/Champion', xp: 1 },
-    { id: 'vehicleWrecked', label: 'Wreck Vehicle', xp: 2, onSelectText: (count) => `Adds ${count} to the vehicle wrecked count` },
-    { id: 'rally', label: 'Successful Rally', xp: 1 },
-    { id: 'assistance', label: 'Provide Assistance', xp: 1 },
-    { id: 'misc', label: 'Misc.', xp: 1 },
-  ];
+  // The edition decides which XP awards exist; an unknown edition offers none,
+  // leaving the manual amount field below as the only way to add XP.
+  const awards = useMemo(
+    () => xpAwardsFor(editionSlug).map((id): XpCase => ({ id, ...XP_CASES[id] })),
+    [editionSlug]
+  );
 
-  const xpCheckboxCases: XpCase[] = [
-    { id: 'battleParticipation', label: 'Battle Participation', xp: 1 },
-  ];
+  // Repeatable awards render with -/+ steppers, once-only ones as checkboxes.
+  const xpCountCases = useMemo(() => awards.filter((c) => c.input === 'counter'), [awards]);
+  const xpCheckboxCases = useMemo(() => awards.filter((c) => c.input === 'checkbox'), [awards]);
 
   // Track which of these XP events are checked
   const [xpCounts, setXpCounts] = useState<Record<string, number>>(
@@ -508,8 +507,10 @@ export function FighterXpModal({
               );
             })}
 
-            {/* Separator after the first cases */}
-            <hr className="my-2 border-border" />
+            {/* Separator after the first cases, only when both sides have some */}
+            {xpCountCases.length > 0 && xpCheckboxCases.length > 0 && (
+              <hr className="my-2 border-border" />
+            )}
 
             {/* Single XP Checkboxes */}
             {xpCheckboxCases.map((xpCase, idx, arr) => (

--- a/components/gang/gang-page-content.tsx
+++ b/components/gang/gang-page-content.tsx
@@ -621,6 +621,7 @@ export default function GangPageContent({
           helperFighterName={xpModalFighter.fighter_name}
           gangId={gangId}
           campaignId={gangCampaigns[0]?.campaign_id}
+          editionSlug={gangData.processedData.edition_slug}
           onClose={() => setXpModalFighter(null)}
           onXpUpdated={(newXp, _newTotalXp, newKills, newKillCount) => {
             setGangData(prev => ({

--- a/utils/xpCases.ts
+++ b/utils/xpCases.ts
@@ -1,0 +1,113 @@
+import { EditionSlug } from '@/types/edition';
+
+/**
+ * Every XP award the Add XP modal can offer, across all editions.
+ *
+ * Ids are persisted: the modal writes them into the `xp_breakdown` payload on
+ * fighter logs, and formatXpBreakdown reads them back long afterwards. An id is
+ * therefore a permanent contract — labels can be reworded freely (log lines are
+ * rendered at write time and never re-render), but an id must never be reused
+ * or repurposed, and must never mean different things in different editions:
+ * the formatter is server-side and has no edition context. That is why N26's
+ * wider elite bonus is its own `eliteTargetBonus` rather than a relabelled
+ * `leaderChampionBonus`.
+ */
+export type XpCaseId =
+  | 'seriousInjury'
+  | 'outOfAction'
+  | 'leaderChampionBonus'
+  | 'eliteTargetBonus'
+  | 'vehicleWrecked'
+  | 'rally'
+  | 'assistance'
+  | 'misc'
+  | 'battleParticipation'
+  | 'objectiveControl';
+
+export interface XpCaseDef {
+  label: string;
+  /** XP granted per tick (checkbox) or per count (counter). */
+  xp: number;
+  /**
+   * 'counter' awards can be earned repeatedly in one battle and render with
+   * -/+ steppers; 'checkbox' awards are once-only and render below the
+   * separator.
+   */
+  input: 'counter' | 'checkbox';
+  /** Optional hint shown under the label once the count is above zero. */
+  onSelectText?: (count: number) => string;
+}
+
+export const XP_CASES: Record<XpCaseId, XpCaseDef> = {
+  seriousInjury: { label: 'Cause Serious Injury', xp: 1, input: 'counter' },
+  outOfAction: {
+    label: 'Cause OOA',
+    xp: 2,
+    input: 'counter',
+    onSelectText: (count) => `Adds ${count} to the OOA count`,
+  },
+  leaderChampionBonus: { label: 'Leader/Champion', xp: 1, input: 'counter' },
+  eliteTargetBonus: { label: 'Leader/Champion/Brute/Vehicle', xp: 1, input: 'counter' },
+  vehicleWrecked: {
+    label: 'Wreck Vehicle',
+    xp: 2,
+    input: 'counter',
+    onSelectText: (count) => `Adds ${count} to the vehicle wrecked count`,
+  },
+  rally: { label: 'Successful Rally', xp: 1, input: 'counter' },
+  assistance: { label: 'Provide Assistance', xp: 1, input: 'counter' },
+  misc: { label: 'Misc.', xp: 1, input: 'counter' },
+  battleParticipation: { label: 'Battle Participation', xp: 1, input: 'checkbox' },
+  objectiveControl: { label: 'Controlled an Objective', xp: 1, input: 'checkbox' },
+};
+
+/**
+ * The awards each edition offers, in render order.
+ *
+ * Keyed by EditionSlug on purpose: adding an edition is a compile error here
+ * until it states its own awards, the same guarantee EDITION_CAPABILITIES gives
+ * the capability flags. This is edition-keyed *data* rather than a behaviour
+ * switch, so it lives in its own module and EditionCapabilities stays
+ * boolean-only — the pattern set by utils/characteristicLimits.ts.
+ */
+const XP_AWARDS_BY_EDITION: Record<EditionSlug, readonly XpCaseId[]> = {
+  n23: [
+    'seriousInjury',
+    'outOfAction',
+    'leaderChampionBonus',
+    'vehicleWrecked',
+    'rally',
+    'assistance',
+    'misc',
+    'battleParticipation',
+  ],
+  // N26 keeps N23's order but drops Rally, widens the elite bonus to Brutes and
+  // Vehicles, and adds a once-per-battle objective award. Wrecking an enemy
+  // Leader's vehicle stays 2 XP with the elite bonus ticked separately, mirroring
+  // how OOA + Leader/Champion already works. Rules: the Receive Rewards step of
+  // the Post-battle Sequence.
+  n26: [
+    'seriousInjury',
+    'outOfAction',
+    'eliteTargetBonus',
+    'vehicleWrecked',
+    'assistance',
+    'misc',
+    'battleParticipation',
+    'objectiveControl',
+  ],
+};
+
+/**
+ * An unset or unrecognised slug offers no preset awards at all, matching
+ * NO_CAPABILITIES in types/edition.ts. A missing slug means the edition failed
+ * to load, and offering one edition's awards would invite logging XP under
+ * rules that do not apply; the modal still accepts a manual amount.
+ */
+const NO_AWARDS: readonly XpCaseId[] = [];
+
+export function xpAwardsFor(editionSlug: string | null | undefined): readonly XpCaseId[] {
+  if (!editionSlug) return NO_AWARDS;
+
+  return XP_AWARDS_BY_EDITION[editionSlug as EditionSlug] ?? NO_AWARDS;
+}


### PR DESCRIPTION
## Why

The XP award list in the shared Add XP modal was hard-coded to N23, so N26 gangs were offered awards their edition does not have and were missing two it does.

N26 changes the list in three ways:

| Award | N23 | N26 |
| --- | --- | --- |
| Successful Rally | ✅ | ❌ removed |
| Leader/Champion (+1) | ✅ | widened to **Leader/Champion/Brute/Vehicle** |
| Controlled an Objective (+1, once per battle) | ❌ | ✅ added |

## What changed

The award definitions move out of the modal into a new **`utils/xpCases.ts`**, following the `utils/characteristicLimits.ts` pattern for edition-keyed data: a `Record<EditionSlug, readonly XpCaseId[]>` gets the same compile-error-on-a-new-edition guarantee that `EDITION_CAPABILITIES` gives the capability flags, while `EditionCapabilities` stays boolean-only. This is *data* rather than a behaviour switch, so it does not belong in the capability record.

- **Unknown edition degrades safely.** An unset or unrecognised slug offers no presets and leaves the manual XP amount field, mirroring `NO_CAPABILITIES` rather than quietly aliasing to a real edition. That makes an empty award list reachable for the first time, so the separator between the counters and the checkboxes now only renders when both sides have entries.
- **N26's wider elite bonus is its own `eliteTargetBonus` id**, not a relabelled `leaderChampionBonus`. Breakdown ids are persisted in fighter logs and `formatXpBreakdown` is server-side with no edition context, so a single id cannot carry two meanings.
- **Shared cases keep their existing N23 labels** for that same reason, which leaves the N23 modal unchanged.
- **`app/actions/logs/log-helpers.ts` derives its two lookup maps from the registry** instead of duplicating them, but stays typed `Record<string, …>`: it indexes with ids read back from stored payloads, which may predate the union or outlive an award being retired from every edition's list. Historic `rally` entries still format correctly.

The three entry points that render the modal — the gang overview, the fighter page, and the battle session participant card — each pass their edition down. The edition is taken from the **gang**, not the fighter, since a fighter-derived slug resolves through `fighter_types` and is `null` for custom fighter types. The battle session already had `editionSlug` in scope from the battle-session edition work, so that one is a single prop.

No database or server action change: `updateFighterXpWithOoa` already accepts a free-form `xp_breakdown` map and was edition-agnostic.

## Out of scope

- Advancements and ranks.
- Persisting the objective award across modal openings — it is once per *modal opening*, not enforced once per battle.
- Gating Assistance and objectives for Vehicles and Pets. N26 does forbid those, but the modal has no fighter-type props today and the existing N23 modal does not enforce the comparable per-activation cap either, so this does not make N26 stricter than N23.

## Testing

Verified with `npm run lint` (only pre-existing errors in unrelated files remain) and `npm run build`, which type-checks the whole project.

> [!NOTE]
> Not yet exercised against a running app — the local Supabase database is on a stale schema and cannot serve sign-in, so the modal has not been clicked through in either edition.

## Worth checking on staging

1. **N23 gang, no regression.** The modal still lists Cause Serious Injury, Cause OOA, Leader/Champion, Wreck Vehicle, Successful Rally, Provide Assistance and Misc. as counters, with Battle Participation as the only checkbox. Should be identical to production.
2. **N26 gang.** Successful Rally is gone, Leader/Champion reads Leader/Champion/Brute/Vehicle, and Controlled an Objective appears as a second checkbox below Battle Participation.
3. **N26 totals.** Cause OOA 1 + Leader/Champion/Brute/Vehicle 1 totals 3 XP, and the fighter's XP and OOA count both increase correctly after saving.
4. **N26 fighter log.** The saved entry names the two new awards in full rather than printing raw ids like `eliteTargetBonus` or `objectiveControl`.
5. **An older N23 log entry containing Successful Rally still renders its label**, not a raw `rally` id. This is the main risk in deriving the log lookup maps from the new registry, and needs existing staging data rather than a freshly created entry.
6. **All three entry points** show the right list for the same fighter: gang overview card menu, fighter detail page, battle session participant card. The battle session is the one to watch, since its edition comes from the session rather than the gang.
7. **A custom fighter type in an N26 gang** still gets the N26 list, confirming the edition is read from the gang and not the fighter type.
8. **The optional OOA / wrecked-crew target picker** still opens, records targets and increments kills in both editions.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
