### PR TITLE
Make admin skills API and Default Skills edition-aware

### DIFF
--- a/app/api/admin/skills/route.ts
+++ b/app/api/admin/skills/route.ts
@@ -13,6 +13,7 @@ export async function GET(request: Request) {
   const supabase = await createClient();
   const { searchParams } = new URL(request.url);
   const skillTypeId = searchParams.get('skill_type_id');
+  const editionId = searchParams.get('edition_id');
   const effectTypeId = searchParams.get('effect_type_id');
   const modifierId = searchParams.get('modifier_id');
 
@@ -66,11 +67,20 @@ export async function GET(request: Request) {
     // Handle skill queries
     let query = supabase
       .from('skills')
-      .select('id, name, skill_type_id, gang_origin_id')
+      .select(editionId
+        ? 'id, name, skill_type_id, gang_origin_id, skill_types!inner(edition_id)'
+        : 'id, name, skill_type_id, gang_origin_id, skill_types(edition_id)')
       .order('name');
 
     if (skillTypeId) {
       query = query.eq('skill_type_id', skillTypeId);
+    }
+
+    // A skill belongs to an edition through its skill set. The inner relation is
+    // important here: filtering an ordinary embedded relation would leave the
+    // parent skill rows in the result with an empty relation.
+    if (editionId) {
+      query = query.eq('skill_types.edition_id', editionId);
     }
 
     const { data, error } = await query;
@@ -79,22 +89,26 @@ export async function GET(request: Request) {
 
     // If fetching a specific skill, include its effects
     let transformedData;
-    if (skillTypeId && data.length > 0) {
+    if (skillTypeId) {
       // Fetch effects for all skills in the result
       const skillIds = data.map((skill: Skill) => skill.id);
 
-      const { data: effectTypes } = await supabase
-        .from('fighter_effect_types')
-        .select(`
-          id,
-          effect_name,
-          fighter_effect_category_id,
-          type_specific_data,
-          sort_order,
-          fighter_effect_categories(id, category_name)
-        `)
-        .in('type_specific_data->>skill_id', skillIds)
-        .order('sort_order', { ascending: true, nullsFirst: false });
+      let effectTypes: any[] = [];
+      if (skillIds.length > 0) {
+        const { data: effectTypeData } = await supabase
+          .from('fighter_effect_types')
+          .select(`
+            id,
+            effect_name,
+            fighter_effect_category_id,
+            type_specific_data,
+            sort_order,
+            fighter_effect_categories(id, category_name)
+          `)
+          .in('type_specific_data->>skill_id', skillIds)
+          .order('sort_order', { ascending: true, nullsFirst: false });
+        effectTypes = effectTypeData || [];
+      }
 
       // Fetch modifiers for the effect types
       let modifiers: any[] = [];
@@ -128,7 +142,7 @@ export async function GET(request: Request) {
 
       // Extract unique categories from the effects (they're already nested in each effect)
       const uniqueCategories = new Map();
-      effectTypes?.forEach((et: any) => {
+      effectTypes.forEach((et: any) => {
         if (et.fighter_effect_categories) {
           uniqueCategories.set(
             et.fighter_effect_categories.id,

--- a/components/admin/admin-create-fighter-type.tsx
+++ b/components/admin/admin-create-fighter-type.tsx
@@ -185,6 +185,15 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
   const handleEditionChange = (newEditionId: string) => {
     setEditionId(newEditionId);
 
+    // Skills are edition-owned through their skill set. Unknown skill metadata
+    // is discarded as well so a stale selection can never be submitted after
+    // the user explicitly changes edition.
+    setSelectedSkills(prev => prev.filter(skillId => {
+      const skill = skills.find(candidate => candidate.id === skillId);
+      const skillType = skillTypes.find(type => type.id === skill?.skill_type_id);
+      return !!skillType && (!newEditionId || skillType.edition_id === newEditionId);
+    }));
+
     if (editions.find(edition => edition.id === newEditionId)?.slug !== 'n26') {
       setIsVehicle(false);
     }
@@ -230,9 +239,11 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
   };
 
   const { data: skills = [] } = useQuery<Skill[]>({
-    queryKey: ['admin-skills', selectedSkillType],
+    queryKey: ['admin-skills', selectedSkillType, editionId],
     queryFn: async () => {
-      const response = await fetch(`/api/admin/skills?skill_type_id=${selectedSkillType}`);
+      const params = new URLSearchParams({ skill_type_id: selectedSkillType });
+      if (editionId) params.set('edition_id', editionId);
+      const response = await fetch(`/api/admin/skills?${params}`);
       if (!response.ok) throw new Error('Failed to fetch skills');
       const data = await response.json();
       return Array.isArray(data) ? data : data.skills || [];
@@ -1210,4 +1221,4 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
       </div>
     </div>
   );
-} 
+}

--- a/components/admin/admin-create-fighter-type.tsx
+++ b/components/admin/admin-create-fighter-type.tsx
@@ -82,6 +82,7 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
   const [selectedEquipment, setSelectedEquipment] = useState<string[]>([]);
   const [selectedSkillType, setSelectedSkillType] = useState('');
   const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
+  const [loadedSkills, setLoadedSkills] = useState<Skill[]>([]);
   const [equipmentListSelections, setEquipmentListSelections] = useState<string[]>([]);
   const [equipmentDiscounts, setEquipmentDiscounts] = useState<{
     equipment_id: string;
@@ -189,7 +190,7 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
     // is discarded as well so a stale selection can never be submitted after
     // the user explicitly changes edition.
     setSelectedSkills(prev => prev.filter(skillId => {
-      const skill = skills.find(candidate => candidate.id === skillId);
+      const skill = loadedSkills.find(candidate => candidate.id === skillId);
       const skillType = skillTypes.find(type => type.id === skill?.skill_type_id);
       return !!skillType && (!newEditionId || skillType.edition_id === newEditionId);
     }));
@@ -843,6 +844,14 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
                   onChange={(e) => {
                     const value = e.target.value;
                     if (value && !selectedSkills.includes(value)) {
+                      const selectedSkill = skills.find(skill => skill.id === value);
+                      if (selectedSkill) {
+                        setLoadedSkills(previous => {
+                          const merged = new Map(previous.map(skill => [skill.id, skill]));
+                          merged.set(selectedSkill.id, selectedSkill);
+                          return Array.from(merged.values());
+                        });
+                      }
                       setSelectedSkills([...selectedSkills, value]);
                     }
                     e.target.value = "";
@@ -862,8 +871,7 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
 
                 <div className="mt-2 flex flex-wrap gap-2">
                   {selectedSkills.map((skillId) => {
-                    const skill = skills.find(s => s.id === skillId) || 
-                                skills.find(s => s.id === skillId);
+                    const skill = loadedSkills.find(s => s.id === skillId);
                     if (!skill) return null;
                     
                     return (

--- a/components/admin/admin-create-skill.tsx
+++ b/components/admin/admin-create-skill.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -23,7 +23,7 @@ export function AdminCreateSkillModal({ onClose, onSubmit }: AdminCreateSkillMod
   const [editionId, setEditionId] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
-  const { data: skillTypeList = [] } = useQuery<Array<{id: string, skill_type: string}>>({
+  const { data: skillTypeList = [] } = useQuery<Array<{id: string, skill_type: string, edition_id?: string | null}>>({
     queryKey: ['admin-skill-types'],
     queryFn: async () => {
       const response = await fetch('/api/admin/skill-types');
@@ -32,6 +32,24 @@ export function AdminCreateSkillModal({ onClose, onSubmit }: AdminCreateSkillMod
     },
     staleTime: 5 * 60 * 1000,
   });
+
+  const filteredSkillTypeList = useMemo(
+    () => editionId
+      ? skillTypeList.filter(type => type.edition_id === editionId)
+      : skillTypeList,
+    [skillTypeList, editionId]
+  );
+
+  const handleEditionChange = (newEditionId: string) => {
+    setEditionId(newEditionId);
+
+    if (newEditionId && skillType) {
+      const selectedType = skillTypeList.find(type => type.id === skillType);
+      if (!selectedType || selectedType.edition_id !== newEditionId) {
+        setSkillType('');
+      }
+    }
+  };
 
   const { data: gangOriginList = [] } = useQuery<Array<{id: string, origin_name: string, category_name: string}>>({
     queryKey: ['admin-gang-origins'],
@@ -146,6 +164,8 @@ export function AdminCreateSkillModal({ onClose, onSubmit }: AdminCreateSkillMod
 
         <div className="px-[10px] py-4">
           <div className="grid grid-cols-1 gap-4">
+            <EditionSelect value={editionId} onChange={handleEditionChange} defaultToCurrent />
+
             <div className="col-span-1">
               <label className="block text-sm font-medium text-muted-foreground mb-1">
                 Skill Set *
@@ -159,7 +179,7 @@ export function AdminCreateSkillModal({ onClose, onSubmit }: AdminCreateSkillMod
                 <option value="">Select a skill set</option>
 
                 {Object.entries(
-                  skillTypeList
+                  filteredSkillTypeList
                     .sort((a, b) => {
                       const rankA = skillSetRank[a.skill_type.toLowerCase()] ?? Infinity;
                       const rankB = skillSetRank[b.skill_type.toLowerCase()] ?? Infinity;
@@ -180,7 +200,7 @@ export function AdminCreateSkillModal({ onClose, onSubmit }: AdminCreateSkillMod
                       if (!groups[groupLabel]) groups[groupLabel] = [];
                       groups[groupLabel].push(type);
                       return groups;
-                    }, {} as Record<string, typeof skillTypeList>)
+                    }, {} as Record<string, typeof filteredSkillTypeList>)
                 ).map(([groupLabel, skillList]) => (
                   <optgroup key={groupLabel} label={groupLabel}>
                     {skillList.map((type) => (
@@ -272,10 +292,6 @@ export function AdminCreateSkillModal({ onClose, onSubmit }: AdminCreateSkillMod
               )}
             </div>
 
-            {/* Skills inherit their edition from the skill set; only new skill sets need one */}
-            {skillTypeName !== '' && (
-              <EditionSelect value={editionId} onChange={setEditionId} defaultToCurrent />
-            )}
           </div>
         </div>
 

--- a/components/admin/admin-edit-fighter-type.tsx
+++ b/components/admin/admin-edit-fighter-type.tsx
@@ -217,8 +217,10 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
   // Memoize filtered skills to avoid recalculating on every render
   const availableSkills = useMemo(() => {
     if (!Array.isArray(skills)) return [];
-    return skills.filter(skill => !selectedSkills.includes(skill.id));
-  }, [skills, selectedSkills]);
+    return skills.filter(skill =>
+      skill.skill_type_id === selectedSkillType && !selectedSkills.includes(skill.id)
+    );
+  }, [skills, selectedSkills, selectedSkillType]);
 
   const fetchEquipmentByCategory = async () => {
     if (hasLoadedEquipmentCategoriesRef.current && equipment.length > 0) {
@@ -384,6 +386,14 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
   const handleEditionChange = (newEditionId: string) => {
     setEditionId(newEditionId);
 
+    // Keep loaded metadata for rendering saved skills, but remove any selection
+    // that cannot be proved to belong to the newly selected edition.
+    setSelectedSkills(prev => prev.filter(skillId => {
+      const skill = skills.find(candidate => candidate.id === skillId);
+      const skillType = skillTypes.find(type => type.id === skill?.skill_type_id);
+      return !!skillType && (!newEditionId || skillType.edition_id === newEditionId);
+    }));
+
     if (editions.find(edition => edition.id === newEditionId)?.slug !== 'n26') {
       setIsVehicle(false);
     }
@@ -484,17 +494,23 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
   useEffect(() => {
     const fetchSkills = async () => {
       if (!selectedSkillType) {
-        setSkills([]);
         return;
       }
 
       try {
-        const response = await fetch(`/api/admin/skills?skill_type_id=${selectedSkillType}`);
+        const params = new URLSearchParams({ skill_type_id: selectedSkillType });
+        if (editionId) params.set('edition_id', editionId);
+        const response = await fetch(`/api/admin/skills?${params}`);
         if (!response.ok) throw new Error('Failed to fetch skills');
         const data = await response.json();
         // API returns {skills: [], effect_categories: []} when filtered by skill_type_id
         const skillsArray = Array.isArray(data) ? data : data.skills || [];
-        setSkills(skillsArray);
+        // Preserve metadata for saved selections while the fighter record is
+        // loading so their chips can still be rendered.
+        setSkills(previous => {
+          const merged = new Map([...previous, ...skillsArray].map(skill => [skill.id, skill]));
+          return Array.from(merged.values());
+        });
       } catch (error) {
         console.error('Error fetching skills:', error);
         toast.error('Failed to load skills');
@@ -502,7 +518,7 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
     };
 
     fetchSkills();
-  }, [selectedSkillType]);
+  }, [selectedSkillType, editionId]);
 
   // Fetch full skill details for selected skills when loading a fighter type
   useEffect(() => {

--- a/components/admin/admin-edit-skill.tsx
+++ b/components/admin/admin-edit-skill.tsx
@@ -188,7 +188,7 @@ export function AdminEditSkillModal({ onClose, onSubmit }: AdminEditSkillModalPr
     setEditionId(newEditionId);
     if (newEditionId && skillType) {
       const selectedType = skillTypeList.find(t => t.id === skillType);
-      if (selectedType && selectedType.edition_id !== newEditionId) {
+      if (!selectedType || selectedType.edition_id !== newEditionId) {
         setSkillType('');
         setSkillTypeName('');
         setSkillName('');
@@ -209,11 +209,13 @@ export function AdminEditSkillModal({ onClose, onSubmit }: AdminEditSkillModalPr
     }
   }
 
-  const searchSkillType = async (skillTypeId: string) => {
+  const searchSkillType = async (skillTypeId: string, selectedEditionId: string) => {
     setIsLoading(true);
 
     try {
-      const response = await fetch('/api/admin/skills?skill_type_id=' + skillTypeId, {
+      const params = new URLSearchParams({ skill_type_id: skillTypeId });
+      if (selectedEditionId) params.set('edition_id', selectedEditionId);
+      const response = await fetch(`/api/admin/skills?${params}`, {
         method: 'GET',
         headers: {
           'Content-Type': 'application/json',
@@ -433,13 +435,14 @@ const handleSubmitSkill = async (operation: OperationType) => {
                     const selectedIndex = e.target.selectedIndex;
                     const selectedOption = e.target.options[selectedIndex];
                     const selectedSkillType = selectedOption.getAttribute("data-skill-type") || "";
+                    const selectedType = skillTypeList.find(t => t.id === e.target.value);
+                    const selectedEditionId = selectedType?.edition_id ?? editionId;
                     setSkillType(e.target.value);
                     setSkillName("");
                     if (e.target.value !== "") {
-                      searchSkillType(e.target.value);
+                      searchSkillType(e.target.value, selectedEditionId);
                     }
                     setSkillTypeName(selectedSkillType);
-                    const selectedType = skillTypeList.find(t => t.id === e.target.value);
                     setEditionId(selectedType?.edition_id ?? '');
                   }
                 }


### PR DESCRIPTION
### Motivation
- Ensure skills can be scoped to an edition so admin UI can show only edition-appropriate Default Skills and prevent submitting mismatched defaults after an edition change.
- Preserve existing backward-compatible behaviour for callers that do not provide an edition filter.

### Description
- Add optional `edition_id` query parameter to `GET /api/admin/skills` and join `skill_types` so skills can be constrained to the supplied edition using an inner relation filter while keeping unfiltered responses unchanged.
- Keep the existing response shapes: unfiltered requests still return an array, and `skill_type_id`-filtered requests continue to return `{ skills, effect_categories }` (including empty collections on edition/skill-set mismatches).
- Update `components/admin/admin-create-fighter-type.tsx` to include `editionId` in the `['admin-skills', selectedSkillType, editionId]` query key and send `edition_id` via `URLSearchParams`, and drop selected default-skill IDs that do not belong to the newly selected edition when `handleEditionChange` runs.
- Update `components/admin/admin-edit-fighter-type.tsx` to include `editionId` in the fetch, add `editionId` to the effect dependencies so requests are re-run when the edition changes, retain merged skill metadata so already-saved skills can render while the fighter record loads, and remove selections that cannot be proven to belong to the new edition.

### Testing
- `npx tsc --noEmit` completed successfully with no type errors.
- `npx eslint` checks for the modified files completed successfully with no lint errors reported.
- `git diff --check` returned no whitespace/patch problems for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a75f9e886f48332a3fa1ae84fd1fae7)