### PR TITLE
Scope skill type names by edition

### DIFF
--- a/supabase/migrations/20260808100000_update_skill_types_name_unique_constraint.sql
+++ b/supabase/migrations/20260808100000_update_skill_types_name_unique_constraint.sql
@@ -1,0 +1,6 @@
+ALTER TABLE public.skill_types
+DROP CONSTRAINT skill_types_name_key;
+
+ALTER TABLE public.skill_types
+ADD CONSTRAINT skill_types_edition_id_name_key
+UNIQUE (edition_id, name);


### PR DESCRIPTION
### Motivation
- Ensure `skill_types` names are unique per edition instead of globally so identical names can exist across different editions.

### Description
- Add a new migration file `supabase/migrations/20260808100000_update_skill_types_name_unique_constraint.sql` that drops the existing `skill_types_name_key` constraint and adds a composite unique constraint `skill_types_edition_id_name_key` on `(edition_id, name)`.

### Testing
- ✅ Ran `git diff --cached --check`, `git status --short --branch`, and `git log -1 --oneline --decorate`, which completed successfully, and ⚠️ attempted to call the configured PR tool (`make_pr`) failed due to an environment limitation (missing module / MCP client inability to start).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a76f7655a708332991024c08ed1c771)