### PR TITLE
Pass editionSlug to the Add Vehicle catalog

### DIFF
--- a/components/gang/gang.tsx
+++ b/components/gang/gang.tsx
@@ -1317,6 +1317,7 @@ export default function Gang({
                 gangId={id}
                 gangTypeId={gang_type_id}
                 customGangTypeId={custom_gang_type_id}
+                editionSlug={edition_slug}
                 initialCredits={credits}
                 onFighterAdded={handleFighterAdded}
                 onFighterRollback={onFighterRollback}


### PR DESCRIPTION
The vehicles catalog was the one FighterAddModal call site that never received
editionSlug. #1959 added the prop along with an edition filter in the modal's
queryFn, and wired it to the two instances that existed on that branch; the
third arrived from #1960 in the same merge and was missed.

editionSlug defaults to null, and sameEditionForDisplay reads a missing slug as
n23, so every n26 vehicle fighter type was discarded client-side and Add
Vehicle rendered an empty list on every n26 gang.