### PR TITLE
Add N26 Sv and multi-subtype editing to Edit Fighter.

### DIFF
--- a/app/actions/edit-fighter.ts
+++ b/app/actions/edit-fighter.ts
@@ -142,31 +142,41 @@ function normalizeFighterSubtypeNames(subtypes: string[]): string[] {
 /**
  * Edition for subtype validation: prefer the type being written in this update,
  * else the fighter's current type, else the gang's edition.
+ * Fail closed — query errors or a missing slug reject rather than skipping checks.
  */
 async function resolveFighterEditionSlugForUpdate(
   supabase: any,
   fighterId: string,
   params: Pick<UpdateFighterDetailsParams, 'fighter_type_id' | 'custom_fighter_type_id'>
-): Promise<string | null> {
+): Promise<{ ok: true; editionSlug: string } | { ok: false; error: string }> {
+  const fail = {
+    ok: false as const,
+    error: 'Could not resolve edition for fighter subtype validation.',
+  };
+
   if (params.fighter_type_id) {
-    const { data } = await supabase
+    const { data, error } = await supabase
       .from('fighter_types')
       .select('editions:edition_id ( slug )')
       .eq('id', params.fighter_type_id)
       .single();
-    return editionSlugFromJoin(data?.editions);
+    if (error || !data) return fail;
+    const editionSlug = editionSlugFromJoin(data.editions);
+    return editionSlug ? { ok: true, editionSlug } : fail;
   }
 
   if (params.custom_fighter_type_id) {
-    const { data } = await supabase
+    const { data, error } = await supabase
       .from('custom_fighter_types')
       .select('editions:edition_id ( slug )')
       .eq('id', params.custom_fighter_type_id)
       .single();
-    return editionSlugFromJoin(data?.editions);
+    if (error || !data) return fail;
+    const editionSlug = editionSlugFromJoin(data.editions);
+    return editionSlug ? { ok: true, editionSlug } : fail;
   }
 
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from('fighters')
     .select(`
       fighter_types:fighter_type_id ( editions:edition_id ( slug ) ),
@@ -179,32 +189,49 @@ async function resolveFighterEditionSlugForUpdate(
     .eq('id', fighterId)
     .single();
 
-  return (
-    editionSlugFromJoin(data?.fighter_types?.editions) ??
-    editionSlugFromJoin(data?.custom_fighter_types?.editions) ??
-    gangEditionSlug(data?.gangs) ??
-    null
-  );
+  if (error || !data) return fail;
+
+  const editionSlug =
+    editionSlugFromJoin(data.fighter_types?.editions) ??
+    editionSlugFromJoin(data.custom_fighter_types?.editions) ??
+    gangEditionSlug(data.gangs) ??
+    null;
+
+  return editionSlug ? { ok: true, editionSlug } : fail;
 }
 
 async function validateFighterSubtypesForUpdate(
   supabase: any,
   fighterId: string,
   params: UpdateFighterDetailsParams,
-  subtypes: string[]
+  subtypes: string[],
+  currentSubtypes?: string[] | null
 ): Promise<{ ok: true; subtypes: string[] } | { ok: false; error: string }> {
   const normalized = normalizeFighterSubtypeNames(subtypes);
-  const editionSlug = await resolveFighterEditionSlugForUpdate(supabase, fighterId, params);
+  const previous = normalizeFighterSubtypeNames(
+    Array.isArray(currentSubtypes) ? currentSubtypes : []
+  );
 
-  // Only enforce single-subtype when we know the edition forbids multiples.
-  if (editionSlug != null && !allowsMultipleSubtypes(editionSlug) && normalized.length > 1) {
+  // Mirror client confirmDisabled: do not allow wiping a non-empty subtype list
+  if (normalized.length === 0 && previous.length > 0) {
+    return {
+      ok: false,
+      error: 'At least one fighter subtype is required.',
+    };
+  }
+
+  const editionResult = await resolveFighterEditionSlugForUpdate(supabase, fighterId, params);
+  if (!editionResult.ok) return editionResult;
+  const { editionSlug } = editionResult;
+
+  if (!allowsMultipleSubtypes(editionSlug) && normalized.length > 1) {
     return {
       ok: false,
       error: 'This edition only allows one fighter subtype.',
     };
   }
 
-  if (normalized.length > 0 && editionSlug) {
+  if (normalized.length > 0) {
     const { data: edition, error: editionError } = await supabase
       .from('editions')
       .select('id')
@@ -1418,7 +1445,7 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
     // Get fighter data (RLS will handle permissions)
     const { data: fighter, error: fighterError } = await supabase
       .from('fighters')
-      .select('id, gang_id, user_id, cost_adjustment, kills, kill_count, killed, retired, enslaved, captured, fighter_name')
+      .select('id, gang_id, user_id, cost_adjustment, kills, kill_count, killed, retired, enslaved, captured, fighter_name, fighter_subtypes')
       .eq('id', params.fighter_id)
       .single();
 
@@ -1447,7 +1474,8 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
         supabase,
         params.fighter_id,
         params,
-        params.fighter_subtypes
+        params.fighter_subtypes,
+        fighter.fighter_subtypes
       );
       if (!validated.ok) {
         return { success: false, error: validated.error };

--- a/app/actions/edit-fighter.ts
+++ b/app/actions/edit-fighter.ts
@@ -10,6 +10,7 @@ import { logFighterAction } from './logs/fighter-logs';
 import { countsTowardRating, hasKilledStatusFlag } from '@/utils/fighter-status';
 import { updateGangFinancials, updateGangRatingSimple, GangFinancialUpdateResult } from '@/utils/gang-rating-and-wealth';
 import { insertFighterOoaRecords } from './fighter-ooa-records';
+import { allowsMultipleSubtypes, editionSlugFromJoin, gangEditionSlug } from '@/types/edition';
 
 // Helper function to invalidate owner's cache when beast fighter is updated
 async function invalidateBeastOwnerCache(fighterId: string, gangId: string, supabase: any) {
@@ -123,6 +124,117 @@ export interface UpdateFighterDetailsParams {
   selected_archetype_id?: string | null;
   // New: optional stat adjustments to be applied as user effects
   stat_adjustments?: Record<string, number>;
+}
+
+/** Trim, drop empties, dedupe while preserving first-seen order. */
+function normalizeFighterSubtypeNames(subtypes: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const raw of subtypes) {
+    const name = typeof raw === 'string' ? raw.trim() : '';
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    result.push(name);
+  }
+  return result;
+}
+
+/**
+ * Edition for subtype validation: prefer the type being written in this update,
+ * else the fighter's current type, else the gang's edition.
+ */
+async function resolveFighterEditionSlugForUpdate(
+  supabase: any,
+  fighterId: string,
+  params: Pick<UpdateFighterDetailsParams, 'fighter_type_id' | 'custom_fighter_type_id'>
+): Promise<string | null> {
+  if (params.fighter_type_id) {
+    const { data } = await supabase
+      .from('fighter_types')
+      .select('editions:edition_id ( slug )')
+      .eq('id', params.fighter_type_id)
+      .single();
+    return editionSlugFromJoin(data?.editions);
+  }
+
+  if (params.custom_fighter_type_id) {
+    const { data } = await supabase
+      .from('custom_fighter_types')
+      .select('editions:edition_id ( slug )')
+      .eq('id', params.custom_fighter_type_id)
+      .single();
+    return editionSlugFromJoin(data?.editions);
+  }
+
+  const { data } = await supabase
+    .from('fighters')
+    .select(`
+      fighter_types:fighter_type_id ( editions:edition_id ( slug ) ),
+      custom_fighter_types:custom_fighter_type_id ( editions:edition_id ( slug ) ),
+      gangs!gang_id (
+        gang_types!gang_type_id ( editions:edition_id ( slug ) ),
+        custom_gang_types!custom_gang_type_id ( editions:edition_id ( slug ) )
+      )
+    `)
+    .eq('id', fighterId)
+    .single();
+
+  return (
+    editionSlugFromJoin(data?.fighter_types?.editions) ??
+    editionSlugFromJoin(data?.custom_fighter_types?.editions) ??
+    gangEditionSlug(data?.gangs) ??
+    null
+  );
+}
+
+async function validateFighterSubtypesForUpdate(
+  supabase: any,
+  fighterId: string,
+  params: UpdateFighterDetailsParams,
+  subtypes: string[]
+): Promise<{ ok: true; subtypes: string[] } | { ok: false; error: string }> {
+  const normalized = normalizeFighterSubtypeNames(subtypes);
+  const editionSlug = await resolveFighterEditionSlugForUpdate(supabase, fighterId, params);
+
+  // Only enforce single-subtype when we know the edition forbids multiples.
+  if (editionSlug != null && !allowsMultipleSubtypes(editionSlug) && normalized.length > 1) {
+    return {
+      ok: false,
+      error: 'This edition only allows one fighter subtype.',
+    };
+  }
+
+  if (normalized.length > 0 && editionSlug) {
+    const { data: edition, error: editionError } = await supabase
+      .from('editions')
+      .select('id')
+      .eq('slug', editionSlug)
+      .single();
+
+    if (editionError || !edition) {
+      return { ok: false, error: 'Could not resolve edition for fighter subtype validation.' };
+    }
+
+    const { data: catalog, error: catalogError } = await supabase
+      .from('fighter_subtypes')
+      .select('subtype_name')
+      .eq('edition_id', edition.id);
+
+    if (catalogError) {
+      return { ok: false, error: 'Failed to validate fighter subtypes.' };
+    }
+
+    const validNames = new Set((catalog ?? []).map((row: { subtype_name: string }) => row.subtype_name));
+    const unknown = normalized.filter(name => !validNames.has(name));
+    if (unknown.length > 0) {
+      return {
+        ok: false,
+        error: `Unknown fighter subtype(s) for this edition: ${unknown.join(', ')}`,
+      };
+    }
+  }
+
+  return { ok: true, subtypes: normalized };
 }
 
 interface EditFighterResult {
@@ -1330,7 +1442,18 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
     if (params.kill_count !== undefined) updateData.kill_count = params.kill_count;
     if (params.cost_adjustment !== undefined) updateData.cost_adjustment = params.cost_adjustment;
     if (params.special_rules !== undefined) updateData.special_rules = params.special_rules;
-    if (params.fighter_subtypes !== undefined) updateData.fighter_subtypes = params.fighter_subtypes;
+    if (params.fighter_subtypes !== undefined) {
+      const validated = await validateFighterSubtypesForUpdate(
+        supabase,
+        params.fighter_id,
+        params,
+        params.fighter_subtypes
+      );
+      if (!validated.ok) {
+        return { success: false, error: validated.error };
+      }
+      updateData.fighter_subtypes = validated.subtypes;
+    }
     if (params.fighter_type !== undefined) updateData.fighter_type = params.fighter_type;
     if (params.fighter_type_id !== undefined) updateData.fighter_type_id = params.fighter_type_id;
     if (params.custom_fighter_type_id !== undefined) updateData.custom_fighter_type_id = params.custom_fighter_type_id;

--- a/app/actions/edit-fighter.ts
+++ b/app/actions/edit-fighter.ts
@@ -1347,7 +1347,7 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
       .from('fighters')
       .update(updateData)
       .eq('id', params.fighter_id)
-      .select('id, fighter_name, label, kills, kill_count, cost_adjustment')
+      .select('id, fighter_name, label, kills, kill_count, cost_adjustment, fighter_subtypes')
       .single();
 
     if (updateError) throw updateError;

--- a/components/fighter/edit-fighter/character-stats-modal.tsx
+++ b/components/fighter/edit-fighter/character-stats-modal.tsx
@@ -1,10 +1,11 @@
 import { useState, useMemo } from 'react';
 import { FighterEffect, FighterProps as Fighter } from '@/types/fighter';
+import { hasSaveCharacteristic } from '@/types/edition';
 import { Button } from "@/components/ui/button";
 import { LuPlus } from "react-icons/lu";
 import { LuMinus } from "react-icons/lu";
 
-type StatKey = "M" | "WS" | "BS" | "S" | "T" | "W" | "I" | "A" | "Ld" | "Cl" | "Wil" | "Int";
+type StatKey = "M" | "WS" | "BS" | "S" | "T" | "W" | "I" | "A" | "Sv" | "Ld" | "Cl" | "Wil" | "Int";
 
 interface Stat {
   key: StatKey;
@@ -35,6 +36,7 @@ export function CharacterStatsModal({
     wounds: 0,
     initiative: 0,
     attacks: 0,
+    save: 0,
     leadership: 0,
     cool: 0,
     willpower: 0,
@@ -43,7 +45,7 @@ export function CharacterStatsModal({
 
   // Map fighter stats to our format for display
   const displayStats = useMemo((): Stat[] => {
-    return [
+    const stats: Stat[] = [
       { key: "M", name: "Movement", value: `${fighter.movement}"` },
       { key: "WS", name: "Weapon Skill", value: `${fighter.weapon_skill}+` },
       { key: "BS", name: "Ballistic Skill", value: `${fighter.ballistic_skill}+` },
@@ -57,6 +59,17 @@ export function CharacterStatsModal({
       { key: "Wil", name: "Willpower", value: `${fighter.willpower}+` },
       { key: "Int", name: "Intelligence", value: `${fighter.intelligence}+` },
     ];
+
+    if (hasSaveCharacteristic(fighter.edition_slug)) {
+      const attacksIndex = stats.findIndex(stat => stat.key === "A");
+      stats.splice(attacksIndex + 1, 0, {
+        key: "Sv",
+        name: "Save",
+        value: fighter.save != null ? `${fighter.save}+` : '-'
+      });
+    }
+
+    return stats;
   }, [fighter]);
 
   // Get the property name from the stat key
@@ -70,6 +83,7 @@ export function CharacterStatsModal({
       case "W": return "wounds";
       case "I": return "initiative";
       case "A": return "attacks";
+      case "Sv": return "save";
       case "Ld": return "leadership";
       case "Cl": return "cool";
       case "Wil": return "willpower";
@@ -96,19 +110,20 @@ export function CharacterStatsModal({
     }));
   };
 
-  // IMPORTANT: The base values should be the fighter's original stats
-  const getBaseValue = (key: StatKey): number => {
+  // IMPORTANT: The base values should be the fighter's original stats.
+  // Save is nullable — null means the characteristic is unset.
+  const getBaseValue = (key: StatKey): number | null => {
     const propName = getPropertyName(key);
-    return fighter[propName as keyof Fighter] as number;
+    const value = fighter[propName as keyof Fighter] as number | null | undefined;
+    if (key === "Sv") return value == null ? null : Number(value);
+    return value as number;
   };
 
   // This function now correctly gets the total including ALL modifiers
   // but does NOT include our adjustments (those are handled separately)
-  const getCurrentTotal = (key: StatKey): number => {
+  const getCurrentTotal = (key: StatKey): number | null => {
     const propName = getPropertyName(key);
-
-    // Get base value
-    const baseValue = fighter[propName as keyof Fighter] as number;
+    const baseValue = getBaseValue(key);
 
     // Get all modifiers from effects (injuries, advancements, user effects)
     let modifiers = 0;
@@ -134,19 +149,20 @@ export function CharacterStatsModal({
     processEffects(fighter.effects?.equipment);
     processEffects(fighter.effects?.user);
 
-    // Return total (base + existing modifiers)
-    return baseValue + modifiers;
+    if (key === "Sv" && baseValue == null && modifiers === 0) return null;
+    return (baseValue ?? 0) + modifiers;
   };
 
   // This function gets what the new total will be after our adjustments
   const getAdjustedTotal = (key: StatKey): string => {
     const propName = getPropertyName(key);
-
-    // Start with the current total (including all existing modifiers)
     const currentTotal = getCurrentTotal(key);
+    const adjustment = adjustments[propName] || 0;
 
-    // Add our new adjustment
-    const withAdjustment = currentTotal + (adjustments[propName] || 0);
+    // Null save with no adjustments stays unset; an adjustment grants a save.
+    if (key === "Sv" && currentTotal == null && adjustment === 0) return '-';
+
+    const withAdjustment = (currentTotal ?? 0) + adjustment;
 
     // Format based on stat type
     if (key === "M") return `${withAdjustment}"`;
@@ -158,7 +174,7 @@ export function CharacterStatsModal({
   const getBaseDisplay = (key: StatKey): string => {
     const baseValue = getBaseValue(key);
 
-    // Format the base value appropriately
+    if (key === "Sv" && baseValue == null) return '-';
     if (key === "M") return `${baseValue}"`;
     if (key === "W" || key === "A" || key === "S" || key === "T") return `${baseValue}`;
     return `${baseValue}+`;
@@ -203,7 +219,13 @@ export function CharacterStatsModal({
                       size="icon"
                       className="h-10 w-10 rounded-md"
                       onClick={() => handleDecrease(stat.key)}
-                      disabled={isSaving}
+                      disabled={
+                        isSaving ||
+                        // Unset Sv: only allow increase until a save is granted
+                        (stat.key === "Sv" &&
+                          getCurrentTotal("Sv") == null &&
+                          (adjustments.save || 0) <= 0)
+                      }
                     >
                       <LuMinus className="h-4 w-4" />
                     </Button>

--- a/components/fighter/edit-fighter/fighter-characteristic-table.tsx
+++ b/components/fighter/edit-fighter/fighter-characteristic-table.tsx
@@ -1,27 +1,51 @@
 import { useMemo } from 'react';
 import { FighterProps as Fighter } from '@/types/fighter';
+import { hasSaveCharacteristic } from '@/types/edition';
 
 export function FighterCharacteristicTable({ fighter }: { fighter: Fighter }) {
-  // Define the stats to display
-  const stats = [
-    { key: 'movement', label: 'M' },
-    { key: 'weapon_skill', label: 'WS' },
-    { key: 'ballistic_skill', label: 'BS' },
-    { key: 'strength', label: 'S' },
-    { key: 'toughness', label: 'T' },
-    { key: 'wounds', label: 'W' },
-    { key: 'initiative', label: 'I' },
-    { key: 'attacks', label: 'A' },
-    { key: 'leadership', label: 'Ld' },
-    { key: 'cool', label: 'Cl' },
-    { key: 'willpower', label: 'Wil' },
-    { key: 'intelligence', label: 'Int' }
-  ];
+  const stats = useMemo(() => {
+    const baseStats = [
+      { key: 'movement', label: 'M' },
+      { key: 'weapon_skill', label: 'WS' },
+      { key: 'ballistic_skill', label: 'BS' },
+      { key: 'strength', label: 'S' },
+      { key: 'toughness', label: 'T' },
+      { key: 'wounds', label: 'W' },
+      { key: 'initiative', label: 'I' },
+      { key: 'attacks', label: 'A' },
+      { key: 'leadership', label: 'Ld' },
+      { key: 'cool', label: 'Cl' },
+      { key: 'willpower', label: 'Wil' },
+      { key: 'intelligence', label: 'Int' }
+    ];
 
-  // IMPORTANT FIX: Get base values from original fighter properties directly
-  const getStat = (fighter: Fighter, key: string): number => {
-    // Return original base values from fighter object
-    return fighter[key as keyof Fighter] as number || 0;
+    if (!hasSaveCharacteristic(fighter.edition_slug)) return baseStats;
+
+    const attacksIndex = baseStats.findIndex(stat => stat.key === 'attacks');
+    return [
+      ...baseStats.slice(0, attacksIndex + 1),
+      { key: 'save', label: 'Sv' },
+      ...baseStats.slice(attacksIndex + 1)
+    ];
+  }, [fighter.edition_slug]);
+
+  // IMPORTANT FIX: Get base values from original fighter properties directly.
+  // Save is nullable (NULL = not applicable); do not coerce it to 0.
+  const getStat = (fighter: Fighter, key: string): number | null => {
+    const value = fighter[key as keyof Fighter];
+    if (key === 'save') {
+      return value == null ? null : Number(value);
+    }
+    return (value as number) || 0;
+  };
+
+  const formatStatValue = (key: string, value: number | null): string | number => {
+    if (key === 'save' && value == null) return '-';
+    if (key === 'movement') return `${value}"`;
+    if (key === 'wounds' || key === 'attacks' || key === 'strength' || key === 'toughness') {
+      return value as number;
+    }
+    return `${value}+`;
   };
 
   // Single function to calculate effects for any category
@@ -72,11 +96,7 @@ export function FighterCharacteristicTable({ fighter }: { fighter: Fighter }) {
 
               return (
                 <td key={stat.key} className="border-l border-border text-center text-xs">
-                  {stat.key === 'movement' ? `${baseValue}"` :
-                   stat.key === 'wounds' || stat.key === 'attacks' ||
-                   stat.key === 'strength' || stat.key === 'toughness' ?
-                   baseValue :
-                   `${baseValue}+`}
+                  {formatStatValue(stat.key, baseValue)}
                 </td>
               );
             })}
@@ -204,15 +224,16 @@ export function FighterCharacteristicTable({ fighter }: { fighter: Fighter }) {
               const augmentationsValue = augmentationsEffects[stat.key] || 0;
               const equipmentValue = equipmentEffects[stat.key] || 0;
               const powerBoostsValue = powerBoostsEffects[stat.key] || 0;
-              const total = baseValue + injuryValue + advancementValue + bionicsValue + userValue + geneSmithingValue + rigGlitchesValue + augmentationsValue + equipmentValue + powerBoostsValue;
+              const modifiers = injuryValue + advancementValue + bionicsValue + userValue + geneSmithingValue + rigGlitchesValue + augmentationsValue + equipmentValue + powerBoostsValue;
+
+              // Null save with no modifiers stays unset; modifiers alone grant a save.
+              const total = stat.key === 'save' && baseValue == null && modifiers === 0
+                ? null
+                : (baseValue ?? 0) + modifiers;
 
               return (
                 <td key={stat.key} className="border-l border-border text-center text-xs">
-                  {stat.key === 'movement' ? `${total}"` :
-                   stat.key === 'wounds' || stat.key === 'attacks' ||
-                   stat.key === 'strength' || stat.key === 'toughness' ?
-                   total :
-                   `${total}+`}
+                  {formatStatValue(stat.key, total)}
                 </td>
               );
             })}

--- a/components/fighter/edit-fighter/fighter-edit-modal.tsx
+++ b/components/fighter/edit-fighter/fighter-edit-modal.tsx
@@ -11,6 +11,7 @@ import { HiX } from "react-icons/hi";
 import { toast } from 'sonner';
 import { applySpecialRulesModifiers } from '@/utils/effect-modifiers';
 import { getFighterSubtypeSortRank } from '@/utils/fighterSubtypeRank';
+import { allowsMultipleSubtypes } from '@/types/edition';
 import { isArchetypeEligible, mapArchetypeSkillAccessToOverrides } from '@/utils/archetypeEligibility';
 import { SkillAccessModal } from './skill-access-modal';
 import { FighterCharacteristicTable } from './fighter-characteristic-table';
@@ -18,6 +19,13 @@ import { CharacterStatsModal } from './character-stats-modal';
 
 const normalizeSpecialRule = (rule: string) => rule.replace(/^"|"$/g, '');
 
+/** Order-sensitive equality for fighter_subtypes arrays (reference-list order). */
+function sameFighterSubtypes(a?: string[] | null, b?: string[] | null): boolean {
+  const left = a ?? [];
+  const right = b ?? [];
+  if (left.length !== right.length) return false;
+  return left.every((name, i) => name === right[i]);
+}
 
 interface FighterTypesData {
   displayTypes: Array<{
@@ -204,11 +212,17 @@ export function EditFighterModal({
   // State for skill access modal
   const [showSkillAccessModal, setShowSkillAccessModal] = useState(false);
 
-  // State for fighter subtype selection
-  const [selectedFighterSubtypeId, setSelectedFighterSubtypeId] = useState<string>('');
+  // State for fighter subtype selection (names; multi on N26, single on N23)
+  const [selectedFighterSubtypes, setSelectedFighterSubtypes] = useState<string[]>(() => {
+    const initial = fighter.fighter_subtypes ?? [];
+    return allowsMultipleSubtypes(fighter.edition_slug) ? initial : initial.slice(0, 1);
+  });
+  const [pendingSubtypeToAdd, setPendingSubtypeToAdd] = useState('');
 
   // State for archetype selection - initialize from fighter's saved archetype
   const [selectedArchetypeId, setSelectedArchetypeId] = useState<string>(fighter.selected_archetype_id || '');
+
+  const allowMultipleSubtypes = allowsMultipleSubtypes(fighter.edition_slug);
 
   // Fetch fighter subtypes for the subtype dropdown, scoped to the fighter's
   // edition: subtype_name is only unique within an edition, so an unscoped fetch
@@ -227,6 +241,24 @@ export function EditFighterModal({
     staleTime: 10 * 60 * 1000,
   });
 
+  const fighterSubtypesForDisplay = useMemo(() => {
+    return (allFighterSubtypes ?? [])
+      .filter(fc => !['*', 'Others', 'Special Terrain'].includes(fc.subtype_name))
+      .filter(fc =>
+        fc.subtype_name !== 'Exotic Beast Specialist' ||
+        fighter.fighter_subtypes?.includes('Exotic Beast') ||
+        selectedFighterSubtypes.includes('Exotic Beast')
+      );
+  }, [allFighterSubtypes, fighter.fighter_subtypes, selectedFighterSubtypes]);
+
+  // Subtypes not yet selected — for the N26 add Combobox
+  const availableSubtypeComboboxOptions = useMemo(() => {
+    const selected = new Set(selectedFighterSubtypes);
+    return fighterSubtypesForDisplay
+      .filter(fc => !selected.has(fc.subtype_name))
+      .map(fc => ({ value: fc.subtype_name, label: fc.subtype_name }));
+  }, [fighterSubtypesForDisplay, selectedFighterSubtypes]);
+
   // Compute the default fighter subtype name from the currently selected fighter type
   const defaultFighterSubtypeName = useMemo(() => {
     if (selectedFighterTypeId && fighterTypes.length > 0) {
@@ -236,14 +268,13 @@ export function EditFighterModal({
     return fighter.fighter_subtypes?.[0] || 'Unknown';
   }, [selectedFighterTypeId, fighterTypes, fighter.fighter_subtypes]);
 
-  // The effective fighter subtype: override if selected, otherwise default from type
-  const effectiveFighterSubtype = useMemo(() => {
-    if (selectedFighterSubtypeId && allFighterSubtypes) {
-      const overrideSubtype = allFighterSubtypes.find(fc => fc.id === selectedFighterSubtypeId);
-      if (overrideSubtype) return overrideSubtype.subtype_name;
-    }
-    return defaultFighterSubtypeName;
-  }, [selectedFighterSubtypeId, allFighterSubtypes, defaultFighterSubtypeName]);
+  // Archetypes still use a single effective subtype (first selected, else type default)
+  const effectiveFighterSubtype = selectedFighterSubtypes[0] || defaultFighterSubtypeName;
+
+  const archetypeFighterSubtypeId = useMemo(() => {
+    if (!effectiveFighterSubtype || !allFighterSubtypes) return '';
+    return allFighterSubtypes.find(fc => fc.subtype_name === effectiveFighterSubtype)?.id ?? '';
+  }, [effectiveFighterSubtype, allFighterSubtypes]);
 
   // Resolve the effective fighter type for default special rules (specialisation aware)
   const effectiveFighterType = useMemo(() => {
@@ -309,6 +340,57 @@ export function EditFighterModal({
     return options;
   }, [availableDefaultSpecialRules]);
 
+  // Group by type+subtype, prefer default (empty specialisation) versions, then cheapest
+  const fighterTypeComboboxOptions = useMemo(() => {
+    const typeSubtypeMap = new Map<string, { fighter: typeof fighterTypes[number]; cost: number }>();
+
+    fighterTypes.forEach(ft => {
+      const key = `${ft.fighter_type}-${ft.fighter_subtypes.join(',')}`;
+
+      if (!typeSubtypeMap.has(key)) {
+        typeSubtypeMap.set(key, { fighter: ft, cost: ft.total_cost });
+        return;
+      }
+
+      const current = typeSubtypeMap.get(key)!;
+      const currentHasEmptySpecialisation =
+        !(current.fighter as any).specialisation ||
+        Object.keys((current.fighter as any).specialisation).length === 0;
+      const fighterHasEmptySpecialisation =
+        !(ft as any).specialisation || Object.keys((ft as any).specialisation).length === 0;
+
+      if (fighterHasEmptySpecialisation && !currentHasEmptySpecialisation) {
+        typeSubtypeMap.set(key, { fighter: ft, cost: ft.total_cost });
+      } else if (currentHasEmptySpecialisation && !fighterHasEmptySpecialisation) {
+        // Keep current (default version)
+      } else if (ft.total_cost < current.cost) {
+        typeSubtypeMap.set(key, { fighter: ft, cost: ft.total_cost });
+      }
+    });
+
+    const typeOptions = Array.from(typeSubtypeMap.values())
+      .sort((a, b) => {
+        const subtypeRankA = getFighterSubtypeSortRank(a.fighter.fighter_subtypes, fighter.edition_slug);
+        const subtypeRankB = getFighterSubtypeSortRank(b.fighter.fighter_subtypes, fighter.edition_slug);
+
+        if (subtypeRankA !== subtypeRankB) {
+          return subtypeRankA - subtypeRankB;
+        }
+
+        return a.cost - b.cost;
+      })
+      .map(({ fighter: ft }) => {
+        const displayName = `${ft.fighter_type} (${ft.fighter_subtypes.join(', ')})`;
+        const gangVariantSuffix = (ft as any).is_gang_variant ? ` - ${(ft as any).gang_variant_name}` : '';
+        return {
+          value: ft.id,
+          label: `${displayName}${gangVariantSuffix}`,
+        };
+      });
+
+    return typeOptions;
+  }, [fighterTypes, fighter.edition_slug]);
+
   // Determine if this fighter can use archetypes (Outcasts gang + Leader/Champion subtype)
   const canUseArchetypes = isArchetypeEligible({
     gangTypeId,
@@ -317,11 +399,11 @@ export function EditFighterModal({
 
   // Fetch archetypes using TanStack Query (only if eligible and modal is open)
   const { data: archetypesData } = useQuery({
-    queryKey: ['skill-archetypes', selectedFighterSubtypeId],
+    queryKey: ['skill-archetypes', archetypeFighterSubtypeId],
     queryFn: async () => {
       const params = new URLSearchParams();
-      if (selectedFighterSubtypeId) {
-        params.set('fighter_subtype_id', selectedFighterSubtypeId);
+      if (archetypeFighterSubtypeId) {
+        params.set('fighter_subtype_id', archetypeFighterSubtypeId);
       }
       const response = await fetch(`/api/fighters/skill-archetypes?${params.toString()}`);
       if (!response.ok) throw new Error('Failed to fetch archetypes');
@@ -403,6 +485,9 @@ export function EditFighterModal({
         kills: submit.kills,
         kill_count: submit.kill_count,
         cost_adjustment: parseInt(submit.costAdjustment) || 0,
+        ...(submit.fighter_subtypes !== undefined
+          ? { fighter_subtypes: submit.fighter_subtypes }
+          : {}),
         ...(submit.fighter_type && (submit.fighter_type_id || submit.custom_fighter_type_id)
           ? {
               fighter_type: { fighter_type: submit.fighter_type, fighter_type_id: submit.fighter_type_id ?? null, gang_type_id: (submit as any).gang_type_id ?? null, custom_gang_type_id: (submit as any).custom_gang_type_id ?? null } as any,
@@ -471,10 +556,12 @@ export function EditFighterModal({
     setSelectedGangLegacyId((fighter as any).fighter_gang_legacy_id || '');
     setSelectedArchetypeId(fighter.selected_archetype_id || '');
     setHasExplicitlySelectedType(false);
-    if (fighter.fighter_subtypes?.length && allFighterSubtypes) {
-      const subtypeMatch = allFighterSubtypes.find(fc => fighter.fighter_subtypes.includes(fc.subtype_name));
-      if (subtypeMatch) setSelectedFighterSubtypeId(subtypeMatch.id);
-    }
+    const initialSubtypes = fighter.fighter_subtypes ?? [];
+    setSelectedFighterSubtypes(
+      allowsMultipleSubtypes(fighter.edition_slug)
+        ? initialSubtypes
+        : initialSubtypes.slice(0, 1)
+    );
   }
 
   // Pre-populate current fighter type and specialisation when fighter types are loaded
@@ -489,7 +576,7 @@ export function EditFighterModal({
 
     const allVariantsOfType = fighterTypes.filter(ft =>
       ft.fighter_type === currentType.fighter_type &&
-      ft.fighter_subtypes[0] === currentType.fighter_subtypes[0]
+      sameFighterSubtypes(ft.fighter_subtypes, currentType.fighter_subtypes)
     );
 
     let dropdownType = allVariantsOfType.find(ft =>
@@ -506,7 +593,7 @@ export function EditFighterModal({
 
     const fighterTypeGroup = fighterTypes.filter(t =>
       t.fighter_type === currentType.fighter_type &&
-      t.fighter_subtypes[0] === currentType.fighter_subtypes[0]
+      sameFighterSubtypes(t.fighter_subtypes, currentType.fighter_subtypes)
     );
 
     const specialisationOptions: Array<{ value: string; label: string; cost: number; fighterTypeId: string }> = [];
@@ -600,6 +687,12 @@ export function EditFighterModal({
         fighter_type: selectedType.fighter_type,
         fighter_subtypes: selectedType.fighter_subtypes
       }));
+      const typeSubtypes = selectedType.fighter_subtypes ?? [];
+      setSelectedFighterSubtypes(
+        allowMultipleSubtypes ? typeSubtypes : typeSubtypes.slice(0, 1)
+      );
+      setPendingSubtypeToAdd('');
+      setSelectedArchetypeId('');
 
       // Update available legacies for the selected fighter type
       setAvailableLegacies(selectedType.available_legacies || []);
@@ -607,7 +700,7 @@ export function EditFighterModal({
       // Get all fighters with the same fighter_type name and fighter_subtypes to check for specialisations
       const fighterTypeGroup = fighterTypes.filter(t =>
         t.fighter_type === selectedType.fighter_type &&
-        t.fighter_subtypes[0] === selectedType.fighter_subtypes[0]
+        sameFighterSubtypes(t.fighter_subtypes, selectedType.fighter_subtypes)
       );
       
       // If we have multiple entries with the same fighter_type + subtype, they represent different specialisations
@@ -689,6 +782,29 @@ export function EditFighterModal({
   // Add handler for gang legacy change
   const handleGangLegacyChange = (legacyId: string) => {
     setSelectedGangLegacyId(legacyId);
+  };
+
+  const handleAddFighterSubtype = () => {
+    const subtypeName = pendingSubtypeToAdd.trim();
+    if (!subtypeName || selectedFighterSubtypes.includes(subtypeName)) return;
+
+    const selected = new Set([...selectedFighterSubtypes, subtypeName]);
+    // Keep the reference-list order so the stored array doesn't depend on add order
+    setSelectedFighterSubtypes(
+      fighterSubtypesForDisplay.map(fc => fc.subtype_name).filter(name => selected.has(name))
+    );
+    setPendingSubtypeToAdd('');
+    setSelectedArchetypeId('');
+  };
+
+  const handleRemoveFighterSubtype = (subtypeName: string) => {
+    setSelectedFighterSubtypes(prev => prev.filter(name => name !== subtypeName));
+    setSelectedArchetypeId('');
+  };
+
+  const handleSingleFighterSubtypeChange = (subtypeName: string) => {
+    setSelectedFighterSubtypes(subtypeName ? [subtypeName] : []);
+    setSelectedArchetypeId('');
   };
 
   // Add handler for special rule combobox selection
@@ -841,16 +957,20 @@ export function EditFighterModal({
           
           // Get the actual fighter type and subtype values
           const currentFighterType = (fighter.fighter_type as any)?.fighter_type || fighter.fighter_type;
-          const currentFighterSubtypes = fighter.fighter_subtypes || [];
+          // Prefer the selected catalog type's subtypes for group matching so N26
+          // multi-subtype types resolve correctly even if the fighter override differs.
+          const typeForGroup = fighterTypes.find(ft => ft.id === selectedFighterTypeId);
+          const groupSubtypes = typeForGroup?.fighter_subtypes ?? fighter.fighter_subtypes ?? [];
 
           const availableFighterTypes = fighterTypes.filter(ft =>
-            ft.fighter_type === currentFighterType && ft.fighter_subtypes[0] === currentFighterSubtypes[0]
+            ft.fighter_type === currentFighterType &&
+            sameFighterSubtypes(ft.fighter_subtypes, groupSubtypes)
           );
 
           const fighterTypeWithSpecialisation = fighterTypes.find(ft =>
             ft.fighter_specialisation_id === selectedSpecialisation!.id &&
             ft.fighter_type === currentFighterType &&
-            ft.fighter_subtypes[0] === currentFighterSubtypes[0]
+            sameFighterSubtypes(ft.fighter_subtypes, groupSubtypes)
           );
           if (fighterTypeWithSpecialisation) {
             fighterTypeToUse = fighterTypeWithSpecialisation;
@@ -902,14 +1022,12 @@ export function EditFighterModal({
         }
       }
 
-      // Apply the selected fighter subtype
-      if (selectedFighterSubtypeId && allFighterSubtypes) {
-        const selectedSubtype = allFighterSubtypes.find(fc => fc.id === selectedFighterSubtypeId);
-        if (selectedSubtype) {
-          submitData.fighter_subtypes = [selectedSubtype.subtype_name];
-        } else {
-          submitData.fighter_subtypes = fighter.fighter_subtypes;
-        }
+      // Only send subtypes when dirty so rename/specialisation-only saves cannot
+      // clobber a prior override (type update may have set fighter_subtypes above).
+      if (!sameFighterSubtypes(selectedFighterSubtypes, fighter.fighter_subtypes)) {
+        submitData.fighter_subtypes = selectedFighterSubtypes;
+      } else {
+        delete submitData.fighter_subtypes;
       }
       
       // If lifecycle callbacks are provided, use TanStack mutation and close immediately
@@ -1023,81 +1141,14 @@ export function EditFighterModal({
               <label htmlFor="fighter_type_id" className="block text-sm font-medium mb-1">
                 Change Fighter Type
               </label>
-              <select
+              <Combobox
                 id="fighter_type_id"
                 value={selectedFighterTypeId}
-                onChange={(e) => handleFighterTypeChange(e.target.value)}
-                className="w-full p-2 border rounded-md"
-                disabled={false}
-              >
-                <option value="">
-                  Select a fighter type
-                </option>
-                {(() => {
-                  // Create a map to group fighters by type+subtype and find default version for each
-                  const typeSubtypeMap = new Map();
-                  
-                  fighterTypes.forEach(fighter => {
-                    const key = `${fighter.fighter_type}-${fighter.fighter_subtypes.join(',')}`;
-                    
-                    if (!typeSubtypeMap.has(key)) {
-                      typeSubtypeMap.set(key, {
-                        fighter: fighter,
-                        cost: fighter.total_cost
-                      });
-                    } else {
-                      const current = typeSubtypeMap.get(key);
-                      
-                      // Prefer fighters with empty specialisation (default version) for the main dropdown
-                      const currentHasEmptySpecialisation = !(current.fighter as any).specialisation || Object.keys((current.fighter as any).specialisation).length === 0;
-                      const fighterHasEmptySpecialisation = !(fighter as any).specialisation || Object.keys((fighter as any).specialisation).length === 0;
-                      
-                      if (fighterHasEmptySpecialisation && !currentHasEmptySpecialisation) {
-                        // This fighter has empty specialisation, current doesn't - prefer this one
-                        typeSubtypeMap.set(key, {
-                          fighter: fighter,
-                          cost: fighter.total_cost
-                        });
-                      } else if (currentHasEmptySpecialisation && !fighterHasEmptySpecialisation) {
-                        // Current has empty specialisation, this one doesn't - keep current
-                        // Do nothing
-                      } else {
-                        // Both have same specialisation status, take the cheaper option
-                        if (fighter.total_cost < current.cost) {
-                          typeSubtypeMap.set(key, {
-                            fighter: fighter,
-                            cost: fighter.total_cost
-                          });
-                        }
-                      }
-                    }
-                  });
-                  
-                  // Convert the map values to an array and sort
-                  return Array.from(typeSubtypeMap.values())
-                    .sort((a, b) => {
-                      const subtypeRankA = getFighterSubtypeSortRank(a.fighter.fighter_subtypes, fighter.edition_slug);
-                      const subtypeRankB = getFighterSubtypeSortRank(b.fighter.fighter_subtypes, fighter.edition_slug);
-
-                      if (subtypeRankA !== subtypeRankB) {
-                        return subtypeRankA - subtypeRankB;
-                      }
-
-                      return a.cost - b.cost;
-                    })
-                    .map(({ fighter }) => {
-                      const displayName = `${fighter.fighter_type} (${fighter.fighter_subtypes.join(', ')})`;
-                      const gangVariantSuffix = (fighter as any).is_gang_variant ? ` - ${(fighter as any).gang_variant_name}` : '';
-                      
-                      
-                      return (
-                        <option key={fighter.id} value={fighter.id}>
-                          {displayName}{gangVariantSuffix}
-                        </option>
-                      );
-                    });
-                })()}
-              </select>
+                onValueChange={handleFighterTypeChange}
+                placeholder="Select a fighter type"
+                options={fighterTypeComboboxOptions}
+                dropdownPlacement="down"
+              />
               {fighter.fighter_type && (
                 <div className="mt-1 text-sm text-muted-foreground">
                   Current: {typeof (fighter as any).fighter_type === 'object' 
@@ -1115,19 +1166,14 @@ export function EditFighterModal({
                 <label htmlFor="fighter_specialisation_id" className="block text-sm font-medium mb-1">
                   Fighter Specialisation
                 </label>
-                <select
+                <Combobox
                   id="fighter_specialisation_id"
                   value={selectedSpecialisationId}
-                  onChange={(e) => handleSpecialisationChange(e.target.value)}
-                  className="w-full p-2 border rounded-md"
-                  disabled={false}
-                >
-                  {availableSpecialisations.map((specialisation) => (
-                    <option key={specialisation.value} value={specialisation.value}>
-                      {specialisation.label}
-                    </option>
-                  ))}
-                </select>
+                  onValueChange={handleSpecialisationChange}
+                  placeholder="Select a specialisation"
+                  options={availableSpecialisations.map(({ value, label }) => ({ value, label }))}
+                  dropdownPlacement="down"
+                />
                 {(fighter as any).fighter_specialisation ? (
                   <div className="mt-1 text-sm text-muted-foreground">
                     Current: {typeof (fighter as any).fighter_specialisation === 'object' 
@@ -1142,26 +1188,61 @@ export function EditFighterModal({
               </div>
             )}
             
-            {/* Fighter Subtype Override Dropdown */}
+            {/* Fighter Subtype — multi add/chips on N26, single Combobox on N23 */}
             <div>
               <label className="block text-sm font-medium mb-1">
                 Fighter Subtype
               </label>
-              <select
-                value={selectedFighterSubtypeId}
-                onChange={(e) => {
-                  setSelectedFighterSubtypeId(e.target.value);
-                  setSelectedArchetypeId('');
-                }}
-                className="w-full p-2 border rounded-md"
-              >
-                {allFighterSubtypes
-                  ?.filter(fc => !['*', 'Others', 'Special Terrain'].includes(fc.subtype_name))
-                  ?.filter(fc => fc.subtype_name !== 'Exotic Beast Specialist' || fighter.fighter_subtypes?.includes('Exotic Beast'))
-                  .map(fc => (
-                    <option key={fc.id} value={fc.id}>{fc.subtype_name}</option>
-                  ))}
-              </select>
+              {allowMultipleSubtypes ? (
+                <>
+                  <div className="flex space-x-2 mb-2">
+                    <div className="grow min-w-0">
+                      <Combobox
+                        options={availableSubtypeComboboxOptions}
+                        value={pendingSubtypeToAdd}
+                        onValueChange={setPendingSubtypeToAdd}
+                        placeholder="Add a Fighter Subtype"
+                        dropdownPlacement="down"
+                      />
+                    </div>
+                    <Button
+                      onClick={handleAddFighterSubtype}
+                      type="button"
+                      disabled={!pendingSubtypeToAdd}
+                    >
+                      Add
+                    </Button>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    {selectedFighterSubtypes.map((subtypeName) => (
+                      <div
+                        key={subtypeName}
+                        className="bg-muted px-3 py-1 rounded-full flex items-center text-sm"
+                      >
+                        <span>{subtypeName}</span>
+                        <button
+                          type="button"
+                          onClick={() => handleRemoveFighterSubtype(subtypeName)}
+                          className="ml-2 text-muted-foreground hover:text-muted-foreground focus:outline-hidden"
+                        >
+                          <HiX size={14} />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </>
+              ) : (
+                <Combobox
+                  value={selectedFighterSubtypes[0] ?? ''}
+                  onValueChange={handleSingleFighterSubtypeChange}
+                  placeholder="Select fighter subtype"
+                  options={fighterSubtypesForDisplay.map(fc => ({
+                    value: fc.subtype_name,
+                    label: fc.subtype_name,
+                  }))}
+                  dropdownPlacement="down"
+                />
+              )}
               <div className="mt-1 text-sm text-muted-foreground">
                 Current: {fighter.fighter_subtypes?.join(', ') || 'Unknown'}
               </div>
@@ -1339,7 +1420,10 @@ export function EditFighterModal({
         }
         onClose={onClose}
         onConfirm={handleConfirm}
-        confirmDisabled={!formValues.name.trim()}
+        confirmDisabled={
+          !formValues.name.trim() ||
+          (selectedFighterSubtypes.length === 0 && (fighter.fighter_subtypes?.length ?? 0) > 0)
+        }
       />
       
       {/* Stats modal */}


### PR DESCRIPTION
Show edition-gated Sv in Characteristics and Adjust Characteristics, switch Fighter Type/Specialisation to Combobox, and support N26 multi-subtype via add/chips (N23 stays single-select), with dirty-only subtype submits and optimistic/server refresh so overrides are not clobbered. Archetype selection/eligibility is left unchanged on purpose; it still keys off fighter class (subtype) rather than fighter type and needs a separate rework for multi-subtype N26.