### PR TITLE
Earn N26 Advancements by rank instead of spending XP

### DIFF
--- a/app/actions/add-fighter.ts
+++ b/app/actions/add-fighter.ts
@@ -467,6 +467,9 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
       intelligence: effectiveFighterData.intelligence,
       save: effectiveFighterData.save ?? null,
       xp: effectiveFighterData.starting_xp ?? 0,
+      // Snapshot of the recruitment value. Kept on the fighter because the
+      // fighter type is editable and N26 counts Advancements from this figure.
+      starting_xp: effectiveFighterData.starting_xp ?? 0,
       is_vehicle: effectiveFighterData.is_vehicle ?? false,
       kills: 0,
       special_rules: effectiveFighterData.special_rules,

--- a/app/actions/copy-fighter.ts
+++ b/app/actions/copy-fighter.ts
@@ -277,7 +277,13 @@ export async function copyFighter(params: CopyFighterParams): Promise<CopyFighte
       save: sourceFighter.save ?? null,
       is_vehicle: sourceFighter.is_vehicle ?? false,
 
-      xp: params.copy_as_experienced ? sourceFighter.xp : 0,
+      // Recruitment XP belongs to the fighter type, not to what this fighter went
+      // on to earn, so it survives an inexperienced copy. Dropping the copy to
+      // xp 0 while it still records a starting_xp of 13 would leave it sitting
+      // below its own recruitment value; a fresh recruit of that type has
+      // xp === starting_xp, which is what add-fighter writes.
+      starting_xp: sourceFighter.starting_xp,
+      xp: params.copy_as_experienced ? sourceFighter.xp : sourceFighter.starting_xp,
       total_xp: params.copy_as_experienced ? sourceFighter.total_xp : 0,
       kills: params.copy_as_experienced ? sourceFighter.kills : 0,
 
@@ -698,7 +704,9 @@ export async function copyFighter(params: CopyFighterParams): Promise<CopyFighte
             willpower: beastFighter.willpower,
             intelligence: beastFighter.intelligence,
             save: beastFighter.save ?? null,
-            xp: params.copy_as_experienced ? beastFighter.xp : 0,
+            // As above: recruitment XP survives an inexperienced copy.
+            starting_xp: beastFighter.starting_xp,
+            xp: params.copy_as_experienced ? beastFighter.xp : beastFighter.starting_xp,
             total_xp: params.copy_as_experienced ? beastFighter.total_xp : 0,
             kills: params.copy_as_experienced ? beastFighter.kills : 0,
             credits: beastFighter.credits,

--- a/app/actions/fighter-advancement.ts
+++ b/app/actions/fighter-advancement.ts
@@ -6,6 +6,8 @@ import { getAuthenticatedUser } from '@/utils/auth';
 import { revalidateTag } from 'next/cache';
 import { updateGangRatingSimple, updateGangFinancials } from '@/utils/gang-rating-and-wealth';
 import { countsTowardRating } from '@/utils/fighter-status';
+import { hasCumulativeXp, gangEditionSlug } from '@/types/edition';
+import { openAdvancementsFor } from '@/utils/advancementRanks';
 
 import { 
   logCharacteristicAdvancement, 
@@ -16,6 +18,94 @@ import {
 } from './logs/gang-fighter-logs';
 import type { GangLogActionResult } from './logs/gang-logs';
 import { updateFighterDetails } from './edit-fighter';
+
+// A fighter's edition comes from its gang's (custom) gang type — gangs have no
+// edition_id of their own. Whether an Advancement costs XP is edition-specific,
+// so every action that moves a fighter's XP loads it alongside the fighter.
+// gangEditionSlug reads this shape back, including the array/object widening the
+// untyped client introduces.
+const FIGHTER_WITH_EDITION_SELECT = `
+  id, user_id, gang_id, xp, starting_xp, free_skill, fighter_name, killed, retired, enslaved, captured,
+  gangs!gang_id (
+    gang_types!gang_type_id ( editions:edition_id ( slug ) ),
+    custom_gang_types!custom_gang_type_id ( editions:edition_id ( slug ) )
+  )
+`;
+
+const fighterEditionSlug = (fighter: any): string | null =>
+  gangEditionSlug(fighter?.gangs);
+
+/**
+ * How many Advancements a fighter has already taken, counted from the database.
+ *
+ * Mirrors countAdvancementsTaken in utils/advancementRanks.ts, which the cards
+ * apply to data they already hold: a characteristic is an effect in the
+ * 'advancements' category, a skill is a fighter_skill flagged is_advance.
+ */
+async function countAdvancementsTakenFor(supabase: any, fighterId: string): Promise<number> {
+  const [characteristics, skillAdvances] = await Promise.all([
+    supabase
+      .from('fighter_effects')
+      .select('id, fighter_effect_types!inner(fighter_effect_categories!inner(category_name))', {
+        count: 'exact',
+        head: true,
+      })
+      .eq('fighter_id', fighterId)
+      .eq('fighter_effect_types.fighter_effect_categories.category_name', 'advancements'),
+    supabase
+      .from('fighter_skills')
+      .select('id', { count: 'exact', head: true })
+      .eq('fighter_id', fighterId)
+      .eq('is_advance', true),
+  ]);
+
+  // This count is half of a server-side limit, so a failed query must not read
+  // as "nothing taken yet" — that would grant an Advancement on the strength of
+  // an error. Fail closed and let the caller refuse.
+  if (characteristics.error || skillAdvances.error) {
+    throw new Error('Failed to count existing advancements');
+  }
+
+  return (characteristics.count ?? 0) + (skillAdvances.count ?? 0);
+}
+
+/**
+ * Whether the fighter may take another Advancement right now, as an error
+ * message or null to proceed.
+ *
+ * The two economies gate on different things: an edition that spends XP gates on
+ * whether the fighter can afford the cost, one that earns Advancements by rank
+ * gates on whether it has an earned Advancement it has not yet taken.
+ *
+ * SOFT LIMIT. This reads the count and the caller then inserts, so two requests
+ * racing each other can both pass. That is tolerable here — a gang is edited by
+ * one person and the whole add-advancement path is already several
+ * non-transactional steps — but it is not a guarantee. Do not build anything on
+ * it that assumes the count cannot be exceeded.
+ */
+async function advancementBlockedReason(
+  supabase: any,
+  fighter: any,
+  spendsXp: boolean,
+  xpCost: number,
+  isAdvance: boolean = true,
+): Promise<string | null> {
+  if (spendsXp) {
+    return fighter.xp < xpCost ? 'Insufficient XP' : null;
+  }
+
+  // A starting or free skill is not an Advancement and consumes none.
+  if (!isAdvance) return null;
+
+  const open = openAdvancementsFor(
+    fighterEditionSlug(fighter),
+    fighter.starting_xp ?? 0,
+    fighter.xp,
+    await countAdvancementsTakenFor(supabase, fighter.id),
+  );
+
+  return open > 0 ? null : 'No advancements available';
+}
 
 // Type for power boost type_specific_data
 interface PowerBoostTypeData {
@@ -118,7 +208,7 @@ export async function addCharacteristicAdvancement(
     // Verify fighter ownership and get fighter data
     const { data: fighter, error: fighterError } = await supabase
       .from('fighters')
-      .select('id, user_id, gang_id, xp, free_skill, fighter_name, killed, retired, enslaved, captured')
+      .select(FIGHTER_WITH_EDITION_SELECT)
       .eq('id', params.fighter_id)
       .single();
 
@@ -128,9 +218,18 @@ export async function addCharacteristicAdvancement(
 
     // Note: Authorization is enforced by RLS policies on fighters table
 
-    // Check if fighter has enough XP
-    if (fighter.xp < params.xp_cost) {
-      return { success: false, error: 'Insufficient XP' };
+    // A rank-based edition earns Advancements rather than buying them, so its XP
+    // total only ever grows and there is nothing to afford.
+    const spendsXp = !hasCumulativeXp(fighterEditionSlug(fighter));
+
+    const blockedReason = await advancementBlockedReason(
+      supabase,
+      fighter,
+      spendsXp,
+      params.xp_cost,
+    );
+    if (blockedReason) {
+      return { success: false, error: blockedReason };
     }
 
     // Get the effect type details
@@ -211,8 +310,9 @@ export async function addCharacteristicAdvancement(
     // Update fighter's XP only (characteristic is handled by effect modifiers)
     const { data: updatedFighter, error: updateError } = await supabase
       .from('fighters')
-      .update({ 
-        xp: fighter.xp - params.xp_cost,
+      .update({
+        // Nothing is spent in a rank-based edition, so XP is left where it is.
+        xp: spendsXp ? fighter.xp - params.xp_cost : fighter.xp,
         updated_at: new Date().toISOString()
       })
       .eq('id', params.fighter_id)
@@ -309,7 +409,7 @@ export async function addSkillAdvancement(
     // Verify fighter ownership and get fighter data
     const { data: fighter, error: fighterError } = await supabase
       .from('fighters')
-      .select('id, user_id, gang_id, xp, free_skill, fighter_name, killed, retired, enslaved, captured')
+      .select(FIGHTER_WITH_EDITION_SELECT)
       .eq('id', params.fighter_id)
       .single();
 
@@ -319,9 +419,19 @@ export async function addSkillAdvancement(
 
     // Note: Authorization is enforced by RLS policies on fighters table
 
-    // Check if fighter has enough XP
-    if (fighter.xp < params.xp_cost) {
-      return { success: false, error: 'Insufficient XP' };
+    // A rank-based edition earns Advancements rather than buying them, so its XP
+    // total only ever grows and there is nothing to afford.
+    const spendsXp = !hasCumulativeXp(fighterEditionSlug(fighter));
+
+    const blockedReason = await advancementBlockedReason(
+      supabase,
+      fighter,
+      spendsXp,
+      params.xp_cost,
+      params.is_advance ?? true,
+    );
+    if (blockedReason) {
+      return { success: false, error: blockedReason };
     }
 
     // Insert the new skill advancement with fighter owner's user_id
@@ -413,7 +523,8 @@ export async function addSkillAdvancement(
 
     // Update fighter's XP and conditionally set free_skill to false
     const updateData: any = {
-      xp: fighter.xp - params.xp_cost,
+      // Nothing is spent in a rank-based edition, so XP is left where it is.
+      xp: spendsXp ? fighter.xp - params.xp_cost : fighter.xp,
       updated_at: new Date().toISOString()
     };
     
@@ -640,7 +751,7 @@ export async function deleteAdvancement(
     // Verify fighter ownership
     const { data: fighter, error: fighterError } = await supabase
       .from('fighters')
-      .select('id, user_id, gang_id, xp, free_skill, fighter_name, killed, retired, enslaved, captured')
+      .select(FIGHTER_WITH_EDITION_SELECT)
       .eq('id', params.fighter_id)
       .single();
 
@@ -649,6 +760,11 @@ export async function deleteAdvancement(
     }
 
     // Note: Authorization is enforced by RLS policies on fighters table
+
+    // Nothing was spent on a rank-based Advancement, so deleting one refunds
+    // nothing. The Advancement becomes available again on its own: the taken
+    // count drops, so openAdvancementsFor rises back by one.
+    const spendsXp = !hasCumulativeXp(fighterEditionSlug(fighter));
 
     let xpToRefund = 0;
     let ratingDelta = 0;
@@ -848,8 +964,8 @@ export async function deleteAdvancement(
     // Update fighter's XP and free_skill status
     const { data: updatedFighter, error: updateError } = await supabase
       .from('fighters')
-      .update({ 
-        xp: fighter.xp + xpToRefund,
+      .update({
+        xp: spendsXp ? fighter.xp + xpToRefund : fighter.xp,
         free_skill: newFreeSkillStatus,
         updated_at: new Date().toISOString()
       })

--- a/app/lib/shared/fighter-data.ts
+++ b/app/lib/shared/fighter-data.ts
@@ -31,6 +31,7 @@ export interface FighterBasic {
   intelligence: number;
   save?: number | null;
   xp: number;
+  starting_xp: number;
   special_rules?: string[];
   fighter_subtypes: string[];
   fighter_type?: string;
@@ -154,6 +155,7 @@ export const getFighterBasic = async (fighterId: string, supabase: any): Promise
           intelligence,
           save,
           xp,
+          starting_xp,
           special_rules,
           fighter_subtypes,
           fighter_type,

--- a/app/lib/shared/gang-data.ts
+++ b/app/lib/shared/gang-data.ts
@@ -141,6 +141,7 @@ export interface GangFighter {
   alliance_crew_name?: string;
   position?: string;
   xp: number;
+  starting_xp: number;
   kills: number;
   credits: number;
   loadout_cost?: number; // Cost of equipment in active loadout only (for fighter card display)
@@ -953,6 +954,14 @@ export const getGangFightersList = async (
 
   return unstable_cache(
     async () => {
+      // Every fighter in a roster belongs to one gang, so the edition is resolved
+      // once here rather than per fighter from fighter_types — which yields null
+      // for custom fighter types and would leave them with no edition at all.
+      // getGangBasic already derives it and is warm by the time the gang and
+      // print pages reach this, so no round trip is added on those paths. Its
+      // cache tag is deliberately not adopted: a gang's edition never changes.
+      const gangEditionSlugForRoster = (await getGangBasic(gangId, supabase))?.edition_slug ?? null;
+
       // Step 1: Fetch ALL fighters for the gang in ONE query with joins
       const { data: fighters, error: fightersError } = await supabase
         .from('fighters')
@@ -978,6 +987,7 @@ export const getGangFightersList = async (
           intelligence,
           save,
           xp,
+          starting_xp,
           special_rules,
           fighter_subtypes,
           fighter_type,
@@ -1991,6 +2001,7 @@ export const getGangFightersList = async (
           kill_count: fighter.kill_count ?? 0,
           position: fighter.position,
           xp: fighter.xp,
+          starting_xp: fighter.starting_xp,
           kills: fighter.kills || 0,
           credits: totalCost,
           loadout_cost: activeLoadoutId ? displayLoadoutCost : undefined, // Only set when loadout is active
@@ -2007,7 +2018,7 @@ export const getGangFightersList = async (
           willpower: fighter.willpower,
           intelligence: fighter.intelligence,
           save: fighter.save ?? null,
-          edition_slug: fighterTypeInfo.editions?.slug ?? null,
+          edition_slug: gangEditionSlugForRoster,
           weapons,
           wargear,
           effects,

--- a/components/fighter/fighter-advancement-list.tsx
+++ b/components/fighter/fighter-advancement-list.tsx
@@ -3,6 +3,9 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { Button } from "@/components/ui/button";
 import { toast } from 'sonner';
+import { useRollLogger } from '@/hooks/use-roll-logger';
+import { N26AdvancementPanel } from '@/components/fighter/n26-advancement-panel';
+import { hasCumulativeXp } from '@/types/edition';
 import Modal from "@/components/ui/modal";
 import { Skill, FighterSkills, FighterEffect as FighterEffectType } from '@/types/fighter';
 import { TypeSpecificData } from '@/types/fighter-effect';
@@ -478,7 +481,6 @@ export function AdvancementModal({
   const [gangerPurchaseBusy, setGangerPurchaseBusy] = useState(false);
   // Ganger / Exotic Beast advancement roll UI (inline)
   const [gangerSelectedRowId, setGangerSelectedRowId] = useState('');
-  const [gangerRollCooldown, setGangerRollCooldown] = useState(false);
   const [gangerCharMap, setGangerCharMap] = useState<Record<string, GangerCharAdv>>({});
   const [gangerSpecialistCosts, setGangerSpecialistCosts] = useState<{ xp_cost: number; credits_increase: number }>({
     xp_cost: 6,
@@ -676,8 +678,17 @@ export function AdvancementModal({
     [gangerSelectedRowId]
   );
 
+  // A rank-based edition puts every fighter on one Advancement table and spends
+  // no XP, so the N23 subtype-specific tables and escalating costs do not apply.
+  const isCumulativeXp = hasCumulativeXp(editionSlug);
+
+  // The Ganger / Exotic Beast table, its flat 6 XP cost and the Specialist
+  // promotion are all N23 rules, and a rank-based edition promotes Specialists by
+  // its own rules. This must be false there — it gates the ganger purchase path,
+  // not just the roll UI.
   const isGangerOrExoticBeastSubtype =
-    fighterSubtypes.includes('Ganger') || fighterSubtypes.includes('Exotic Beast');
+    !isCumulativeXp &&
+    (fighterSubtypes.includes('Ganger') || fighterSubtypes.includes('Exotic Beast'));
 
   const gangerModalRollBuy =
     isGangerOrExoticBeastSubtype &&
@@ -914,69 +925,44 @@ export function AdvancementModal({
     };
   }, [fighterId, shouldFetchGangerSkillsInSet, gangerSelectedSkillSetId, gangerPromotionTypeId]);
 
-  const logGangerRollMutation = useMutation({
-    mutationFn: async (variables: { outcome_label: string; dice_data: Record<string, unknown> }) => {
-      const result = await verifyAndLogRolledGangerAdvancementRoll({
-        fighter_id: fighterId,
-        advancement_table: GANGER_ADVANCEMENT_TABLE_LABEL,
-        outcome_label: variables.outcome_label,
-        dice_data: variables.dice_data
-      });
-      if (!result.success) throw new Error(result.error || 'Failed to log advancement roll');
-      return result;
-    },
-    onSuccess: () => {
-      toast.success('Advancement roll logged');
-    },
-    onError: (e: Error) => {
-      toast.error(e?.message || 'Failed to log advancement roll');
-    }
+  const gangerRollLogger = useRollLogger<{ outcome_label: string; dice_data: Record<string, unknown> }>({
+    log: (variables) => verifyAndLogRolledGangerAdvancementRoll({
+      fighter_id: fighterId,
+      advancement_table: GANGER_ADVANCEMENT_TABLE_LABEL,
+      ...variables
+    }),
+    successMessage: 'Advancement roll logged',
+    errorMessage: 'Failed to log advancement roll'
   });
 
-  const logGangerSubRollMutation = useMutation({
-    mutationFn: async (variables: { outcome_label: string; dice_data: Record<string, unknown> }) => {
-      const result = await verifyAndLogRolledGangerAdvancementRoll({
-        fighter_id: fighterId,
-        advancement_table: GANGER_ADVANCEMENT_TABLE_LABEL,
-        outcome_label: variables.outcome_label,
-        dice_data: variables.dice_data
-      });
-      if (!result.success) throw new Error(result.error || 'Failed to log sub-roll');
-      return result;
-    },
-    onSuccess: () => {
-      toast.success('Sub-roll recorded in gang log');
-    },
-    onError: (e: Error) => {
-      toast.error(e?.message || 'Failed to log sub-roll');
-    }
+  // cooldownMs 0: only the main Ganger roll was ever debounced. The sub-roll and
+  // skill rolls guarded on in-flight alone, and this keeps that behaviour rather
+  // than quietly adding a 2s block to them.
+  const gangerSubRollLogger = useRollLogger<{ outcome_label: string; dice_data: Record<string, unknown> }>({
+    log: (variables) => verifyAndLogRolledGangerAdvancementRoll({
+      fighter_id: fighterId,
+      advancement_table: GANGER_ADVANCEMENT_TABLE_LABEL,
+      ...variables
+    }),
+    successMessage: 'Sub-roll recorded in gang log',
+    errorMessage: 'Failed to log sub-roll',
+    cooldownMs: 0
   });
 
-  const logSkillAdvancementRollMutation = useMutation({
-    mutationFn: async (variables: {
-      skill_set_name: string;
-      skill_set_access_label: string;
-      acquisition_type_label: string;
-      outcome_label: string;
-      dice_data: Record<string, unknown>;
-    }) => {
-      const result = await verifyAndLogRolledSkillAdvancementRoll({
-        fighter_id: fighterId,
-        skill_set_name: variables.skill_set_name,
-        skill_set_access_label: variables.skill_set_access_label,
-        acquisition_type_label: variables.acquisition_type_label,
-        outcome_label: variables.outcome_label,
-        dice_data: variables.dice_data
-      });
-      if (!result.success) throw new Error(result.error || 'Failed to log skill advancement roll');
-      return result;
-    },
-    onSuccess: () => {
-      toast.success('Skill advancement roll recorded in gang log');
-    },
-    onError: (e: Error) => {
-      toast.error(e?.message || 'Failed to log skill advancement roll');
-    }
+  const skillAdvancementRollLogger = useRollLogger<{
+    skill_set_name: string;
+    skill_set_access_label: string;
+    acquisition_type_label: string;
+    outcome_label: string;
+    dice_data: Record<string, unknown>;
+  }>({
+    log: (variables) => verifyAndLogRolledSkillAdvancementRoll({
+      fighter_id: fighterId,
+      ...variables
+    }),
+    successMessage: 'Skill advancement roll recorded in gang log',
+    errorMessage: 'Failed to log skill advancement roll',
+    cooldownMs: 0
   });
 
   const applyGangerSpecialistMutation = useMutation({
@@ -1090,24 +1076,22 @@ export function AdvancementModal({
   });
 
   const logGangerResolvedRollWithCooldown = (row: TableEntry, rollTotal: number, dice: number[]) => {
-    if (gangerRollCooldown || logGangerRollMutation.isPending) return false;
-    setGangerRollCooldown(true);
-    try {
-      const combo = GANGER_ADVANCEMENT_COMBO_OPTIONS.find(
-        (o) => o.range[0] === row.range[0] && o.range[1] === row.range[1]
-      );
-      if (combo) {
-        setGangerCostsUserOverride(false);
-        setGangerSelectedRowId(combo.id);
-      }
-      logGangerRollMutation.mutate({
-        outcome_label: row.name,
-        dice_data: { result: rollTotal, dice }
-      });
-      return true;
-    } finally {
-      setTimeout(() => setGangerRollCooldown(false), 2000);
+    // Selecting the rolled row is part of accepting the roll, so it stays behind
+    // the same guard: a refused double-click must not move the selection either.
+    const accepted = gangerRollLogger.logRoll({
+      outcome_label: row.name,
+      dice_data: { result: rollTotal, dice }
+    });
+    if (!accepted) return false;
+
+    const combo = GANGER_ADVANCEMENT_COMBO_OPTIONS.find(
+      (o) => o.range[0] === row.range[0] && o.range[1] === row.range[1]
+    );
+    if (combo) {
+      setGangerCostsUserOverride(false);
+      setGangerSelectedRowId(combo.id);
     }
+    return true;
   };
 
   const executeGangerPairPurchase = useCallback(
@@ -1285,8 +1269,8 @@ export function AdvancementModal({
     if (!gangerModalRollBuy) return { canBuy: false, pending: false };
     const pending =
       applyGangerSpecialistMutation.isPending ||
-      logGangerSubRollMutation.isPending ||
-      logGangerRollMutation.isPending;
+      gangerSubRollLogger.isPending ||
+      gangerRollLogger.isPending;
     if (!userPermissions?.canEdit) return { canBuy: false, pending };
     if (!gangerSelectedRowId || !gangerSelectedRow) return { canBuy: false, pending };
     if (editableXpCost < 0 || currentXp < editableXpCost) return { canBuy: false, pending };
@@ -1324,8 +1308,8 @@ export function AdvancementModal({
     gangerSelectedSkillIndex,
     gangerSkillsInSet,
     applyGangerSpecialistMutation.isPending,
-    logGangerSubRollMutation.isPending,
-    logGangerRollMutation.isPending
+    gangerSubRollLogger.isPending,
+    gangerRollLogger.isPending
   ]);
 
   const gangerCostsDepsKey = `${gangerModalRollBuy}-${gangerSelectedRow?.kind}-${gangerPairStatName}-${gangerCostsUserOverride}`;
@@ -1353,12 +1337,11 @@ export function AdvancementModal({
       toast.error('No skills in this set (or still loading)');
       return;
     }
-    if (logGangerSubRollMutation.isPending) return;
     const r = roll(gangerSkillsInSet.length);
     const chosen = gangerSkillsInSet[r - 1];
     setGangerSkillPickRoll(r);
     setGangerSelectedSkillIndex(r - 1);
-    logGangerSubRollMutation.mutate({
+    gangerSubRollLogger.logRoll({
       outcome_label: `Specialist — Skill: ${chosen.skill_name}`,
       dice_data: {
         result: r,
@@ -1370,7 +1353,6 @@ export function AdvancementModal({
   };
 
   const rollSkillFromSet = useCallback(() => {
-    if (logSkillAdvancementRollMutation.isPending) return;
     const pool = availableAdvancements.filter((a) => a.is_available !== false);
     if (pool.length === 0) {
       toast.error('No available skills in this set');
@@ -1411,7 +1393,7 @@ export function AdvancementModal({
         ? 'Promotion to Champion'
         : sample?.available_acquisition_types?.find((t) => t.type_id === skillAcquisitionType)?.name ??
           skillAcquisitionType;
-    logSkillAdvancementRollMutation.mutate({
+    skillAdvancementRollLogger.logRoll({
       skill_set_name: skillSetName,
       skill_set_access_label: skillSetAccessLabel,
       acquisition_type_label: acquisitionTypeLabel,
@@ -1436,7 +1418,7 @@ export function AdvancementModal({
     skillAccess,
     skillAcquisitionType,
     advancementType,
-    logSkillAdvancementRollMutation
+    skillAdvancementRollLogger
   ]);
 
   const gangerAdvancementComboboxOptions = useMemo(
@@ -1996,9 +1978,6 @@ export function AdvancementModal({
     }
   };
 
-  const isGangerOrExoticBeastRestricted =
-    fighterSubtypes.includes('Ganger') || fighterSubtypes.includes('Exotic Beast');
-
   const handleAdvancementPurchase = async () => {
     if (gangerModalRollBuy) {
       setGangerPurchaseBusy(true);
@@ -2095,8 +2074,8 @@ export function AdvancementModal({
     championPurchaseBusy ||
     applyGangerSpecialistMutation.isPending ||
     applyChampionPromotionMutation.isPending ||
-    logGangerSubRollMutation.isPending ||
-    logGangerRollMutation.isPending;
+    gangerSubRollLogger.isPending ||
+    gangerRollLogger.isPending;
 
   const buyAdvancementDisabled = gangerModalRollBuy
     ? !gangerBuyUi.canBuy || purchaseBlockingBusy || gangerBuyUi.pending
@@ -2140,11 +2119,18 @@ export function AdvancementModal({
         <div className="p-2 overflow-y-auto grow">
           <div className="mb-4">
             <p className="text-sm text-muted-foreground mb-2">
-              XP cost and rating increase are automatically calculated based on the type and number of advancements.
+              {isCumulativeXp
+                ? 'Advancements are earned by rank and cost no XP. Roll 2D6, then take any result you rolled high enough for.'
+                : 'XP cost and rating increase are automatically calculated based on the type and number of advancements.'}
             </p>
           </div>
 
-          {userPermissions &&
+          {isCumulativeXp && userPermissions && (
+            <N26AdvancementPanel fighterId={fighterId} canEdit={!!userPermissions.canEdit} />
+          )}
+
+          {!isCumulativeXp &&
+            userPermissions &&
             onFighterDetailsUpdate &&
             (fighterSubtypes.includes('Ganger') || fighterSubtypes.includes('Exotic Beast')) && (
               <div className="mb-4 space-y-4">
@@ -2179,9 +2165,8 @@ export function AdvancementModal({
                     buttonText="Roll 2D6"
                     disabled={
                       !userPermissions.canEdit ||
-                      logGangerRollMutation.isPending ||
-                      logGangerSubRollMutation.isPending ||
-                      gangerRollCooldown
+                      gangerRollLogger.disabled ||
+                      gangerSubRollLogger.isPending
                     }
                   />
                 </div>
@@ -2301,7 +2286,7 @@ export function AdvancementModal({
                           onClick={rollGangerSkillInSet}
                           disabled={
                             !userPermissions.canEdit ||
-                            logGangerSubRollMutation.isPending
+                            gangerSubRollLogger.disabled
                           }
                         >
                           Roll for Skill
@@ -2352,7 +2337,7 @@ export function AdvancementModal({
             )}
 
           <div className="space-y-4">
-          {!isGangerOrExoticBeastRestricted && (
+          {!isGangerOrExoticBeastSubtype && (
             <>
             <div className="relative">
               <Combobox
@@ -2440,7 +2425,7 @@ export function AdvancementModal({
                           onClick={rollSkillFromSet}
                           disabled={
                             !userPermissions?.canEdit ||
-                            logSkillAdvancementRollMutation.isPending ||
+                            skillAdvancementRollLogger.disabled ||
                             availableAdvancements.filter((a) => a.is_available !== false).length === 0
                           }
                         >
@@ -2565,7 +2550,7 @@ export function AdvancementModal({
                           onClick={rollSkillFromSet}
                           disabled={
                             !userPermissions?.canEdit ||
-                            logSkillAdvancementRollMutation.isPending ||
+                            skillAdvancementRollLogger.disabled ||
                             availableAdvancements.filter((a) => a.is_available !== false).length === 0
                           }
                         >
@@ -2603,7 +2588,9 @@ export function AdvancementModal({
             </>
           )}
 
-            <div className="grid grid-cols-2 gap-4">
+            <div className={isCumulativeXp ? '' : 'grid grid-cols-2 gap-4'}>
+              {/* No XP is spent in a rank-based edition, so there is no cost to show. */}
+              {!isCumulativeXp && (
               <div>
                 <label className="block text-sm font-medium text-muted-foreground mb-1">
                   XP Cost
@@ -2619,6 +2606,7 @@ export function AdvancementModal({
                   min="0"
                 />
               </div>
+              )}
               <div>
                 <label className="block text-sm font-medium text-muted-foreground mb-1">
                   Cost Increase in Credits

--- a/components/fighter/fighter-details-card.tsx
+++ b/components/fighter/fighter-details-card.tsx
@@ -4,6 +4,7 @@ import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
 import { FighterDetailsStatsTable } from '../ui/fighter-details-stats-table';
 import { hasSaveCharacteristic } from '@/types/edition';
+import { LevelUpBadge } from '@/components/ui/level-up-badge';
 import { memo } from 'react';
 import { calculateAdjustedStats } from '@/utils/effect-modifiers';
 import { FighterProps, FighterEffect, Vehicle } from '@/types/fighter';
@@ -51,11 +52,17 @@ interface FighterDetailsCardProps {
   save?: number | null;
   edition_slug?: string | null;
   xp: number;
+  starting_xp?: number;
   total_xp?: number;
   advancements?: {
     characteristics: Record<string, any>;
     skills: Record<string, any>;
   };
+  /**
+   * The fighter's actual skill rows. Distinct from `advancements.skills`, which
+   * the server does not populate on first load.
+   */
+  skills?: Record<string, { is_advance?: boolean }>;
   onNameUpdate?: (name: string) => void;
   onAddXp?: () => void;
   onEdit?: () => void;
@@ -243,7 +250,9 @@ export const FighterDetailsCard = memo(function FighterDetailsCard({
   save,
   edition_slug,
   xp,
+  starting_xp = 0,
   advancements,
+  skills,
   onAddXp,
   onEdit,
   killed,
@@ -457,6 +466,13 @@ export const FighterDetailsCard = memo(function FighterDetailsCard({
             {starved && <TbMeatOff className="text-red-500" />}
             {recovery && <FaMedkit className="text-blue-500" />}
             {captured && <GiHandcuffs className="text-sky-300" />}
+            <LevelUpBadge
+              editionSlug={edition_slug}
+              startingXp={starting_xp}
+              xp={xp}
+              effects={effects}
+              skills={skills}
+            />
           </div>
 
           {/* Profile picture of the fighter */}

--- a/components/fighter/fighter-injury-list.tsx
+++ b/components/fighter/fighter-injury-list.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { FighterEffect, FighterSkills } from '@/types/fighter';
 import { toast } from 'sonner';
+import { useRollLogger } from '@/hooks/use-roll-logger';
 import Modal from '@/components/ui/modal';
 import { List } from "@/components/ui/list";
 import { Button } from '@/components/ui/button';
@@ -106,7 +107,6 @@ export function InjuriesList({
   const [showEquipmentSelection, setShowEquipmentSelection] = useState(false);
   const [targetEquipmentId, setTargetEquipmentId] = useState<string | null>(null);
   const [isEffectSelectionValid, setIsEffectSelectionValid] = useState(false);
-  const [injuryRollCooldown, setInjuryRollCooldown] = useState(false);
   const [selectedCapturingGangId, setSelectedCapturingGangId] = useState<string>('');
   const [selectedHatredTargetId, setSelectedHatredTargetId] = useState<string>('');
   // First step of the fighter picker only — narrows the fighter list, never submitted.
@@ -568,36 +568,24 @@ export function InjuriesList({
     },
   });
 
-  // TanStack Query mutation for logging rolled injury results
-  const logInjuryRollMutation = useMutation({
-    mutationFn: async (variables: { 
-      fighter_id: string; 
-      injury_type_id: string;
-      injury_table: string;
-      dice_data: any;
-    }) => {
-      const result = await verifyAndLogRolledFighterInjury({
-        fighter_id: variables.fighter_id,
-        injury_type_id: variables.injury_type_id,
-        injury_table: variables.injury_table,
-        dice_data: variables.dice_data
-      });
+  // Logging of rolled injury results. The server message is prefixed here rather
+  // than in the hook, so the toast keeps its existing "Failed to log lasting
+  // injury: <reason>" shape.
+  const injuryRollLogger = useRollLogger<{
+    fighter_id: string;
+    injury_type_id: string;
+    injury_table: string;
+    dice_data: any;
+  }>({
+    log: async (variables) => {
+      const result = await verifyAndLogRolledFighterInjury(variables);
+      if (result.success) return result;
 
-      if (!result.success) {
-        throw new Error(result.error || 'Failed to log lasting injury');
-      }
-      return result;
-    },
-    onSuccess: (result, variables, context) => {
-      const statusMessage: string[] = [];
-      
-      const successText = is_spyrer ? 'Rig glitch logged successfully' : 'Lasting injury logged successfully';
-      toast.success(`${successText}${statusMessage.length > 0 ? ` and ${statusMessage.join(' and ')}` : ''}`);
-    },
-    onError: (error, variables, context) => {
       const errorText = is_spyrer ? 'Failed to log rig glitch' : 'Failed to log lasting injury';
-      toast.error(`${errorText}: ${error instanceof Error ? error.message : 'Unknown error'}`);
-    }
+      return { success: false, error: `${errorText}: ${result.error || 'Unknown error'}` };
+    },
+    successMessage: is_spyrer ? 'Rig glitch logged successfully' : 'Lasting injury logged successfully',
+    errorMessage: is_spyrer ? 'Failed to log rig glitch' : 'Failed to log lasting injury'
   });
 
   // Helper function to format the range display
@@ -617,49 +605,26 @@ export function InjuriesList({
     return min === max ? `${min}` : `${min}-${max}`;
   };
 
-  // Coordinates applying a resolved dice roll:
-  // - Guards against duplicate submissions
-  // - Applies UI selection state
-  // - Logs the roll to the server
-  // - Enforces a short cooldown to prevent spam
-  const logResolvedRollWithCooldown = (injury: FighterEffect, roll: number) => {  
-    if (injuryRollCooldown || logInjuryRollMutation.isPending) {
-      return false;
-    }
-
-    setInjuryRollCooldown(true);
-
-    // Ensure the cooldown is always released once it has been set
-    try {
-      selectRolledInjury(injury);
-      logRolledInjury(injury, roll);
-      return true;      
-    } finally {
-      // Cooldown to prevent rapid re-rolling and excessive logging
-      setTimeout(() => setInjuryRollCooldown(false), 2000);
-    }
-  };
-
-  // Updates local UI state to reflect the injury produced by a dice roll.
-  // This is purely a UI concern and does not trigger any persistence.
-  const selectRolledInjury = (injury: FighterEffect) => {
-    setSelectedInjuryId(injury.id);
-    setSelectedInjury(injury);
-  };
-  
-  // Persists a resolved dice roll to the backend for auditing / verification.
-  // Fire-and-forget mutation; success and error handling are managed by the mutation.
-  const logRolledInjury = (injury: FighterEffect, roll: number) => {
+  // Coordinates applying a resolved dice roll: logs it to the server (the hook
+  // guards against duplicate submissions and enforces the cooldown), then applies
+  // the UI selection. The selection is deliberately behind the same guard — a
+  // refused double-click must not move the selection either.
+  const logResolvedRollWithCooldown = (injury: FighterEffect, roll: number) => {
     const injuryTable = is_spyrer
       ? 'Rig Glitch'
       : (isCrew ? 'Lasting Injury Crew' : 'Lasting Injury');
 
-    logInjuryRollMutation.mutate({
+    const accepted = injuryRollLogger.logRoll({
       fighter_id: fighterId,
       injury_type_id: injury.id,
       injury_table: injuryTable,
       dice_data: { result: roll }
     });
+    if (!accepted) return false;
+
+    setSelectedInjuryId(injury.id);
+    setSelectedInjury(injury);
+    return true;
   };
 
   const fetchAvailableInjuries = useCallback(async () => {
@@ -1019,8 +984,7 @@ export function InjuriesList({
           buttonText="Roll D66"
           disabled={
             !userPermissions.canEdit ||
-            logInjuryRollMutation.isPending ||
-            injuryRollCooldown
+            injuryRollLogger.disabled
           }
         />
       </div>

--- a/components/fighter/fighter-page.tsx
+++ b/components/fighter/fighter-page.tsx
@@ -82,6 +82,7 @@ interface Fighter {
   save?: number | null;
   edition_slug?: string | null;
   xp: number;
+  starting_xp?: number;
   total_xp: number;
   killed?: boolean;
   retired?: boolean;
@@ -687,8 +688,10 @@ export default function FighterPage({
             save={fighterData.fighter?.save ?? null}
             edition_slug={editionSlug}
             xp={fighterData.fighter?.xp || 0}
+            starting_xp={fighterData.fighter?.starting_xp || 0}
             total_xp={fighterData.fighter?.total_xp || 0}
             advancements={fighterData.fighter?.advancements || { characteristics: {}, skills: {} }}
+            skills={fighterData.fighter?.skills || {}}
             onNameUpdate={handleNameUpdate}
             onAddXp={() => handleModalToggle('addXp', true)}
             onEdit={canShowEditButtons ? () => handleModalToggle('editFighter', true) : undefined}

--- a/components/fighter/n26-advancement-panel.tsx
+++ b/components/fighter/n26-advancement-panel.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import DiceRoller from '@/components/dice-roller';
+import {
+  N26_ADVANCEMENT_TABLE,
+  resolveN26AdvancementFromUtil,
+  rollNd6Outcome,
+} from '@/utils/dice';
+import { verifyAndLogRolledGangerAdvancementRoll } from '@/app/actions/fighter-advancement';
+import { useRollLogger } from '@/hooks/use-roll-logger';
+
+const N26_ADVANCEMENT_TABLE_LABEL = 'Advancement';
+
+interface N26AdvancementPanelProps {
+  fighterId: string;
+  canEdit: boolean;
+}
+
+/**
+ * The 2D6 Advancement roll for editions that earn Advancements by rank.
+ *
+ * Self-contained: it rolls, logs the result to the gang log, and shows the table
+ * for reference. It does not pick the Advancement — the player takes any result
+ * they rolled at or above, and the choice is made with the characteristic
+ * selector below it, the same way the N23 Ganger table already works.
+ *
+ * The credits shown are the rulebook's reference values. What actually gets
+ * charged comes from get_fighter_available_advancements, so the two can be
+ * reconciled by correcting the catalog rather than this table.
+ */
+export function N26AdvancementPanel({ fighterId, canEdit }: N26AdvancementPanelProps) {
+  const rollLogger = useRollLogger<{ outcome_label: string; dice_data: Record<string, unknown> }>({
+    log: (variables) => verifyAndLogRolledGangerAdvancementRoll({
+      fighter_id: fighterId,
+      advancement_table: N26_ADVANCEMENT_TABLE_LABEL,
+      ...variables,
+    }),
+    successMessage: 'Advancement roll logged',
+    errorMessage: 'Failed to log advancement roll',
+  });
+
+  const logResolvedRoll = (total: number, dice: number[]) => {
+    const row = resolveN26AdvancementFromUtil(total);
+    if (row) {
+      rollLogger.logRoll({ outcome_label: row.name, dice_data: { result: total, dice } });
+    }
+  };
+
+  return (
+    <div className="mb-4 space-y-4">
+      <div className="space-y-2">
+        <DiceRoller
+          items={N26_ADVANCEMENT_TABLE}
+          getRange={(r) => ({ min: r.range[0], max: r.range[1] })}
+          getName={(r) => r.name}
+          inline
+          rollFn={() => rollNd6Outcome(2)}
+          resolveNameForRoll={(t) => resolveN26AdvancementFromUtil(t)?.name}
+          // Only onRolled is wired: onRoll fires when no row matched, and this
+          // table covers every 2D6 result.
+          onRolled={(rolled) => {
+            if (rolled.length > 0) logResolvedRoll(rolled[0].roll, rolled[0].dice);
+          }}
+          buttonText="Roll 2D6"
+          disabled={!canEdit || rollLogger.disabled}
+        />
+      </div>
+
+      <div className="space-y-1 pt-2 border-t">
+        <p className="text-sm font-medium">Advancement table</p>
+        <p className="text-xs text-muted-foreground">
+          The roll is recorded in your gang log. Choose the result below — you may take any result you
+          rolled high enough for.
+        </p>
+        <ul className="text-xs text-muted-foreground pt-1 space-y-0.5">
+          {N26_ADVANCEMENT_TABLE.map((row) => (
+            <li key={`${row.range[0]}-${row.range[1]}`} className="flex gap-2">
+              <span className="font-mono w-10 shrink-0">
+                {row.range[0] === row.range[1] ? row.range[0] : `${row.range[0]}-${row.range[1]}`}
+              </span>
+              <span className="grow">{row.name}</span>
+              <span className="shrink-0">+{row.credits}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/components/fighter/vehicle-lasting-damages.tsx
+++ b/components/fighter/vehicle-lasting-damages.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { FighterEffect } from '@/types/fighter';
 import { toast } from 'sonner';
+import { useRollLogger } from '@/hooks/use-roll-logger';
 import Modal from '../ui/modal';
 import { Checkbox } from "@/components/ui/checkbox";
 import DiceRoller from '@/components/dice-roller';
@@ -68,41 +69,26 @@ export function VehicleDamagesList({
   const [selectedDamageId, setSelectedDamageId] = useState<string>('');
   const [isRepairModalOpen, setIsRepairModalOpen] = useState(false);
   const [selectedRepairTypeId, setSelectedRepairTypeId] = useState<string>('');
-  const [damageRollCooldown, setDamageRollCooldown] = useState(false);
 
   const queryClient = useQueryClient();
 
-  const logDamageRollMutation = useMutation({
-    mutationFn: async (variables: {
-      vehicle_id: string;
-      fighter_id: string;
-      gang_id: string;
-      damage_type_id: string;
-      damage_table: string;
-      dice_data: { result: number };
-    }) => {
-      const result = await verifyAndLogRolledVehicleDamage({
-        vehicle_id: variables.vehicle_id,
-        fighter_id: variables.fighter_id,
-        gang_id: variables.gang_id,
-        damage_type_id: variables.damage_type_id,
-        damage_table: variables.damage_table,
-        dice_data: variables.dice_data
-      });
-      if (!result.success) {
-        throw new Error(result.error || 'Failed to log vehicle damage roll');
-      }
-      return result;
-    },
-    onError: (error) => {
-      toast.error(error instanceof Error ? error.message : 'Failed to log vehicle damage roll');
-    }
+  // No success toast here, unlike the injury and advancement rollers: applying
+  // the damage already reports itself, and this only records the roll.
+  const damageRollLogger = useRollLogger<{
+    vehicle_id: string;
+    fighter_id: string;
+    gang_id: string;
+    damage_type_id: string;
+    damage_table: string;
+    dice_data: { result: number };
+  }>({
+    log: (variables) => verifyAndLogRolledVehicleDamage(variables),
+    errorMessage: 'Failed to log vehicle damage roll'
   });
 
   const logResolvedDamageRollWithCooldown = (damage: { id: string; effect_name: string }, roll: number) => {
-    if (!vehicleId || damageRollCooldown || logDamageRollMutation.isPending) return;
-    setDamageRollCooldown(true);
-    logDamageRollMutation.mutate({
+    if (!vehicleId) return;
+    damageRollLogger.logRoll({
       vehicle_id: vehicleId,
       fighter_id: fighterId,
       gang_id: gangId,
@@ -110,7 +96,6 @@ export function VehicleDamagesList({
       damage_table: 'Lasting Damage',
       dice_data: { result: roll }
     });
-    setTimeout(() => setDamageRollCooldown(false), 2000);
   };
 
   const VEHICLE_DAMAGE_CATEGORY_ID = 'a993261a-4172-4afb-85bf-f35e78a1189f';
@@ -465,7 +450,7 @@ export function VehicleDamagesList({
               return resolveVehicleDamageFromUtil(roll);
             }}
             buttonText="Roll D6"
-            disabled={!userPermissions.canEdit || logDamageRollMutation.isPending || damageRollCooldown}
+            disabled={!userPermissions.canEdit || damageRollLogger.disabled}
             onRolled={(rolled) => {
               if (rolled.length === 0) return;
               const roll = rolled[0].roll;
@@ -646,7 +631,7 @@ export function VehicleDamagesList({
                     return resolveVehicleDamageFromUtil(roll);
                   }}
                   buttonText="Roll D6"
-                  disabled={!userPermissions.canEdit || logDamageRollMutation.isPending || damageRollCooldown}
+                  disabled={!userPermissions.canEdit || damageRollLogger.disabled}
                   onRolled={(rolled) => {
                     if (rolled.length === 0) return;
                     const roll = rolled[0].roll;

--- a/components/gang/fighter-card.tsx
+++ b/components/gang/fighter-card.tsx
@@ -5,6 +5,7 @@ import WeaponTable from './fighter-card-weapon-table';
 import { Equipment } from '@/types/equipment';
 import { FighterProps, FighterEffect, Vehicle, VehicleEquipment, FighterSkills } from '@/types/fighter';
 import { hasSaveCharacteristic } from '@/types/edition';
+import { LevelUpBadge } from '@/components/ui/level-up-badge';
 import { calculateAdjustedStats, applySpecialRulesModifiers } from '@/utils/effect-modifiers';
 import { injuryAggregationLabel } from '@/utils/injuryTarget';
 import { TbMeatOff } from "react-icons/tb";
@@ -153,6 +154,7 @@ const FighterCard = memo(function FighterCard({
   save,
   edition_slug,
   xp,
+  starting_xp = 0,
   advancements,
   weapons,
   wargear,
@@ -605,6 +607,13 @@ const FighterCard = memo(function FighterCard({
             {starved && <TbMeatOff className="text-red-500" />}
             {recovery && <FaMedkit className="text-blue-500" />}
             {captured && <GiHandcuffs className="text-sky-300" />}
+            <LevelUpBadge
+              editionSlug={edition_slug}
+              startingXp={starting_xp}
+              xp={xp}
+              effects={effects}
+              skills={skills}
+            />
           </div>
           {/* Render image if image_url is present, before credits box */}
           {image_url && (

--- a/components/ui/level-up-badge.tsx
+++ b/components/ui/level-up-badge.tsx
@@ -1,0 +1,48 @@
+import { countAdvancementsTaken, openAdvancementsFor } from '@/utils/advancementRanks';
+
+interface LevelUpBadgeProps {
+  editionSlug?: string | null;
+  startingXp?: number;
+  xp: number;
+  effects?: { advancements?: unknown[] } | null;
+  /**
+   * The fighter's actual skill rows. Distinct from `advancements.skills`, which
+   * is a parallel shape the server does not populate on first load — counting
+   * from that would silently miss every skill the fighter already has.
+   */
+  skills?: Record<string, { is_advance?: boolean }> | null;
+}
+
+/**
+ * "2 Level Ups" — Advancements the fighter has earned but not yet taken.
+ *
+ * Renders nothing when there are none, which includes every edition that spends
+ * XP on Advancements rather than earning them by rank, so callers need no
+ * edition check of their own.
+ *
+ * The count is derived on read from data the card already holds, so it cannot
+ * drift from the limit the add-advancement actions enforce, and awarding XP
+ * needs no extra write.
+ */
+export function LevelUpBadge({
+  editionSlug,
+  startingXp = 0,
+  xp,
+  effects,
+  skills,
+}: LevelUpBadgeProps) {
+  const openAdvancements = openAdvancementsFor(
+    editionSlug,
+    startingXp,
+    xp,
+    countAdvancementsTaken(effects, skills),
+  );
+
+  if (openAdvancements <= 0) return null;
+
+  return (
+    <span className="text-xs font-bold text-amber-500 whitespace-nowrap">
+      {openAdvancements} Level Up{openAdvancements === 1 ? '' : 's'}
+    </span>
+  );
+}

--- a/hooks/use-roll-logger.ts
+++ b/hooks/use-roll-logger.ts
@@ -1,0 +1,94 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+/**
+ * What every `verifyAndLogRolled*` server action returns.
+ */
+type LogRollResult = { success: boolean; error?: string };
+
+interface UseRollLoggerOptions<TVars> {
+  /** The server action to call. Bind the fighter/vehicle id at the call site. */
+  log: (variables: TVars) => Promise<LogRollResult>;
+  /** Toast on success. Omit to stay silent — the vehicle damage roller does. */
+  successMessage?: string;
+  /** Fallback message when the action fails without one of its own. */
+  errorMessage: string;
+  /** Debounce window after a roll is submitted. */
+  cooldownMs?: number;
+}
+
+export interface RollLogger<TVars> {
+  /**
+   * Submits a roll for logging. Returns false when the call was refused because
+   * one is already in flight or the cooldown has not elapsed, so a caller that
+   * also updates local state can skip that work.
+   */
+  logRoll: (variables: TVars) => boolean;
+  isPending: boolean;
+  /** `isPending || coolingDown` — feeds a DiceRoller's `disabled` prop. */
+  disabled: boolean;
+}
+
+/**
+ * Logging a dice roll to the gang log, with a debounce.
+ *
+ * Five call sites across the advancement, injury and vehicle-damage lists were
+ * each repeating the same mutation — call the action, throw when `success` is
+ * false, toast either way — alongside a hand-rolled `useState` boolean and a
+ * `setTimeout` to stop double submissions.
+ *
+ * Note the cooldown is released on a timer rather than when the request settles.
+ * That is deliberate and matches the behaviour it replaces: the point is to
+ * absorb a double-click, not to serialise requests. `isPending` covers the
+ * in-flight case on its own.
+ */
+export function useRollLogger<TVars>({
+  log,
+  successMessage,
+  errorMessage,
+  cooldownMs = 2000,
+}: UseRollLoggerOptions<TVars>): RollLogger<TVars> {
+  const [coolingDown, setCoolingDown] = useState(false);
+
+  // Read synchronously inside logRoll: two clicks in the same tick would both
+  // see the state variable as false, since React batches the update.
+  const coolingDownRef = useRef(false);
+
+  const mutation = useMutation({
+    mutationFn: async (variables: TVars) => {
+      const result = await log(variables);
+      if (!result.success) throw new Error(result.error || errorMessage);
+      return result;
+    },
+    onSuccess: () => {
+      if (successMessage) toast.success(successMessage);
+    },
+    onError: (e: Error) => {
+      toast.error(e?.message || errorMessage);
+    },
+  });
+
+  const { mutate, isPending } = mutation;
+
+  const logRoll = useCallback(
+    (variables: TVars): boolean => {
+      if (coolingDownRef.current || isPending) return false;
+
+      coolingDownRef.current = true;
+      setCoolingDown(true);
+      mutate(variables);
+      setTimeout(() => {
+        coolingDownRef.current = false;
+        setCoolingDown(false);
+      }, cooldownMs);
+
+      return true;
+    },
+    [mutate, isPending, cooldownMs],
+  );
+
+  return { logRoll, isPending, disabled: isPending || coolingDown };
+}

--- a/supabase/functions/get_fighter_available_advancements.sql
+++ b/supabase/functions/get_fighter_available_advancements.sql
@@ -12,22 +12,38 @@ DECLARE
   v_advancements_category_id UUID;
   v_fighter_subtypes jsonb;
   v_uses_flat_cost boolean; -- Flag for fighters that use flat costs (Ganger and Exotic Beast)
+  v_edition_id UUID;
+  v_cumulative_xp boolean; -- Edition earns Advancements by rank instead of buying them
 BEGIN
-  -- Get fighter's current XP and fighter subtypes
-  SELECT f.xp, f.fighter_subtypes
-  INTO v_fighter_xp, v_fighter_subtypes
+  -- Get fighter's current XP, subtypes, and the edition of the gang it belongs
+  -- to. The edition is resolved from the gang the same way add_fighter_injury
+  -- does it: Advancement rows are edition-scoped, and without this an N23
+  -- fighter would be offered N26 Advancements and vice versa.
+  SELECT f.xp, f.fighter_subtypes, COALESCE(gt.edition_id, cgt.edition_id)
+  INTO v_fighter_xp, v_fighter_subtypes, v_edition_id
   FROM fighters f
+  JOIN gangs g ON g.id = f.gang_id
+  LEFT JOIN gang_types gt ON gt.gang_type_id = g.gang_type_id
+  LEFT JOIN custom_gang_types cgt ON cgt.id = g.custom_gang_type_id
   WHERE f.id = get_fighter_available_advancements.fighter_id;
 
   IF NOT FOUND THEN
     RAISE EXCEPTION 'Fighter not found with ID %', get_fighter_available_advancements.fighter_id;
   END IF;
-  
-  -- Determine if the fighter uses flat costs based on their subtypes
-  -- Only Gangers and Exotic Beasts use flat costs
-  v_uses_flat_cost :=
-    v_fighter_subtypes ?| array['Ganger', 'Exotic Beast'];
-  
+
+  -- SQL cannot read the capability registry in types/edition.ts, so the slug is
+  -- resolved to an id once here rather than compared per row. Mirrors the
+  -- cumulativeXp capability: N26 earns Advancements by crossing a rank
+  -- threshold and spends no XP on them.
+  v_cumulative_xp := v_edition_id IS NOT NULL
+    AND v_edition_id = (SELECT id FROM editions WHERE slug = 'n26');
+
+  -- Determine if the fighter uses flat costs based on their subtypes.
+  -- Only Gangers and Exotic Beasts use flat costs, and only where XP is spent:
+  -- an edition that earns Advancements by rank has no cost to make flat.
+  v_uses_flat_cost := NOT v_cumulative_xp
+    AND v_fighter_subtypes ?| array['Ganger', 'Exotic Beast'];
+
   -- Get the advancements category ID
   SELECT id INTO v_advancements_category_id
   FROM fighter_effect_categories
@@ -47,6 +63,9 @@ BEGIN
       COALESCE((fet.type_specific_data->>'credits_increase')::integer, 10) AS base_credits_increase
     FROM fighter_effect_types fet
     WHERE fet.fighter_effect_category_id = v_advancements_category_id
+      -- Edition-scoped: effect_name repeats across editions, so an unfiltered
+      -- read would hand N26 rows to N23 fighters once the N26 catalog is seeded.
+      AND fet.edition_id IS NOT DISTINCT FROM v_edition_id
   ),
   advancement_counts AS (
     -- Count how many times each fighter has advanced each characteristic
@@ -68,6 +87,8 @@ BEGIN
       etc.base_xp_cost,
       -- Calculate XP cost based on fighter subtype and characteristic
       CASE
+        -- Advancements are earned by rank, not bought: there is nothing to pay
+        WHEN v_cumulative_xp THEN 0
         -- For Gangers and Exotic Beasts: fixed 6 XP cost
         WHEN v_uses_flat_cost THEN 6
         -- For Juves and Prospects: base cost only (no escalating penalty)
@@ -78,6 +99,8 @@ BEGIN
       END as xp_cost,
       -- Calculate credits increase based on fighter subtype and characteristic
       CASE
+        -- Flat per characteristic, straight off the edition's own catalog rows
+        WHEN v_cumulative_xp THEN etc.base_credits_increase
         -- For Gangers and Exotic Beasts: credits based on advancement table
         WHEN v_uses_flat_cost THEN
           CASE
@@ -100,6 +123,9 @@ BEGIN
       true as is_available,
       -- Check if fighter has enough XP based on the calculated cost
       CASE
+        -- Nothing is spent, so affordability never blocks. Whether an
+        -- Advancement is actually owed is a rank question the caller answers.
+        WHEN v_cumulative_xp THEN true
         WHEN v_uses_flat_cost THEN v_fighter_xp >= 6
         WHEN v_fighter_subtypes ?| array['Juve', 'Prospect'] THEN v_fighter_xp >= etc.base_xp_cost
         WHEN COALESCE(ac.times_increased, 0) = 0 THEN v_fighter_xp >= etc.base_xp_cost
@@ -130,7 +156,8 @@ BEGIN
     'current_xp', v_fighter_xp,
     'fighter_subtypes', v_fighter_subtypes,
     'uses_flat_cost', v_uses_flat_cost,
-    -- Ganger/Exotic Beast: Specialist table row (random Primary skill) — same flat costs as other ganger advances
+    -- Ganger/Exotic Beast: Specialist table row (random Primary skill) — same flat costs as other ganger advances.
+    -- v_uses_flat_cost is already false for rank-based editions, which promote Specialists by their own rules.
     'ganger_to_specialist_advancement', CASE WHEN v_uses_flat_cost THEN jsonb_build_object(
       'xp_cost', 6,
       'credits_increase', 20

--- a/supabase/migrations/20260810120000_add_fighters_starting_xp.sql
+++ b/supabase/migrations/20260810120000_add_fighters_starting_xp.sql
@@ -1,0 +1,41 @@
+-- Starting XP recorded on the fighter itself (N26 "Advance Models" rules).
+--
+-- N26 never spends XP: a model earns an Advancement each time its running total
+-- crosses a rank threshold. Counting those crossings needs to know where the
+-- model started, because the tiers widen as XP rises — a Ganger recruited on
+-- 13 XP sits on a 6-wide band, not the 3-wide Rookie band a fresh model starts
+-- on.
+--
+-- WHY THE FIGHTER CARRIES ITS OWN COPY. fighter_types.starting_xp and
+-- custom_fighter_types.starting_xp hold the value a fighter is recruited with,
+-- but both are editable in Admin. Reading recruitment XP from the type would
+-- mean that correcting a fighter type retroactively changes how much XP every
+-- existing fighter of that type counts as having earned, and therefore how many
+-- Advancements it is owed. Each fighter keeps its own copy, fixed at the moment
+-- it joined the gang.
+--
+-- WHICH COLUMN IS AUTHORITATIVE. The fighters table now carries three XP
+-- columns and they are not interchangeable:
+--
+--   xp           current XP. Under N26 this only ever grows; under N23 it is a
+--                currency and falls when an Advancement is bought.
+--   starting_xp  recruitment XP. AUTHORITATIVE for rank calculations.
+--   total_xp     lifetime XP counter. NOT authoritative here — updateFighterXp
+--                and updateFighterXpWithOoa both return total_xp set to the
+--                fighter's current xp, so it does not reliably mean "XP earned
+--                since recruitment" and must not be used to derive ranks.
+--
+-- DEFAULT 0, deliberately. 0 is a legal starting value: N23 does not use the
+-- concept at all, and some N26 fighter types genuinely start on 0. The rank
+-- table in utils/advancementRanks.ts handles it correctly by omitting the
+-- Rookie band's own first tier (1-3) from its data — nothing ever *moves onto*
+-- that tier, so a model on 0 or 1 alike first advances at 4. This matches the
+-- existing DEFAULT 0 on both (custom_)fighter_types.starting_xp columns.
+--
+-- Stored as numeric to match fighters.xp and the type-level starting_xp columns.
+
+ALTER TABLE public.fighters
+  ADD COLUMN IF NOT EXISTS starting_xp numeric NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.fighters.starting_xp IS
+  'XP this fighter was recruited with, copied from its (custom_)fighter_type at recruitment. Fixed thereafter: N26 Advancements are earned by crossing rank thresholds above this value, so it must not follow later edits to the fighter type. Authoritative for rank calculations — total_xp is not.';

--- a/supabase/migrations/20260810120000_add_fighters_starting_xp.sql
+++ b/supabase/migrations/20260810120000_add_fighters_starting_xp.sql
@@ -6,13 +6,25 @@
 -- 13 XP sits on a 6-wide band, not the 3-wide Rookie band a fresh model starts
 -- on.
 --
--- WHY THE FIGHTER CARRIES ITS OWN COPY. fighter_types.starting_xp and
--- custom_fighter_types.starting_xp hold the value a fighter is recruited with,
--- but both are editable in Admin. Reading recruitment XP from the type would
--- mean that correcting a fighter type retroactively changes how much XP every
--- existing fighter of that type counts as having earned, and therefore how many
--- Advancements it is owed. Each fighter keeps its own copy, fixed at the moment
--- it joined the gang.
+-- WHY THE FIGHTER CARRIES ITS OWN COPY. A fighter is recruited with
+-- xp = its type's starting_xp, so the value is known at that moment — but it
+-- cannot be recovered afterwards from anything already stored:
+--
+--   * Not from the fighter's type. fighter_type_id is not fixed: promoting a
+--     fighter rewrites it (promoteFighter -> updateFighterDetails), and
+--     updateFighterDetails can reassign fighter_type_id / custom_fighter_type_id
+--     outright. A Ganger recruited on 13 XP and promoted to Champion would start
+--     being measured against the Champion's starting XP, silently changing how
+--     many Advancements it is owed mid-campaign. Both type-level columns are
+--     also editable in Admin, so correcting the catalog would rebase every
+--     existing fighter of that type.
+--
+--   * Not from xp - total_xp. total_xp is not maintained on the live path:
+--     updateFighterXpWithOoa (what the Add XP modal calls) writes xp only and
+--     returns a total_xp it never stored. The one path that does maintain the
+--     column, /api/fighters/[id] with xp_to_add, has no caller in the UI.
+--
+-- So each fighter keeps its own copy, fixed at the moment it joined the gang.
 --
 -- WHICH COLUMN IS AUTHORITATIVE. The fighters table now carries three XP
 -- columns and they are not interchangeable:

--- a/supabase/migrations/20260810130000_seed_n26_advancements.sql
+++ b/supabase/migrations/20260810130000_seed_n26_advancements.sql
@@ -1,0 +1,131 @@
+-- Seed the N26 characteristic Advancement catalog.
+--
+-- Same tables as N23: fighter_effect_types in the 'advancements' category, with
+-- one fighter_effect_type_modifiers row each. fighter_effect_types is
+-- edition-scoped via edition_id and effect_name repeats across editions, so
+-- every row here is a NEW row alongside its N23 namesake. The N23 rows are left
+-- untouched.
+--
+-- What differs from N23 is the numbers, not the shape:
+--
+--   * No XP cost. N26 earns Advancements by crossing a rank threshold rather
+--     than buying them, so type_specific_data carries xp_cost 0 and N23's
+--     escalating "base + 2 per previous increase" pricing does not apply.
+--   * Credits increases come from the N26 Advancement table and are flat --
+--     there is no Ganger/Exotic Beast special case.
+--       +5   Leadership, Intelligence, Cool, Willpower
+--       +10  Initiative, Movement
+--       +15  Weapon Skill, Ballistic Skill
+--       +20  Strength, Toughness, Wounds, Attacks, Save
+--   * Save is an N26-only Advancement; N23 fighters have no Save characteristic.
+--
+-- MODIFIER SIGNS. Target numbers improve by going DOWN, raw values by going UP:
+--   * Weapon Skill, Ballistic Skill, Save are target numbers -> -1
+--   * everything else is a raw value                         -> +1
+-- Note Initiative, Leadership, Cool, Willpower and Intelligence are raw values
+-- in N26 but target numbers in N23 (see N26_FIGHTER_LIMITS in
+-- utils/characteristicLimits.ts), so their sign here is the OPPOSITE of the N23
+-- rows of the same name. This is the same inversion the N26 Lasting Injury seed
+-- documents, where 'reduce Ld by 1' is -1 rather than N23's +1.
+--
+-- Unlike that injury seed, the modifiers ARE seeded here rather than entered by
+-- hand in Admin: an injury may legitimately carry no stat change, but an
+-- Advancement with no modifier does nothing at all. addCharacteristicAdvancement
+-- looks the template up by stat_name with .single(), deriving stat_name from
+-- effect_name (lowercased, spaces to underscores) -- so exactly one modifier per
+-- row, and the stat_name column below must match that derivation exactly.
+--
+-- '+1 Save' assumes the fighter already has a Save to improve; a null Save is a
+-- fighter type data error rather than something to resolve here.
+--
+-- Re-runnable: both inserts are guarded, so applying twice is a no-op.
+
+BEGIN;
+
+WITH target AS (
+  SELECT
+    (SELECT id FROM public.fighter_effect_categories WHERE category_name = 'advancements') AS category_id,
+    (SELECT id FROM public.editions WHERE slug = 'n26') AS edition_id
+),
+-- Named seed_rows rather than rows: ROWS is a Postgres keyword, and the
+-- `name(col, col) AS (...)` CTE form reads like a CREATE TABLE column list to
+-- static analysers (Supabase's SQL editor flags it as creating a table without
+-- RLS). Postgres parses either form; this one doesn't set off the warning.
+-- Ordered as they appear on the Advancement table, cheapest first.
+seed_rows(effect_name, credits_increase, sort_order) AS (
+  VALUES
+    ('Leadership',       5,  1),
+    ('Intelligence',     5,  2),
+    ('Cool',             5,  3),
+    ('Willpower',        5,  4),
+    ('Initiative',      10,  5),
+    ('Movement',        10,  6),
+    ('Weapon Skill',    15,  7),
+    ('Ballistic Skill', 15,  8),
+    ('Strength',        20,  9),
+    ('Toughness',       20, 10),
+    ('Wounds',          20, 11),
+    ('Attacks',         20, 12),
+    ('Save',            20, 13)
+)
+INSERT INTO public.fighter_effect_types
+  (effect_name, fighter_effect_category_id, edition_id, type_specific_data, sort_order)
+SELECT
+  r.effect_name,
+  t.category_id,
+  t.edition_id,
+  jsonb_build_object('xp_cost', 0, 'credits_increase', r.credits_increase),
+  r.sort_order
+FROM seed_rows r
+CROSS JOIN target t
+WHERE t.category_id IS NOT NULL
+  AND t.edition_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM public.fighter_effect_types existing
+    WHERE existing.effect_name = r.effect_name
+      AND existing.fighter_effect_category_id = t.category_id
+      AND existing.edition_id = t.edition_id
+  );
+
+-- One modifier per Advancement. stat_name must match the app's derivation from
+-- effect_name (lowercased, spaces to underscores), because
+-- addCharacteristicAdvancement looks the template up by that name.
+WITH target AS (
+  SELECT
+    (SELECT id FROM public.fighter_effect_categories WHERE category_name = 'advancements') AS category_id,
+    (SELECT id FROM public.editions WHERE slug = 'n26') AS edition_id
+),
+seed_modifiers(effect_name, stat_name, numeric_value) AS (
+  VALUES
+    -- Raw values in N26: higher is better.
+    ('Leadership',      'leadership',       1),
+    ('Intelligence',    'intelligence',     1),
+    ('Cool',            'cool',             1),
+    ('Willpower',       'willpower',        1),
+    ('Initiative',      'initiative',       1),
+    ('Movement',        'movement',         1),
+    ('Strength',        'strength',         1),
+    ('Toughness',       'toughness',        1),
+    ('Wounds',          'wounds',           1),
+    ('Attacks',         'attacks',          1),
+    -- Target numbers: lower is better.
+    ('Weapon Skill',    'weapon_skill',    -1),
+    ('Ballistic Skill', 'ballistic_skill', -1),
+    ('Save',            'save',            -1)
+)
+INSERT INTO public.fighter_effect_type_modifiers
+  (fighter_effect_type_id, stat_name, default_numeric_value, operation)
+SELECT fet.id, m.stat_name, m.numeric_value, 'add'
+FROM seed_modifiers m
+CROSS JOIN target t
+JOIN public.fighter_effect_types fet
+  ON fet.effect_name = m.effect_name
+ AND fet.fighter_effect_category_id = t.category_id
+ AND fet.edition_id = t.edition_id
+WHERE NOT EXISTS (
+  SELECT 1 FROM public.fighter_effect_type_modifiers existing
+  WHERE existing.fighter_effect_type_id = fet.id
+    AND existing.stat_name = m.stat_name
+);
+
+COMMIT;

--- a/types/edition.ts
+++ b/types/edition.ts
@@ -111,6 +111,12 @@ const EDITION_CAPABILITIES = {
   /** Fighter types carry a Starting XP value (feeds N26 advancement ranks) */
   startingXp:               { n23: false, n26: true  },
   /**
+   * XP accumulates and is never spent: Advancements are earned by crossing rank
+   * thresholds (see utils/advancementRanks.ts). When false, XP is a currency
+   * spent on Advancements and refunded if one is deleted.
+   */
+  cumulativeXp:             { n23: false, n26: true  },
+  /**
    * Weapon profiles use the N26 statline (SR, LR, Str, AP, Lethality) rather
    * than the N23 one (Rng S/L, Acc S/L, Str, AP, D, Am). Ammo and Damage are
    * written into Traits on N26 profiles.
@@ -180,6 +186,9 @@ export const hasTradePoints = (editionSlug?: string | null): boolean =>
 
 export const hasStartingXp = (editionSlug?: string | null): boolean =>
   can('startingXp', editionSlug);
+
+export const hasCumulativeXp = (editionSlug?: string | null): boolean =>
+  can('cumulativeXp', editionSlug);
 
 export const hasLethalityStatline = (editionSlug?: string | null): boolean =>
   can('lethalityStatline', editionSlug);

--- a/types/fighter.ts
+++ b/types/fighter.ts
@@ -158,6 +158,7 @@ export interface FighterProps {
   save?: number | null;
   edition_slug?: string | null;
   xp: number;
+  starting_xp?: number;
   kills: number;
   kill_count?: number;
   gang_id?: string;

--- a/utils/advancementRanks.ts
+++ b/utils/advancementRanks.ts
@@ -1,0 +1,93 @@
+import { hasCumulativeXp } from '@/types/edition';
+
+/**
+ * XP totals that move a model onto a new rank, and so award an Advancement.
+ *
+ * Not keyed by edition on purpose. Whether an edition works this way is one
+ * decision, and it is already declared as the `cumulativeXp` capability in
+ * types/edition.ts — the registry that every caller reads and that a new edition
+ * cannot compile without answering. A second `Record<EditionSlug, …>` here would
+ * be the same decision written twice, with nothing keeping the two in step.
+ *
+ * The Rookie band's own first tier (1-3) is absent: every model is recruited
+ * onto it and nothing ever *moves onto* it, so a model starting on 1 first
+ * advances at 4. Leaving it out of the data rather than filtering by starting XP
+ * is what makes a starting_xp of 0 work — 0 and 1 both sit below the first entry
+ * and yield the same count at every XP total. That matters, because 0 is a legal
+ * starting value: N23 does not use Starting XP at all, and some N26 fighter
+ * types genuinely start on 0.
+ *
+ * Legend of the Underhive (229) is entered like any other rank but has nothing
+ * above it, so Advancement stops there — 20 in total.
+ */
+const N26_TIER_STARTS: readonly number[] = [
+  4, 7, 10,
+  13, 19, 25, 31,
+  37, 49, 61, 73,
+  85, 97, 109, 121,
+  133, 157, 181, 205,
+  229,
+];
+
+const tiersAtOrBelow = (xp: number): number =>
+  N26_TIER_STARTS.filter((tierStart) => tierStart <= xp).length;
+
+/**
+ * How many Advancements a model has earned in total.
+ *
+ * Under a cumulative-XP edition `currentXp` is starting XP plus everything ever
+ * awarded, and an Advancement is granted each time that total moves the model
+ * onto a new rank.
+ *
+ * This is a range count rather than `currentXp - startingXp` because the tiers
+ * widen as XP rises: rebasing to zero would put a Ganger recruited on 13 XP back
+ * on the 3-wide Rookie track and advance them at twice the intended rate.
+ */
+export function advancementsEarnedFor(
+  editionSlug: string | null | undefined,
+  startingXp: number,
+  currentXp: number,
+): number {
+  // Editions that spend XP on Advancements have no ranks, and an unresolved slug
+  // means the edition failed to load — award nothing in either case.
+  if (!hasCumulativeXp(editionSlug)) return 0;
+
+  // XP below the recruitment value is only reachable by editing a fighter after
+  // the fact; it means no Advancement, never a negative one.
+  return Math.max(0, tiersAtOrBelow(currentXp) - tiersAtOrBelow(startingXp));
+}
+
+/**
+ * How many Advancements a model has already taken.
+ *
+ * A characteristic lands as a fighter_effect in the 'advancements' category, a
+ * skill as a fighter_skill flagged is_advance. Starting and free skills are not
+ * Advancements and carry is_advance false.
+ */
+export function countAdvancementsTaken(
+  effects: { advancements?: unknown[] } | null | undefined,
+  skills: Record<string, { is_advance?: boolean }> | null | undefined,
+): number {
+  const characteristics = effects?.advancements?.length ?? 0;
+  const skillAdvances = Object.values(skills ?? {}).filter((skill) => skill?.is_advance).length;
+
+  return characteristics + skillAdvances;
+}
+
+/**
+ * Advancements earned but not yet taken — the "Level Up" state the badge shows,
+ * and the limit the add-advancement actions enforce. Derived on read from data
+ * the caller already holds, so the badge and the limit cannot drift apart and
+ * awarding XP needs no extra write.
+ */
+export function openAdvancementsFor(
+  editionSlug: string | null | undefined,
+  startingXp: number,
+  currentXp: number,
+  advancementsTaken: number,
+): number {
+  return Math.max(
+    0,
+    advancementsEarnedFor(editionSlug, startingXp, currentXp) - advancementsTaken,
+  );
+}

--- a/utils/dice.ts
+++ b/utils/dice.ts
@@ -347,3 +347,45 @@ export const resolveGangerExoticBeastAdvancementRangeFromUtilByName = (
   const entry = GANGER_EXOTIC_BEAST_ADVANCEMENT_TABLE.find((e) => e.name === name);
   return entry?.range;
 };
+
+// ============================================================================
+// N26 Advancement - 2D6 table
+// ============================================================================
+
+/**
+ * One result on the N26 Advancement table.
+ *
+ * `credits` is the rulebook's Credits Value increase for the result, shown for
+ * reference while choosing. It is NOT what gets applied — the figure the app
+ * charges comes from the fighter_effect_types row via
+ * get_fighter_available_advancements, so a catalog correction takes effect
+ * without touching this table.
+ */
+export type N26AdvancementEntry = {
+  range: [number, number];
+  name: string;
+  credits: number;
+};
+
+/**
+ * The player may take any result they rolled at or above, so a roll sets an
+ * upper bound rather than picking a row. Nothing here enforces that: the roll is
+ * logged and the player selects a result, matching how the N23 Ganger table
+ * already behaves.
+ */
+export const N26_ADVANCEMENT_TABLE: N26AdvancementEntry[] = [
+  { range: [2, 2],   name: '+1 Leadership, +1 Intelligence or a random Primary skill', credits: 5 },
+  { range: [3, 4],   name: '+1 Cool or +1 Willpower',                                  credits: 5 },
+  { range: [5, 5],   name: 'A new Primary skill or a random Secondary skill',          credits: 10 },
+  { range: [6, 6],   name: '+1 Initiative or +1" Movement',                            credits: 10 },
+  { range: [7, 8],   name: 'A new Secondary skill',                                    credits: 15 },
+  { range: [9, 9],   name: '+1 Weapon Skill or +1 Ballistic Skill',                    credits: 15 },
+  { range: [10, 10], name: '+1 Strength or +1 Toughness',                              credits: 20 },
+  { range: [11, 11], name: '+1 Wounds, +1 Attacks or +1 Save',                         credits: 20 },
+  // A 12 lifts the Skill Set restriction entirely — any set, including sets
+  // exclusive to other gangs. The model's own Type/Subtype gate still applies.
+  { range: [12, 12], name: 'Any skill',                                                credits: 30 },
+];
+
+export const resolveN26AdvancementFromUtil = (roll: number): N26AdvancementEntry | undefined =>
+  N26_ADVANCEMENT_TABLE.find((e) => roll >= e.range[0] && roll <= e.range[1]);

--- a/utils/exotic-beasts.ts
+++ b/utils/exotic-beasts.ts
@@ -104,7 +104,8 @@ export async function createExoticBeastsForEquipment(
           willpower,
           intelligence,
           save,
-          special_rules
+          special_rules,
+          starting_xp
         )
       `)
       .eq('equipment_id', params.equipmentId);
@@ -147,7 +148,10 @@ export async function createExoticBeastsForEquipment(
           intelligence: fighterType.intelligence,
           save: fighterType.save ?? null,
           special_rules: fighterType.special_rules || [],
-          xp: 0
+          // A beast is recruited like any other fighter, so it starts on its
+          // type's Starting XP and records that as its recruitment value.
+          xp: fighterType.starting_xp ?? 0,
+          starting_xp: fighterType.starting_xp ?? 0
         })
         .select('id, fighter_name, fighter_type, fighter_subtypes, credits, created_at')
         .single();


### PR DESCRIPTION
## Why

N26 replaces N23's "spend XP to buy an Advancement" economy with a rank ladder: XP only ever accumulates, and a model earns an Advancement each time its total crosses a tier boundary. Nothing in the app knew this — `fighter-advancement.ts` had no edition awareness at all, and `get_fighter_available_advancements` returned every row in the `advancements` category regardless of edition.

This is a fresh implementation from `main`, written after reviewing #1947 (which is left alone). Three things that review settled and this branch assumes:

- **`starting_xp = 0` is a legal value.** N23 does not use the concept and some N26 fighter types genuinely start on 0. So there is no `DEFAULT 1` migration here, and the admin fighter-type forms and API route need **no changes at all** — they already do the right thing.
- **The Level Up badge appears on the gang roster too.** `getGangFightersList` is pure query-builder, built to avoid per-fighter round trips, so it cannot call a per-fighter RPC. The tier table therefore lives in TS.
- **Edition gating goes through the capability registry**, as reshaped by #1949.

## What changed

**`fighters.starting_xp`** (`numeric NOT NULL DEFAULT 0`) snapshots the XP a fighter was recruited with. `(custom_)fighter_types.starting_xp` are editable, so reading recruitment XP from the type would retroactively change how many Advancements every existing fighter of that type is owed. Set on all four recruitment paths — `add-fighter`, both `copy-fighter` branches, and `exotic-beasts` (whose `fighter_types` embed did not select it either). `copy-gang` needs nothing, it spreads `select('*')`.

The migration comment also records which of the three XP columns is authoritative: `starting_xp` is, `total_xp` is not — `updateFighterXp` and `updateFighterXpWithOoa` both return `total_xp` set to the fighter's current `xp`.

**N26 Advancement catalog** — 13 `fighter_effect_types` rows with a modifier each, edition-scoped alongside their N23 namesakes. No XP cost; credits straight off the N26 table (+5 psychology, +10 Initiative/Movement, +15 WS/BS, +20 S/T/W/A/Sv), flat with no Ganger special case. Save is N26-only.

Modifier signs follow the direction each characteristic improves in — target numbers down, raw values up. **Initiative and the four psychology characteristics are raw values in N26 but target numbers in N23**, so their signs are the opposite of the N23 rows of the same name, the same inversion the N26 injury seed documents.

**`get_fighter_available_advancements`** now resolves the fighter's edition from its gang the way `add_fighter_injury` does and filters on it. Without this the seed would have offered N26 rows to N23 fighters — the regression that matters most here. N26 also forces `xp_cost` 0, flat credits, `uses_flat_cost` false and no Ganger-to-Specialist row.

**`cumulativeXp` capability** — one new row in `EDITION_CAPABILITIES`. `utils/advancementRanks.ts` is deliberately **not** edition-keyed: the registry already answers that question and a second `Record<EditionSlug, …>` would be the same decision declared twice with nothing keeping them in step.

The rank table omits the Rookie band's own first tier (1–3), because nothing ever *moves onto* it. That is what makes `starting_xp = 0` work: 0 and 1 are provably indistinguishable at every XP total.

| Starting XP | Next Advancement at |
|---|---|
| 0 | 4 |
| 1 | 4 |
| 3 | 4 |
| 4 | 7 |
| 13 (Ganger) | 19 |

The rulebook's own example Ganger profile reads `13/19` for Current/Target XP, which matches.

**Actions** — the three that move a fighter's XP load its edition and gate all five sites: both affordability guards, both deductions and the refund on delete. N26 gates on the open-advancement count instead, the same figure the badge shows, so the two cannot disagree. Deleting an N26 Advancement gives the Level Up back for free, since the taken count drops.

This also gates `isGangerOrExoticBeastSubtype`, which drives the **ganger purchase path** and not just the roll UI — an N26 Ganger would otherwise have been charged N23's flat 6 XP.

**UI** — `LevelUpBadge` on the fighter page and gang roster, derived on read so nothing can drift and entering XP needs no extra write. `N26AdvancementPanel` owns the 2D6 roll and table rather than threading more ternaries through a 3,100-line component.

## Please look at this one separately

**The roster edition source changed, and it reaches beyond the badge.** `getGangFightersList` set `edition_slug` from `fighter_types`, which is `null` for custom fighter types. It now resolves once from the gang. That value also drives `hasSaveCharacteristic` (the Sv column) and three `WeaponTable editionSlug` props — the N26 lethality statline — on every roster card. Gangs using custom fighter types will render differently, correctly, after this.

## Also in here

A preparatory commit extracts `hooks/use-roll-logger.ts`, replacing five copies of the same mutation skeleton and three hand-rolled cooldowns across the advancement, injury and vehicle-damage lists. It fixes a latent double-click bug on the way — the originals compared the cooldown against state, so two clicks in the same tick both saw it as `false` and both submitted.

## Out of scope

Batch selection of several Advancements at once, maximum-characteristic enforcement, N26 skill advancements (blocked upstream — there are no N26 `skill_types` yet), vehicles, rank titles, and the Level Up badge in printed rosters.

## Testing

- `npm run build` and `npm run lint` clean. The 9 remaining lint problems are all pre-existing on `main`, none in a file this branch touches.
- Both migrations applied to a throwaway Postgres 16 and **re-applied**: the seed stays at 13 rows and 13 modifiers, and the column add is a no-op the second time.
- `get_fighter_available_advancements` exercised in rolled-back transactions against three fighters. **The N23 Ganger sees only its N23 row, flat cost 6, Specialist row unchanged** — the regression that matters most. The N26 Ganger sees 13 characteristics, every `xp_cost` 0, credits matching the table, `uses_flat_cost` false and no Specialist row. A gang with only a `custom_gang_type_id` resolves to N26 correctly, exercising the `COALESCE` branch.
- 18 rank-math checks against the real module: every worked example above, the 20-Advancement ceiling at 229, `starting_xp` 0 matching 1 across 0–400, and zeros for `n23` / `null` / unknown slugs.

> [!NOTE]
> Not exercised in a browser — local sign-in is unavailable. The PostgREST embed added to `fighter-advancement.ts` is verified only by its FK chain, which does check out: `fighters.gang_id → gangs`, `gangs.gang_type_id → gang_types`, `gangs.custom_gang_type_id → custom_gang_types`, both to `editions`. Note `fighters` has two FKs to `gangs`, which is why the `!gang_id` disambiguation hint is required. It sits on the critical path of all three advancement actions for **both** editions, so a bad embed would break N23 too — worth a click-through before merge.

## Worth checking on staging

- **Whether `fighter_types.starting_xp` is populated for the N26 catalog.** Types that should start higher — Gangers on 13, etc. — need that data entered, or they will advance faster than intended. This is catalog data entry, not a defect: 0 is a perfectly valid value for the types that should have it.
- The roster of a gang using **custom fighter types**, for the edition-source change above.
- A Lasting Injury roll and a Vehicle Lasting Damage roll, for the `useRollLogger` conversion.