### PR TITLE
Fix Outcasts archetype eligibility for multi-subtype N23/N26 fighters.

### DIFF
--- a/app/actions/add-fighter.ts
+++ b/app/actions/add-fighter.ts
@@ -8,7 +8,7 @@ import { updateGangFinancials } from '@/utils/gang-rating-and-wealth';
 import { logFighterAction } from '@/app/actions/logs/fighter-logs';
 import { mapArchetypeSkillAccessToOverrides } from '@/utils/archetypeEligibility';
 import { assertArchetypeAssignable } from '@/utils/assertArchetypeAssignable';
-import { editionSlugFromJoin, type EditionJoin } from '@/types/edition';
+import { editionSlugFromJoin, gangEditionSlug, type EditionJoin } from '@/types/edition';
 
 interface SelectedEquipment {
   equipment_id: string;
@@ -373,7 +373,11 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
           .single(),
       supabase
         .from('gangs')
-        .select('id, credits, user_id, gang_type_id')
+        .select(`
+          id, credits, user_id, gang_type_id,
+          gang_types!gang_type_id ( editions:edition_id ( slug ) ),
+          custom_gang_types!custom_gang_type_id ( editions:edition_id ( slug ) )
+        `)
         .eq('id', params.gang_id)
         .single()
     ]);
@@ -442,11 +446,15 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
         ? fighterSource.fighter_subtypes
         : ['Custom'];
 
+      // Prefer fighter-type edition; fall back to gang edition for legacy custom types with null edition_id
+      const editionSlug =
+        editionSlugFromJoin(fighterSource.editions) ?? gangEditionSlug(gangData);
+
       const assignable = await assertArchetypeAssignable(supabase, {
         gangTypeId: gangData.gang_type_id,
         fighterSubtypes,
         archetypeId: params.selected_archetype_id,
-        editionSlug: editionSlugFromJoin(fighterSource.editions),
+        editionSlug,
       });
       if (!assignable.ok) {
         return {

--- a/app/actions/add-fighter.ts
+++ b/app/actions/add-fighter.ts
@@ -6,10 +6,9 @@ import { invalidateFighterAddition, invalidateUserGangsList } from '@/utils/cach
 import { createExoticBeastsForEquipment } from '@/utils/exotic-beasts';
 import { updateGangFinancials } from '@/utils/gang-rating-and-wealth';
 import { logFighterAction } from '@/app/actions/logs/fighter-logs';
-import {
-  isArchetypeEligible,
-  mapArchetypeSkillAccessToOverrides,
-} from '@/utils/archetypeEligibility';
+import { mapArchetypeSkillAccessToOverrides } from '@/utils/archetypeEligibility';
+import { assertArchetypeAssignable } from '@/utils/assertArchetypeAssignable';
+import { editionSlugFromJoin, type EditionJoin } from '@/types/edition';
 
 interface SelectedEquipment {
   equipment_id: string;
@@ -18,6 +17,13 @@ interface SelectedEquipment {
   effect_ids?: string[];
   is_editable?: boolean;
 }
+
+/** Fighter type / custom fighter type row with optional editions embed for slug resolution. */
+type FighterTypeSource = {
+  editions?: EditionJoin;
+  fighter_subtypes?: string[] | null;
+  [key: string]: unknown;
+};
 
 interface AddFighterParams {
   fighter_name: string;
@@ -317,7 +323,7 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
     // First try to get fighter if user owns it
     const { data: ownedFighter } = await supabase
       .from('custom_fighter_types')
-      .select('*')
+      .select('*, editions:edition_id ( slug )')
       .eq('id', params.fighter_type_id)
       .eq('user_id', user.id)
       .maybeSingle();
@@ -347,7 +353,7 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
           // Fetch the actual fighter data
           const { data: fighterData } = await supabase
             .from('custom_fighter_types')
-            .select('*')
+            .select('*, editions:edition_id ( slug )')
             .eq('id', params.fighter_type_id)
             .single();
 
@@ -362,7 +368,7 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
         Promise.resolve({ data: null, error: null }) : // Skip regular fighter type lookup for custom fighters
         supabase
           .from('fighter_types')
-          .select('*')
+          .select('*, editions:edition_id ( slug )')
           .eq('id', params.fighter_type_id)
           .single(),
       supabase
@@ -431,15 +437,24 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
     // Server-side archetype eligibility (UI check is not sufficient)
     let archetypeIdToPersist: string | null = null;
     if (params.selected_archetype_id) {
-      if (!isArchetypeEligible({
+      const fighterSource = effectiveFighterData as FighterTypeSource;
+      const fighterSubtypes = fighterSource.fighter_subtypes?.length
+        ? fighterSource.fighter_subtypes
+        : ['Custom'];
+
+      const assignable = await assertArchetypeAssignable(supabase, {
         gangTypeId: gangData.gang_type_id,
-        fighterSubtype: effectiveFighterData.fighter_subtypes?.[0] ?? 'Custom',
-      })) {
+        fighterSubtypes,
+        archetypeId: params.selected_archetype_id,
+        editionSlug: editionSlugFromJoin(fighterSource.editions),
+      });
+      if (!assignable.ok) {
         return {
           success: false,
-          error: 'This fighter type cannot be assigned an archetype for this gang.',
+          error: assignable.error,
         };
       }
+
       archetypeIdToPersist = params.selected_archetype_id;
     }
 

--- a/app/actions/edit-fighter.ts
+++ b/app/actions/edit-fighter.ts
@@ -12,6 +12,7 @@ import { updateGangFinancials, updateGangRatingSimple, GangFinancialUpdateResult
 import { insertFighterOoaRecords } from './fighter-ooa-records';
 import { allowsMultipleSubtypes, editionSlugFromJoin, gangEditionSlug } from '@/types/edition';
 import { assertArchetypeAssignable } from '@/utils/assertArchetypeAssignable';
+import { mapArchetypeSkillAccessToOverrides } from '@/utils/archetypeEligibility';
 
 // Helper function to invalidate owner's cache when beast fighter is updated
 async function invalidateBeastOwnerCache(fighterId: string, gangId: string, supabase: any) {
@@ -1503,6 +1504,7 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
     // Archetype: reject illegal assigns; clear when subtypes invalidate the current one
     const previousArchetypeId: string | null = fighter.selected_archetype_id ?? null;
     let clearedArchetype = false;
+    let archetypeIdForOverrides: string | null = null;
 
     const wantsExplicitClear =
       params.selected_archetype_id !== undefined && !params.selected_archetype_id;
@@ -1563,6 +1565,9 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
           }
         } else {
           updateData.selected_archetype_id = params.selected_archetype_id;
+          if (params.selected_archetype_id !== previousArchetypeId) {
+            archetypeIdForOverrides = params.selected_archetype_id;
+          }
         }
       } else if (previousArchetypeId) {
         // Subtypes changed without an explicit archetype write — drop if no longer assignable
@@ -1584,7 +1589,7 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
 
     if (updateError) throw updateError;
 
-    // Drop skill-access overrides when the archetype is removed (eligibility loss or explicit clear)
+    // Keep skill-access overrides in sync with the persisted archetype (server-derived, not client-supplied)
     if (clearedArchetype) {
       const { error: overrideDeleteError } = await supabase
         .from('fighter_skill_access_override')
@@ -1592,8 +1597,47 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
         .eq('fighter_id', params.fighter_id);
 
       if (overrideDeleteError) {
-        // Fighter row already updated; don't fail the whole save over orphan overrides
         console.error('Failed to clear skill access overrides after archetype removal:', overrideDeleteError);
+      }
+    } else if (archetypeIdForOverrides) {
+      try {
+        const { data: archetypeData, error: archetypeFetchError } = await supabase
+          .from('skill_access_archetypes')
+          .select('skill_access')
+          .eq('id', archetypeIdForOverrides)
+          .single();
+
+        if (archetypeFetchError || !archetypeData) {
+          console.error('Failed to fetch archetype for skill-access overrides:', archetypeFetchError);
+        } else if (archetypeData.skill_access && Array.isArray(archetypeData.skill_access)) {
+          const overrides = mapArchetypeSkillAccessToOverrides(archetypeData.skill_access);
+
+          const { error: overrideDeleteError } = await supabase
+            .from('fighter_skill_access_override')
+            .delete()
+            .eq('fighter_id', params.fighter_id);
+
+          if (overrideDeleteError) {
+            console.error('Failed to clear prior skill access overrides:', overrideDeleteError);
+          } else if (overrides.length > 0) {
+            const overrideRows = overrides.map(sa => ({
+              fighter_id: params.fighter_id,
+              skill_type_id: sa.skill_type_id,
+              access_level: sa.access_level,
+              user_id: fighter.user_id,
+            }));
+
+            const { error: overrideInsertError } = await supabase
+              .from('fighter_skill_access_override')
+              .insert(overrideRows);
+
+            if (overrideInsertError) {
+              console.error('Failed to insert archetype skill-access overrides:', overrideInsertError);
+            }
+          }
+        }
+      } catch (archetypeError) {
+        console.error('Error applying archetype skill-access overrides:', archetypeError);
       }
     }
 

--- a/app/actions/edit-fighter.ts
+++ b/app/actions/edit-fighter.ts
@@ -286,6 +286,8 @@ interface EditFighterResult {
     kill_count?: number;
   };
   error?: string;
+  /** Partial-success note (e.g. archetype saved but skill-access overrides failed) */
+  warning?: string;
   fighter?: {
     id: string;
     fighter_name: string;
@@ -1590,6 +1592,10 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
     if (updateError) throw updateError;
 
     // Keep skill-access overrides in sync with the persisted archetype (server-derived, not client-supplied)
+    const ARCHETYPE_SKILL_ACCESS_WARNING =
+      'Fighter updated but skill access save failed. Please try again via Customise Skill Set Access.';
+    let archetypeSkillAccessWarning: string | undefined;
+
     if (clearedArchetype) {
       const { error: overrideDeleteError } = await supabase
         .from('fighter_skill_access_override')
@@ -1598,6 +1604,7 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
 
       if (overrideDeleteError) {
         console.error('Failed to clear skill access overrides after archetype removal:', overrideDeleteError);
+        archetypeSkillAccessWarning = ARCHETYPE_SKILL_ACCESS_WARNING;
       }
     } else if (archetypeIdForOverrides) {
       try {
@@ -1609,6 +1616,7 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
 
         if (archetypeFetchError || !archetypeData) {
           console.error('Failed to fetch archetype for skill-access overrides:', archetypeFetchError);
+          archetypeSkillAccessWarning = ARCHETYPE_SKILL_ACCESS_WARNING;
         } else if (archetypeData.skill_access && Array.isArray(archetypeData.skill_access)) {
           const overrides = mapArchetypeSkillAccessToOverrides(archetypeData.skill_access);
 
@@ -1619,6 +1627,7 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
 
           if (overrideDeleteError) {
             console.error('Failed to clear prior skill access overrides:', overrideDeleteError);
+            archetypeSkillAccessWarning = ARCHETYPE_SKILL_ACCESS_WARNING;
           } else if (overrides.length > 0) {
             const overrideRows = overrides.map(sa => ({
               fighter_id: params.fighter_id,
@@ -1633,11 +1642,13 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
 
             if (overrideInsertError) {
               console.error('Failed to insert archetype skill-access overrides:', overrideInsertError);
+              archetypeSkillAccessWarning = ARCHETYPE_SKILL_ACCESS_WARNING;
             }
           }
         }
       } catch (archetypeError) {
         console.error('Error applying archetype skill-access overrides:', archetypeError);
+        archetypeSkillAccessWarning = ARCHETYPE_SKILL_ACCESS_WARNING;
       }
     }
 
@@ -1799,6 +1810,7 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
 
     return {
       success: true,
+      warning: archetypeSkillAccessWarning,
       data: { 
         fighter: updatedFighter
       }

--- a/app/actions/edit-fighter.ts
+++ b/app/actions/edit-fighter.ts
@@ -207,7 +207,10 @@ async function validateFighterSubtypesForUpdate(
   params: UpdateFighterDetailsParams,
   subtypes: string[],
   currentSubtypes?: string[] | null
-): Promise<{ ok: true; subtypes: string[] } | { ok: false; error: string }> {
+): Promise<
+  | { ok: true; subtypes: string[]; editionSlug: string }
+  | { ok: false; error: string }
+> {
   const normalized = normalizeFighterSubtypeNames(subtypes);
   const previous = normalizeFighterSubtypeNames(
     Array.isArray(currentSubtypes) ? currentSubtypes : []
@@ -262,7 +265,7 @@ async function validateFighterSubtypesForUpdate(
     }
   }
 
-  return { ok: true, subtypes: normalized };
+  return { ok: true, subtypes: normalized, editionSlug };
 }
 
 interface EditFighterResult {
@@ -1470,6 +1473,10 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
     if (params.kill_count !== undefined) updateData.kill_count = params.kill_count;
     if (params.cost_adjustment !== undefined) updateData.cost_adjustment = params.cost_adjustment;
     if (params.special_rules !== undefined) updateData.special_rules = params.special_rules;
+
+    // Reused by archetype assignability when subtypes were validated in this request
+    let resolvedEditionSlug: string | undefined;
+
     if (params.fighter_subtypes !== undefined) {
       const validated = await validateFighterSubtypesForUpdate(
         supabase,
@@ -1482,6 +1489,7 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
         return { success: false, error: validated.error };
       }
       updateData.fighter_subtypes = validated.subtypes;
+      resolvedEditionSlug = validated.editionSlug;
     }
     if (params.fighter_type !== undefined) updateData.fighter_type = params.fighter_type;
     if (params.fighter_type_id !== undefined) updateData.fighter_type_id = params.fighter_type_id;
@@ -1496,7 +1504,18 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
     const previousArchetypeId: string | null = fighter.selected_archetype_id ?? null;
     let clearedArchetype = false;
 
-    if (params.selected_archetype_id !== undefined || params.fighter_subtypes !== undefined) {
+    const wantsExplicitClear =
+      params.selected_archetype_id !== undefined && !params.selected_archetype_id;
+    const wantsAssignableCheck =
+      Boolean(params.selected_archetype_id) ||
+      (params.selected_archetype_id === undefined &&
+        params.fighter_subtypes !== undefined &&
+        Boolean(previousArchetypeId));
+
+    if (wantsExplicitClear) {
+      updateData.selected_archetype_id = null;
+      if (previousArchetypeId) clearedArchetype = true;
+    } else if (wantsAssignableCheck) {
       const { data: gangData, error: gangError } = await supabase
         .from('gangs')
         .select('gang_type_id')
@@ -1512,36 +1531,41 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
       const fighterSubtypes = effectiveSubtypes.length ? effectiveSubtypes : ['Custom'];
 
       const checkArchetypeAssignable = async (archetypeId: string) => {
-        const editionResult = await resolveFighterEditionSlugForUpdate(
-          supabase,
-          params.fighter_id,
-          params
-        );
-        if (!editionResult.ok) {
-          return { ok: false as const, error: editionResult.error };
+        let editionSlug = resolvedEditionSlug;
+        if (!editionSlug) {
+          const editionResult = await resolveFighterEditionSlugForUpdate(
+            supabase,
+            params.fighter_id,
+            params
+          );
+          if (!editionResult.ok) {
+            return { ok: false as const, error: editionResult.error };
+          }
+          editionSlug = editionResult.editionSlug;
         }
         return assertArchetypeAssignable(supabase, {
           gangTypeId: gangData.gang_type_id,
           fighterSubtypes,
           archetypeId,
-          editionSlug: editionResult.editionSlug,
+          editionSlug,
         });
       };
 
-      if (params.selected_archetype_id !== undefined) {
-        if (params.selected_archetype_id) {
-          const assignable = await checkArchetypeAssignable(params.selected_archetype_id);
-          if (!assignable.ok) {
+      if (params.selected_archetype_id) {
+        const assignable = await checkArchetypeAssignable(params.selected_archetype_id);
+        if (!assignable.ok) {
+          // Same save also changed subtypes: drop the stale archetype instead of failing the edit
+          if (params.fighter_subtypes !== undefined) {
+            updateData.selected_archetype_id = null;
+            if (previousArchetypeId) clearedArchetype = true;
+          } else {
             return { success: false, error: assignable.error };
           }
-          updateData.selected_archetype_id = params.selected_archetype_id;
         } else {
-          updateData.selected_archetype_id = null;
-          if (previousArchetypeId) clearedArchetype = true;
+          updateData.selected_archetype_id = params.selected_archetype_id;
         }
       } else if (previousArchetypeId) {
         // Subtypes changed without an explicit archetype write — drop if no longer assignable
-        // (e.g. still Outcasts-eligible but catalog priority moved Leader ahead of Champion).
         const assignable = await checkArchetypeAssignable(previousArchetypeId);
         if (!assignable.ok) {
           updateData.selected_archetype_id = null;
@@ -1550,13 +1574,12 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
       }
     }
 
-
     // Update fighter
     const { data: updatedFighter, error: updateError } = await supabase
       .from('fighters')
       .update(updateData)
       .eq('id', params.fighter_id)
-      .select('id, fighter_name, label, kills, kill_count, cost_adjustment, fighter_subtypes')
+      .select('id, fighter_name, label, kills, kill_count, cost_adjustment, fighter_subtypes, selected_archetype_id')
       .single();
 
     if (updateError) throw updateError;

--- a/app/actions/edit-fighter.ts
+++ b/app/actions/edit-fighter.ts
@@ -11,6 +11,7 @@ import { countsTowardRating, hasKilledStatusFlag } from '@/utils/fighter-status'
 import { updateGangFinancials, updateGangRatingSimple, GangFinancialUpdateResult } from '@/utils/gang-rating-and-wealth';
 import { insertFighterOoaRecords } from './fighter-ooa-records';
 import { allowsMultipleSubtypes, editionSlugFromJoin, gangEditionSlug } from '@/types/edition';
+import { assertArchetypeAssignable } from '@/utils/assertArchetypeAssignable';
 
 // Helper function to invalidate owner's cache when beast fighter is updated
 async function invalidateBeastOwnerCache(fighterId: string, gangId: string, supabase: any) {
@@ -1445,7 +1446,7 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
     // Get fighter data (RLS will handle permissions)
     const { data: fighter, error: fighterError } = await supabase
       .from('fighters')
-      .select('id, gang_id, user_id, cost_adjustment, kills, kill_count, killed, retired, enslaved, captured, fighter_name, fighter_subtypes')
+      .select('id, gang_id, user_id, cost_adjustment, kills, kill_count, killed, retired, enslaved, captured, fighter_name, fighter_subtypes, selected_archetype_id')
       .eq('id', params.fighter_id)
       .single();
 
@@ -1490,7 +1491,64 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
     if (params.note !== undefined) updateData.note = params.note;
     if (params.note_backstory !== undefined) updateData.note_backstory = params.note_backstory;
     if (params.fighter_gang_legacy_id !== undefined) updateData.fighter_gang_legacy_id = params.fighter_gang_legacy_id;
-    if (params.selected_archetype_id !== undefined) updateData.selected_archetype_id = params.selected_archetype_id;
+
+    // Archetype: reject illegal assigns; clear when subtypes invalidate the current one
+    const previousArchetypeId: string | null = fighter.selected_archetype_id ?? null;
+    let clearedArchetype = false;
+
+    if (params.selected_archetype_id !== undefined || params.fighter_subtypes !== undefined) {
+      const { data: gangData, error: gangError } = await supabase
+        .from('gangs')
+        .select('gang_type_id')
+        .eq('id', fighter.gang_id)
+        .single();
+
+      if (gangError || !gangData) {
+        throw new Error('Gang not found');
+      }
+
+      const effectiveSubtypes: string[] =
+        updateData.fighter_subtypes ?? fighter.fighter_subtypes ?? [];
+      const fighterSubtypes = effectiveSubtypes.length ? effectiveSubtypes : ['Custom'];
+
+      const checkArchetypeAssignable = async (archetypeId: string) => {
+        const editionResult = await resolveFighterEditionSlugForUpdate(
+          supabase,
+          params.fighter_id,
+          params
+        );
+        if (!editionResult.ok) {
+          return { ok: false as const, error: editionResult.error };
+        }
+        return assertArchetypeAssignable(supabase, {
+          gangTypeId: gangData.gang_type_id,
+          fighterSubtypes,
+          archetypeId,
+          editionSlug: editionResult.editionSlug,
+        });
+      };
+
+      if (params.selected_archetype_id !== undefined) {
+        if (params.selected_archetype_id) {
+          const assignable = await checkArchetypeAssignable(params.selected_archetype_id);
+          if (!assignable.ok) {
+            return { success: false, error: assignable.error };
+          }
+          updateData.selected_archetype_id = params.selected_archetype_id;
+        } else {
+          updateData.selected_archetype_id = null;
+          if (previousArchetypeId) clearedArchetype = true;
+        }
+      } else if (previousArchetypeId) {
+        // Subtypes changed without an explicit archetype write — drop if no longer assignable
+        // (e.g. still Outcasts-eligible but catalog priority moved Leader ahead of Champion).
+        const assignable = await checkArchetypeAssignable(previousArchetypeId);
+        if (!assignable.ok) {
+          updateData.selected_archetype_id = null;
+          clearedArchetype = true;
+        }
+      }
+    }
 
 
     // Update fighter
@@ -1502,6 +1560,19 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
       .single();
 
     if (updateError) throw updateError;
+
+    // Drop skill-access overrides when the archetype is removed (eligibility loss or explicit clear)
+    if (clearedArchetype) {
+      const { error: overrideDeleteError } = await supabase
+        .from('fighter_skill_access_override')
+        .delete()
+        .eq('fighter_id', params.fighter_id);
+
+      if (overrideDeleteError) {
+        // Fighter row already updated; don't fail the whole save over orphan overrides
+        console.error('Failed to clear skill access overrides after archetype removal:', overrideDeleteError);
+      }
+    }
 
     // If cost_adjustment changed and fighter is active, update rating and wealth by delta
     let costAdjustmentDelta = 0;

--- a/components/fighter/edit-fighter/fighter-edit-modal.tsx
+++ b/components/fighter/edit-fighter/fighter-edit-modal.tsx
@@ -1,7 +1,6 @@
 import { useState, useMemo, useEffect } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { updateFighterDetails } from '@/app/actions/edit-fighter';
-import { saveFighterSkillAccessOverrides } from '@/app/actions/fighter-skill-access';
 import { Input } from "@/components/ui/input";
 import Modal from "@/components/ui/modal";
 import { FighterProps as Fighter, Archetype } from '@/types/fighter';
@@ -15,7 +14,6 @@ import { allowsMultipleSubtypes } from '@/types/edition';
 import {
   getArchetypeCatalogSubtype,
   isArchetypeEligible,
-  mapArchetypeSkillAccessToOverrides,
 } from '@/utils/archetypeEligibility';
 import { SkillAccessModal } from './skill-access-modal';
 import { FighterCharacteristicTable } from './fighter-characteristic-table';
@@ -548,37 +546,14 @@ export function EditFighterModal({
         onEditSuccess?.(serverFighter, (ctx as any).optimistic, (ctx as any).snapshot);
       }
 
-      // Prefer the persisted archetype — server may clear it when subtypes invalidate the catalog
+      // Prefer the persisted archetype — server may clear it when subtypes invalidate the catalog.
+      // Skill-access overrides are applied server-side from the validated archetype row.
       const persistedArchetypeId: string | null =
         serverFighter && 'selected_archetype_id' in serverFighter
           ? ((serverFighter as { selected_archetype_id?: string | null }).selected_archetype_id ?? null)
           : (submit.selected_archetype_id ?? null);
 
       setSelectedArchetypeId(persistedArchetypeId || '');
-
-      // If archetype changed vs pre-save fighter, save/clear skill access overrides
-      if (persistedArchetypeId !== (fighter.selected_archetype_id ?? null)) {
-        try {
-          if (persistedArchetypeId && archetypesData?.archetypes) {
-            const archetype = (archetypesData.archetypes as Archetype[]).find(
-              (a: Archetype) => a.id === persistedArchetypeId
-            );
-            if (archetype) {
-              const overrides = mapArchetypeSkillAccessToOverrides(archetype.skill_access);
-
-              await saveFighterSkillAccessOverrides({ fighter_id: fighter.id, overrides });
-            }
-          } else if (!persistedArchetypeId && fighter.selected_archetype_id) {
-            // Archetype removed - clear all overrides (reset to default)
-            await saveFighterSkillAccessOverrides({ fighter_id: fighter.id, overrides: [] });
-          }
-        } catch (error) {
-          console.error('Failed to save archetype skill access:', error);
-          toast.error('Fighter updated but skill access save failed. Please try again via Customise Skill Set Access.');
-          return; // Don't show success toast
-        }
-      }
-
       toast.success('Fighter updated successfully');
     }
   });

--- a/components/fighter/edit-fighter/fighter-edit-modal.tsx
+++ b/components/fighter/edit-fighter/fighter-edit-modal.tsx
@@ -548,19 +548,27 @@ export function EditFighterModal({
         onEditSuccess?.(serverFighter, (ctx as any).optimistic, (ctx as any).snapshot);
       }
 
-      // If archetype changed, save the skill access overrides
-      if (submit.selected_archetype_id !== fighter.selected_archetype_id) {
+      // Prefer the persisted archetype — server may clear it when subtypes invalidate the catalog
+      const persistedArchetypeId: string | null =
+        serverFighter && 'selected_archetype_id' in serverFighter
+          ? ((serverFighter as { selected_archetype_id?: string | null }).selected_archetype_id ?? null)
+          : (submit.selected_archetype_id ?? null);
+
+      setSelectedArchetypeId(persistedArchetypeId || '');
+
+      // If archetype changed vs pre-save fighter, save/clear skill access overrides
+      if (persistedArchetypeId !== (fighter.selected_archetype_id ?? null)) {
         try {
-          if (submit.selected_archetype_id && archetypesData?.archetypes) {
+          if (persistedArchetypeId && archetypesData?.archetypes) {
             const archetype = (archetypesData.archetypes as Archetype[]).find(
-              (a: Archetype) => a.id === submit.selected_archetype_id
+              (a: Archetype) => a.id === persistedArchetypeId
             );
             if (archetype) {
               const overrides = mapArchetypeSkillAccessToOverrides(archetype.skill_access);
 
               await saveFighterSkillAccessOverrides({ fighter_id: fighter.id, overrides });
             }
-          } else if (!submit.selected_archetype_id && fighter.selected_archetype_id) {
+          } else if (!persistedArchetypeId && fighter.selected_archetype_id) {
             // Archetype removed - clear all overrides (reset to default)
             await saveFighterSkillAccessOverrides({ fighter_id: fighter.id, overrides: [] });
           }

--- a/components/fighter/edit-fighter/fighter-edit-modal.tsx
+++ b/components/fighter/edit-fighter/fighter-edit-modal.tsx
@@ -478,7 +478,10 @@ export function EditFighterModal({
         stat_adjustments: Object.keys(pendingStatAdjustments).length > 0 ? pendingStatAdjustments : undefined
       });
       if (!result.success) throw new Error(result.error || 'Failed to update fighter');
-      return result.data?.fighter;
+      return {
+        fighter: result.data?.fighter,
+        warning: result.warning,
+      };
     },
     onMutate: (submit) => {
       // Build optimistic user-effect overlay from pendingStatAdjustments
@@ -541,7 +544,8 @@ export function EditFighterModal({
       }
       toast.error(err instanceof Error ? err.message : 'Failed to update fighter');
     },
-    onSuccess: async (serverFighter, submit, ctx) => {
+    onSuccess: async (result, submit, ctx) => {
+      const serverFighter = result?.fighter;
       if (ctx && 'optimistic' in (ctx as any) && 'snapshot' in (ctx as any)) {
         onEditSuccess?.(serverFighter, (ctx as any).optimistic, (ctx as any).snapshot);
       }
@@ -554,7 +558,12 @@ export function EditFighterModal({
           : (submit.selected_archetype_id ?? null);
 
       setSelectedArchetypeId(persistedArchetypeId || '');
-      toast.success('Fighter updated successfully');
+
+      if (result?.warning) {
+        toast.error(result.warning);
+      } else {
+        toast.success('Fighter updated successfully');
+      }
     }
   });
 

--- a/components/fighter/edit-fighter/fighter-edit-modal.tsx
+++ b/components/fighter/edit-fighter/fighter-edit-modal.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { updateFighterDetails } from '@/app/actions/edit-fighter';
 import { saveFighterSkillAccessOverrides } from '@/app/actions/fighter-skill-access';
@@ -12,7 +12,11 @@ import { toast } from 'sonner';
 import { applySpecialRulesModifiers } from '@/utils/effect-modifiers';
 import { getFighterSubtypeSortRank } from '@/utils/fighterSubtypeRank';
 import { allowsMultipleSubtypes } from '@/types/edition';
-import { isArchetypeEligible, mapArchetypeSkillAccessToOverrides } from '@/utils/archetypeEligibility';
+import {
+  getArchetypeCatalogSubtype,
+  isArchetypeEligible,
+  mapArchetypeSkillAccessToOverrides,
+} from '@/utils/archetypeEligibility';
 import { SkillAccessModal } from './skill-access-modal';
 import { FighterCharacteristicTable } from './fighter-characteristic-table';
 import { CharacterStatsModal } from './character-stats-modal';
@@ -268,13 +272,21 @@ export function EditFighterModal({
     return fighter.fighter_subtypes?.[0] || 'Unknown';
   }, [selectedFighterTypeId, fighterTypes, fighter.fighter_subtypes]);
 
-  // Archetypes still use a single effective subtype (first selected, else type default)
-  const effectiveFighterSubtype = selectedFighterSubtypes[0] || defaultFighterSubtypeName;
+  // Archetypes: eligible if any selected subtype matches the gang's Outcasts list; catalog uses fixed priority
+  const subtypesForArchetype = useMemo(() => {
+    if (selectedFighterSubtypes.length > 0) return selectedFighterSubtypes;
+    if (fighter.fighter_subtypes?.length) return fighter.fighter_subtypes;
+    return defaultFighterSubtypeName ? [defaultFighterSubtypeName] : [];
+  }, [selectedFighterSubtypes, fighter.fighter_subtypes, defaultFighterSubtypeName]);
+
+  const archetypeCatalogSubtype = getArchetypeCatalogSubtype(subtypesForArchetype, {
+    gangTypeId,
+  });
 
   const archetypeFighterSubtypeId = useMemo(() => {
-    if (!effectiveFighterSubtype || !allFighterSubtypes) return '';
-    return allFighterSubtypes.find(fc => fc.subtype_name === effectiveFighterSubtype)?.id ?? '';
-  }, [effectiveFighterSubtype, allFighterSubtypes]);
+    if (!archetypeCatalogSubtype || !allFighterSubtypes) return '';
+    return allFighterSubtypes.find(fc => fc.subtype_name === archetypeCatalogSubtype)?.id ?? '';
+  }, [archetypeCatalogSubtype, allFighterSubtypes]);
 
   // Resolve the effective fighter type for default special rules (specialisation aware)
   const effectiveFighterType = useMemo(() => {
@@ -391,10 +403,10 @@ export function EditFighterModal({
     return typeOptions;
   }, [fighterTypes, fighter.edition_slug]);
 
-  // Determine if this fighter can use archetypes (Outcasts gang + Leader/Champion subtype)
+  // Eligible when Outcasts (N23/N26) + any selected subtype is in that gang's archetype list
   const canUseArchetypes = isArchetypeEligible({
     gangTypeId,
-    fighterSubtype: effectiveFighterSubtype || fighter.fighter_subtypes?.[0],
+    fighterSubtypes: subtypesForArchetype,
   });
 
   // Fetch archetypes using TanStack Query (only if eligible and modal is open)
@@ -412,6 +424,24 @@ export function EditFighterModal({
     enabled: isOpen && canUseArchetypes,
     staleTime: 10 * 60 * 1000, // 10 minutes
   });
+
+  // Drop stale selection when ineligible, or when a settled non-empty catalog no longer includes it
+  useEffect(() => {
+    if (!selectedArchetypeId) return;
+
+    if (!canUseArchetypes) {
+      setSelectedArchetypeId('');
+      return;
+    }
+
+    const archetypes = archetypesData?.archetypes as Archetype[] | undefined;
+    // Wait for a real catalog payload; empty/missing lists must not wipe a valid selection
+    if (!archetypes || archetypes.length === 0) return;
+
+    if (!archetypes.some((a) => a.id === selectedArchetypeId)) {
+      setSelectedArchetypeId('');
+    }
+  }, [canUseArchetypes, archetypesData, selectedArchetypeId]);
 
   // TanStack mutation for editing fighter details
   const mutation = useMutation({
@@ -995,7 +1025,7 @@ export function EditFighterModal({
         costAdjustment: formValues.costAdjustment,
         special_rules: formValues.special_rules,
         fighter_gang_legacy_id: selectedGangLegacyId || null,
-        selected_archetype_id: selectedArchetypeId || null
+        selected_archetype_id: canUseArchetypes ? (selectedArchetypeId || null) : null
       };
 
       // Only include fighter type fields if we're actually updating the fighter type
@@ -1283,7 +1313,7 @@ export function EditFighterModal({
               </div>
             )}
 
-            {/* Archetype Selection (only for Underhive Outcasts Leader/Champion) */}
+            {/* Archetype Selection (Underhive Outcasts — N23 Leader/Champion, N26 + Ganger) */}
             {canUseArchetypes && (
               <div>
                 <label htmlFor="archetype" className="block text-sm font-medium mb-1">

--- a/components/gang/fighter-add/FighterAddModal.tsx
+++ b/components/gang/fighter-add/FighterAddModal.tsx
@@ -18,7 +18,7 @@ import { Combobox } from '@/components/ui/combobox';
 import { ImInfo } from 'react-icons/im';
 import { addFighterToGang } from '@/app/actions/add-fighter';
 import { useMutation, useQuery } from '@tanstack/react-query';
-import { isArchetypeEligible } from '@/utils/archetypeEligibility';
+import { getArchetypeCatalogSubtype, isArchetypeEligible } from '@/utils/archetypeEligibility';
 import {
   buildFighterFromServerData,
   buildBeastFromServerData,
@@ -248,7 +248,7 @@ export default function FighterAddModal({
 
   const canUseArchetypes = isArchetypeEligible({
     gangTypeId,
-    fighterSubtype: currentFighterType?.fighter_subtypes?.[0],
+    fighterSubtypes: currentFighterType?.fighter_subtypes,
   });
 
   // Scope the subtype lookup to the fighter type's edition: subtype_name is only
@@ -270,10 +270,12 @@ export default function FighterAddModal({
   });
 
   const currentFighterSubtypeId = useMemo(() => {
-    const primarySubtype = currentFighterType?.fighter_subtypes?.[0];
-    if (!primarySubtype || !allFighterSubtypes) return '';
-    return allFighterSubtypes.find(fc => fc.subtype_name === primarySubtype)?.id ?? '';
-  }, [currentFighterType, allFighterSubtypes]);
+    const catalogSubtype = getArchetypeCatalogSubtype(currentFighterType?.fighter_subtypes, {
+      gangTypeId,
+    });
+    if (!catalogSubtype || !allFighterSubtypes) return '';
+    return allFighterSubtypes.find(fc => fc.subtype_name === catalogSubtype)?.id ?? '';
+  }, [currentFighterType, allFighterSubtypes, gangTypeId]);
 
   const { data: archetypesData } = useQuery({
     queryKey: ['skill-archetypes', currentFighterSubtypeId],
@@ -558,7 +560,7 @@ export default function FighterAddModal({
       use_base_cost_for_rating: useBaseCostForRating,
       use_delegation_cost: useDelegationCost,
       fighter_gang_legacy_id: selectedLegacyId || undefined,
-      selected_archetype_id: selectedArchetypeId || undefined,
+      selected_archetype_id: canUseArchetypes ? (selectedArchetypeId || undefined) : undefined,
     });
 
     return true;

--- a/types/edition.ts
+++ b/types/edition.ts
@@ -29,7 +29,7 @@ export const editionsConflict = (
 
 /** An `editions:edition_id (…)` embed. PostgREST returns a to-one embed as an
  *  object, but generated types sometimes widen it to an array. */
-type EditionJoin = { slug: string } | { slug: string }[] | null | undefined;
+export type EditionJoin = { slug: string } | { slug: string }[] | null | undefined;
 
 function firstOf<T>(value: T | T[] | null | undefined): T | null {
   if (!value) return null;

--- a/utils/archetypeEligibility.ts
+++ b/utils/archetypeEligibility.ts
@@ -9,7 +9,9 @@ export const N26_UNDERHIVE_OUTCASTS_GANG_TYPE_ID = 'e3a5fbf4-edc8-4d85-be05-6d5a
 /**
  * Eligible subtypes per Outcasts gang type.
  * Array order is catalog priority when several eligible subtypes are selected
- * (e.g. Leader + Champion → Leader; N26 Ganger+Specialist → Ganger).
+ * (Leader > Champion > Ganger). Matches Outcasts skill-access archetype tables:
+ * when a fighter holds more than one qualifying subtype, the higher-priority
+ * catalog drives skill access.
  */
 const ARCHETYPE_ELIGIBLE_SUBTYPES_BY_GANG_TYPE: Record<string, readonly string[]> = {
   [N23_UNDERHIVE_OUTCASTS_GANG_TYPE_ID]: ['Leader', 'Champion'],

--- a/utils/archetypeEligibility.ts
+++ b/utils/archetypeEligibility.ts
@@ -1,5 +1,20 @@
-export const UNDERHIVE_OUTCASTS_GANG_TYPE_ID = '77fc520f-b453-46ef-9ef0-6a12872934f8';
-export const ARCHETYPE_ELIGIBLE_FIGHTER_SUBTYPES = ['Leader', 'Champion'];
+/**
+ * Outcasts gang type IDs for skill-archetype eligibility.
+ * Replaces the old single UNDERHIVE_OUTCASTS_GANG_TYPE_ID export — use the
+ * edition-specific constant (N23 vs N26).
+ */
+export const N23_UNDERHIVE_OUTCASTS_GANG_TYPE_ID = '77fc520f-b453-46ef-9ef0-6a12872934f8';
+export const N26_UNDERHIVE_OUTCASTS_GANG_TYPE_ID = 'e3a5fbf4-edc8-4d85-be05-6d5ad0b0d627';
+
+/**
+ * Eligible subtypes per Outcasts gang type.
+ * Array order is catalog priority when several eligible subtypes are selected
+ * (e.g. Leader + Champion → Leader; N26 Ganger+Specialist → Ganger).
+ */
+const ARCHETYPE_ELIGIBLE_SUBTYPES_BY_GANG_TYPE: Record<string, readonly string[]> = {
+  [N23_UNDERHIVE_OUTCASTS_GANG_TYPE_ID]: ['Leader', 'Champion'],
+  [N26_UNDERHIVE_OUTCASTS_GANG_TYPE_ID]: ['Leader', 'Champion', 'Ganger'],
+};
 
 const ARCHETYPE_OVERRIDE_ACCESS_LEVELS = new Set(['primary', 'secondary', 'allowed']);
 
@@ -8,18 +23,71 @@ export type ArchetypeSkillAccessOverride = {
   access_level: 'primary' | 'secondary' | 'allowed';
 };
 
+function normalizeSubtypeList(
+  fighterSubtypes?: Array<string | null | undefined> | null,
+  fighterSubtype?: string | null
+): string[] {
+  if (fighterSubtypes?.length) {
+    return fighterSubtypes.filter((name): name is string => Boolean(name));
+  }
+  return fighterSubtype ? [fighterSubtype] : [];
+}
+
+function getEligibleSubtypesForGang(gangTypeId?: string | null): readonly string[] | null {
+  if (!gangTypeId) return null;
+  return ARCHETYPE_ELIGIBLE_SUBTYPES_BY_GANG_TYPE[gangTypeId] ?? null;
+}
+
 /**
- * Returns true when a fighter belongs to an Underhive Outcasts gang
- * and holds a subtype that can be assigned a skill archetype.
+ * Returns true when a fighter belongs to an Underhive Outcasts gang (N23 or N26)
+ * and holds at least one subtype that can be assigned a skill archetype for that gang.
+ *
+ * Prefer `fighterSubtypes` for multi-subtype fighters; `fighterSubtype`
+ * remains for single-value call sites.
  */
 export function isArchetypeEligible(params: {
   gangTypeId?: string | null;
   fighterSubtype?: string | null;
+  fighterSubtypes?: Array<string | null | undefined> | null;
 }): boolean {
-  return (
-    params.gangTypeId === UNDERHIVE_OUTCASTS_GANG_TYPE_ID &&
-    ARCHETYPE_ELIGIBLE_FIGHTER_SUBTYPES.includes(params.fighterSubtype || '')
+  const eligible = getEligibleSubtypesForGang(params.gangTypeId);
+  if (!eligible) return false;
+
+  const subtypes = normalizeSubtypeList(params.fighterSubtypes, params.fighterSubtype);
+  return subtypes.some((name) => eligible.includes(name));
+}
+
+/**
+ * Picks which subtype drives the archetype catalog when several are present.
+ * Follows the gang type's eligible-subtype order (Leader → Champion → Ganger for N26).
+ */
+export function getArchetypeCatalogSubtype(
+  fighterSubtypes: Array<string | null | undefined> | null | undefined,
+  options: {
+    gangTypeId: string | null | undefined;
+    fighterSubtype?: string | null;
+  }
+): string | null {
+  const eligible = getEligibleSubtypesForGang(options.gangTypeId);
+  if (!eligible) return null;
+
+  const selected = new Set(
+    normalizeSubtypeList(fighterSubtypes, options.fighterSubtype)
   );
+  return eligible.find((name) => selected.has(name)) ?? null;
+}
+
+/**
+ * True when an archetype belongs in this fighter's edition-scoped catalog.
+ * `archetypeSubtypeId` comes from skill_access_archetypes.fighter_subtype_id;
+ * null/empty means unrestricted (legacy rows with no subtype FK).
+ */
+export function isArchetypeInCatalog(params: {
+  catalogSubtypeId?: string | null;
+  archetypeSubtypeId?: string | null;
+}): boolean {
+  if (!params.archetypeSubtypeId) return true;
+  return Boolean(params.catalogSubtypeId) && params.catalogSubtypeId === params.archetypeSubtypeId;
 }
 
 /**

--- a/utils/assertArchetypeAssignable.ts
+++ b/utils/assertArchetypeAssignable.ts
@@ -1,0 +1,111 @@
+import { getEditionIdBySlug } from '@/app/lib/editions';
+import {
+  getArchetypeCatalogSubtype,
+  isArchetypeEligible,
+  isArchetypeInCatalog,
+} from '@/utils/archetypeEligibility';
+
+export type AssertArchetypeAssignableResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+/**
+ * Server-side gate for assigning a skill archetype to a fighter.
+ * Checks Outcasts eligibility, that the archetype exists, and that its
+ * fighter_subtype_id matches the edition-scoped catalog subtype
+ * (Leader → Champion → Ganger priority).
+ */
+export async function assertArchetypeAssignable(
+  supabase: {
+    from: (table: string) => any;
+  },
+  params: {
+    gangTypeId: string | null | undefined;
+    fighterSubtypes: string[];
+    archetypeId: string;
+    editionSlug: string | null | undefined;
+  }
+): Promise<AssertArchetypeAssignableResult> {
+  if (
+    !isArchetypeEligible({
+      gangTypeId: params.gangTypeId,
+      fighterSubtypes: params.fighterSubtypes,
+    })
+  ) {
+    return {
+      ok: false,
+      error: 'This fighter type cannot be assigned an archetype for this gang.',
+    };
+  }
+
+  const { data: archetypeRow, error: archetypeLookupError } = await supabase
+    .from('skill_access_archetypes')
+    .select('id, fighter_subtype_id')
+    .eq('id', params.archetypeId)
+    .single();
+
+  if (archetypeLookupError || !archetypeRow) {
+    return {
+      ok: false,
+      error: 'Selected archetype was not found.',
+    };
+  }
+
+  // Legacy / unrestricted rows with no subtype FK
+  if (!archetypeRow.fighter_subtype_id) {
+    return { ok: true };
+  }
+
+  const catalogSubtypeName = getArchetypeCatalogSubtype(params.fighterSubtypes, {
+    gangTypeId: params.gangTypeId,
+  });
+  if (!catalogSubtypeName) {
+    return {
+      ok: false,
+      error: 'This fighter type cannot be assigned an archetype for this gang.',
+    };
+  }
+
+  if (!params.editionSlug) {
+    return {
+      ok: false,
+      error: 'Could not resolve edition for archetype validation.',
+    };
+  }
+
+  const editionId = await getEditionIdBySlug(params.editionSlug);
+  if (!editionId) {
+    return {
+      ok: false,
+      error: 'Could not resolve edition for archetype validation.',
+    };
+  }
+
+  const { data: catalogSubtype, error: catalogSubtypeError } = await supabase
+    .from('fighter_subtypes')
+    .select('id')
+    .eq('edition_id', editionId)
+    .eq('subtype_name', catalogSubtypeName)
+    .maybeSingle();
+
+  if (catalogSubtypeError || !catalogSubtype?.id) {
+    return {
+      ok: false,
+      error: 'Could not resolve subtype catalog for this edition.',
+    };
+  }
+
+  if (
+    !isArchetypeInCatalog({
+      catalogSubtypeId: catalogSubtype.id,
+      archetypeSubtypeId: archetypeRow.fighter_subtype_id,
+    })
+  ) {
+    return {
+      ok: false,
+      error: "Selected archetype does not match this fighter's subtype catalog.",
+    };
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
Eligibility now checks any selected subtype (not only [0]), uses N23 vs N26 gang-type rules, and validates/clears archetypes against the edition-scoped catalog so the UI no longer flickers or keeps stale skill access.