### PR TITLE
Add N26 edition gating for campaign types and territories.

### DIFF
--- a/app/actions/campaigns/[id]/campaign-territories.ts
+++ b/app/actions/campaigns/[id]/campaign-territories.ts
@@ -2,10 +2,11 @@
 
 import { createClient } from "@/utils/supabase/server";
 import { revalidateTag } from "next/cache";
-import { CACHE_TAGS } from "@/utils/cache-tags";
+import { CACHE_TAGS, purgePreEditionCampaignCatalogCachesOnce } from "@/utils/cache-tags";
 import { logTerritoryLost, logTerritoryClaimed } from "../../logs/gang-campaign-logs";
 import { getAuthenticatedUser } from '@/utils/auth';
 import { checkCampaignArbitrator } from '@/utils/user-permissions';
+import { editionsConflict, editionSlugFromJoin } from '@/types/edition';
 
 export interface AssignGangToTerritoryParams {
   campaignId: string;
@@ -21,7 +22,6 @@ export interface RemoveGangFromTerritoryParams {
 export interface AddTerritoryParams {
   campaignId: string;
   territoryId: string;
-  territoryName: string;
 }
 
 export interface CreateCustomCampaignTerritoryParams {
@@ -248,33 +248,67 @@ export async function removeGangFromTerritory(params: RemoveGangFromTerritoryPar
 }
 
 /**
- * Add a territory to a campaign with targeted cache invalidation
+ * Add a territory to a campaign with targeted cache invalidation.
+ * Only campaign owners, arbitrators, and system admins may call this.
  */
 export async function addTerritoryToCampaign(params: AddTerritoryParams) {
   try {
     const supabase = await createClient();
-    const { campaignId, territoryId, territoryName } = params;
+    const { campaignId, territoryId } = params;
 
     if (!territoryId) {
       throw new Error('Territory ID is required');
     }
 
+    const user = await getAuthenticatedUser(supabase);
+
+    const hasPermission = await checkCampaignArbitrator(user.id, campaignId);
+    if (!hasPermission) {
+      return { success: false, error: 'Only campaign owners and arbitrators can add territories' };
+    }
+
+    const [{ data: campaign, error: campaignError }, { data: templateTerritory, error: templateError }] =
+      await Promise.all([
+        supabase
+          .from('campaigns')
+          .select('campaign_types!campaign_type_id(editions:edition_id(slug))')
+          .eq('id', campaignId)
+          .single(),
+        supabase
+          .from('territories')
+          .select('territory_name, playing_card, editions:edition_id(slug)')
+          .eq('id', territoryId)
+          .maybeSingle(),
+      ]);
+
+    if (campaignError || !campaign) {
+      return { success: false, error: 'Campaign not found' };
+    }
+    if (templateError) {
+      console.error('Error fetching territory template:', templateError);
+      return { success: false, error: 'Failed to load territory template' };
+    }
+    if (!templateTerritory) {
+      return { success: false, error: 'Territory not found' };
+    }
+
+    const campaignEdition = editionSlugFromJoin((campaign as any).campaign_types?.editions);
+    const territoryEdition = editionSlugFromJoin((templateTerritory as any).editions);
+
+    if (editionsConflict(campaignEdition, territoryEdition)) {
+      return {
+        success: false,
+        error: 'This territory is from a different edition than the campaign',
+      };
+    }
+
     const insertData: Record<string, unknown> = {
       campaign_id: campaignId,
       territory_id: territoryId,
-      territory_name: territoryName
+      territory_name: templateTerritory.territory_name
     };
 
-    const { data: templateTerritory, error: templateError } = await supabase
-      .from('territories')
-      .select('playing_card')
-      .eq('id', territoryId)
-      .maybeSingle();
-
-    if (templateError) {
-      console.error('Error fetching territory template for playing_card:', templateError);
-    }
-    const rawCard = templateTerritory?.playing_card;
+    const rawCard = templateTerritory.playing_card;
     insertData.playing_card =
       typeof rawCard === 'string' && rawCard.trim() ? rawCard.trim() : null;
 
@@ -286,6 +320,7 @@ export async function addTerritoryToCampaign(params: AddTerritoryParams) {
 
     revalidateTag(`campaign-territories-${campaignId}`, { expire: 0 });
     revalidateTag(`campaign-${campaignId}`, { expire: 0 });
+    purgePreEditionCampaignCatalogCachesOnce();
 
     return { success: true };
   } catch (error) {

--- a/app/actions/create-campaign.ts
+++ b/app/actions/create-campaign.ts
@@ -3,7 +3,7 @@
 import { createClient } from "@/utils/supabase/server";
 import { getAuthenticatedUser } from "@/utils/auth";
 import { revalidateTag } from 'next/cache';
-import { CACHE_TAGS, invalidateCampaignCount } from '@/utils/cache-tags';
+import { CACHE_TAGS, invalidateCampaignCount, purgePreEditionCampaignCatalogCachesOnce } from '@/utils/cache-tags';
 
 interface CreateCampaignParams {
   name: string;
@@ -54,6 +54,9 @@ export async function createCampaign({ name, campaignTypeId, trading_posts }: Cr
 
     // Invalidate global campaign count
     invalidateCampaignCount();
+
+    // Drop pre-rename catalog cache keys that share campaign-types / territories tags
+    purgePreEditionCampaignCatalogCachesOnce();
 
     // Invalidate user's campaigns list so the new campaign appears immediately
     revalidateTag(CACHE_TAGS.USER_CAMPAIGNS(user.id), { expire: 0 });

--- a/app/api/admin/campaign-types/route.ts
+++ b/app/api/admin/campaign-types/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 import { checkAdmin } from "@/utils/auth";
+import { invalidateCampaignCatalogLists } from "@/utils/cache-tags";
 
 export async function GET() {
   const supabase = await createClient();
@@ -109,6 +110,7 @@ export async function POST(request: Request) {
       }
     }
 
+    invalidateCampaignCatalogLists();
     return NextResponse.json(campaignType);
   } catch (error) {
     console.error('Error creating campaign type:', error);
@@ -240,6 +242,7 @@ export async function PATCH(request: Request) {
       .eq('id', id)
       .single();
     if (fetchError) throw fetchError;
+    invalidateCampaignCatalogLists();
     return NextResponse.json(updatedCampaignType);
   } catch (error) {
     console.error('Error updating campaign type:', error);

--- a/app/api/admin/territories/route.ts
+++ b/app/api/admin/territories/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 import { checkAdmin } from "@/utils/auth";
+import { invalidateCampaignCatalogLists } from "@/utils/cache-tags";
 
 export async function GET(request: Request) {
   const supabase = await createClient();
@@ -75,6 +76,7 @@ export async function POST(request: Request) {
       .single();
 
     if (error) throw error;
+    invalidateCampaignCatalogLists();
     return NextResponse.json(territory);
   } catch (error) {
     console.error('Error creating territory:', error);
@@ -140,6 +142,7 @@ export async function PATCH(request: Request) {
       .single();
 
     if (error) throw error;
+    invalidateCampaignCatalogLists();
     return NextResponse.json(territory);
   } catch (error) {
     console.error('Error updating territory:', error);

--- a/app/api/campaigns/[campaignId]/route.ts
+++ b/app/api/campaigns/[campaignId]/route.ts
@@ -8,6 +8,7 @@ import {
   getCampaignCaptives
 } from "@/app/lib/campaigns/[id]/get-campaign-data";
 import { revalidateTag } from 'next/cache';
+import { purgePreEditionCampaignCatalogCachesOnce } from '@/utils/cache-tags';
 
 export async function GET(request: Request, props: { params: Promise<{ campaignId: string }> }) {
   const params = await props.params;
@@ -27,6 +28,7 @@ export async function GET(request: Request, props: { params: Promise<{ campaignI
     revalidateTag(`campaign-territories-${campaignId}`, { expire: 0 });
     revalidateTag(`campaign-battles-${campaignId}`, { expire: 0 });
     revalidateTag(`campaign-${campaignId}`, { expire: 0 });
+    purgePreEditionCampaignCatalogCachesOnce();
     // Use the same cached functions as the page
     const [
       campaignBasic,
@@ -57,6 +59,7 @@ export async function GET(request: Request, props: { params: Promise<{ campaignI
       campaign_type_id: campaignBasic.campaign_type_id,
       campaign_type_name: (campaignBasic.campaign_types as any)?.campaign_type_name || '',
       campaign_type_image_url: (campaignBasic.campaign_types as any)?.image_url || '',
+      edition_slug: (campaignBasic.campaign_types as any)?.edition_slug ?? null,
       image_url: campaignBasic.image_url || '',
       status: campaignBasic.status,
       description: campaignBasic.description,

--- a/app/campaigns/[id]/page.tsx
+++ b/app/campaigns/[id]/page.tsx
@@ -1,11 +1,13 @@
 import { createClient } from "@/utils/supabase/server";
 import { notFound } from "next/navigation";
+import { after } from "next/server";
 import CampaignPageContent from "@/components/campaigns/[id]/campaign-page-content";
 import { CampaignErrorBoundary } from "@/components/campaigns/campaign-error-boundary";
 import { checkCampaignPermissions } from "@/utils/user-permissions";
 import type { CampaignPermissions } from "@/types/user-permissions";
 import { getAuthenticatedUser } from "@/utils/auth";
 import { editionSlugFromJoin, withEditionSlug } from "@/types/edition";
+import { purgePreEditionCampaignCatalogCachesOnce } from "@/utils/cache-tags";
 
 // Import the optimized functions with unstable_cache
 import { 
@@ -26,6 +28,11 @@ import {
 export default async function CampaignPage(props: { params: Promise<{ id: string }> }) {
   const params = await props.params;
   const supabase = await createClient();
+
+  // Expire pre-rename catalog cache keys after the response (shared tags).
+  after(() => {
+    purgePreEditionCampaignCatalogCachesOnce();
+  });
 
   // Get the user data once at the page level via claims
   let userId: string | undefined = undefined;

--- a/app/lib/campaigns/[id]/get-campaign-data.ts
+++ b/app/lib/campaigns/[id]/get-campaign-data.ts
@@ -5,6 +5,7 @@ import { CACHE_TAGS } from '@/utils/cache-tags';
 import { fetchCampaignAllegiances } from '@/utils/campaigns/allegiances';
 import { getWinnerIdsFromParsed, getClaimerGangIdFromParsed } from '@/utils/battle-winners';
 import { fetchCampaignResources } from '@/utils/campaigns/resources';
+import { editionSlugFromJoin, withEditionSlug } from '@/types/edition';
 
 // No TTL - infinite cache with server action invalidation only
 // Cache only expires when explicitly invalidated via revalidateTag()
@@ -51,7 +52,7 @@ async function _getCampaignBasic(campaignId: string, supabase: SupabaseClient) {
     if (!typeError && campaignType) {
       campaignTypeName = campaignType.campaign_type_name;
       campaignTypeImageUrl = campaignType.image_url || '';
-      campaignTypeEditionSlug = (campaignType as any).editions?.slug ?? null;
+      campaignTypeEditionSlug = editionSlugFromJoin((campaignType as any).editions);
     }
   }
 
@@ -763,15 +764,15 @@ export const getCampaignTypes = async () => {
     async () => {
       const { data, error } = await supabase
         .from('campaign_types')
-        .select('id, campaign_type_name')
+        .select('id, campaign_type_name, editions:edition_id (slug)')
         .order('campaign_type_name');
       
       if (error) throw error;
-      return data || [];
+      return (data || []).map(withEditionSlug);
     },
-    ['campaign-types'],
+    ['campaign-types-with-edition'],
     {
-      tags: ['campaign-types'],
+      tags: [CACHE_TAGS.GLOBAL_CAMPAIGN_TYPES()],
       revalidate: false
     }
   )();
@@ -787,16 +788,19 @@ export const getAllTerritories = async () => {
     async () => {
       const { data, error } = await supabase
         .from('territories')
-        .select('id, territory_name, campaign_type_id, playing_card')
+        .select('id, territory_name, campaign_type_id, playing_card, editions:edition_id (slug)')
         .order('territory_name');
       
       if (error) throw error;
-      return (data || []).map(territory => ({
-        ...territory,
-        territory_id: territory.id
-      }));
+      return (data || []).map(territory => {
+        const withSlug = withEditionSlug(territory);
+        return {
+          ...withSlug,
+          territory_id: withSlug.id
+        };
+      });
     },
-    ['territories-list'],
+    ['territories-list-with-edition'],
     {
       tags: [CACHE_TAGS.GLOBAL_TERRITORIES_LIST()],
       revalidate: false

--- a/components/campaigns/[id]/campaign-add-territory-list.tsx
+++ b/components/campaigns/[id]/campaign-add-territory-list.tsx
@@ -5,17 +5,19 @@ import { toast } from 'sonner';
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Checkbox } from "@/components/ui/checkbox";
-import { campaignRank } from '@/utils/campaigns/campaignRank';
+import { getCampaignRank } from '@/utils/campaigns/campaignRank';
 import { addTerritoryToCampaign, createCustomCampaignTerritory } from "@/app/actions/campaigns/[id]/campaign-territories";
 import { ImInfo } from "react-icons/im";
 import { Tooltip } from 'react-tooltip';
 import type { CampaignType } from '@/types/campaign';
+import { sameEditionForDisplay } from '@/types/edition';
 
 interface Territory {
   id: string;
   territory_name: string;
   campaign_type_id: string | null;
   territory_id?: string | null;
+  edition_slug?: string | null;
 }
 
 interface CampaignTerritory {
@@ -27,6 +29,7 @@ interface TerritoryListProps {
   isAdmin: boolean;
   campaignId: string;
   campaignTypeId: string;
+  editionSlug?: string | null;
   campaignTypes: CampaignType[];
   allTerritories: Territory[];
   existingCampaignTerritories: CampaignTerritory[];
@@ -36,7 +39,8 @@ interface TerritoryListProps {
 export default function TerritoryList({ 
   isAdmin, 
   campaignId, 
-  campaignTypeId, 
+  campaignTypeId,
+  editionSlug,
   campaignTypes, 
   allTerritories, 
   existingCampaignTerritories,
@@ -48,6 +52,8 @@ export default function TerritoryList({
   const [isAdding, setIsAdding] = useState<string | null>(null);
   const [newTerritoryName, setNewTerritoryName] = useState('');
   const [isCreating, setIsCreating] = useState(false);
+
+  const campaignRank = getCampaignRank(editionSlug);
 
   const [prevCampaignTypeId, setPrevCampaignTypeId] = useState(campaignTypeId);
   if (campaignTypeId !== prevCampaignTypeId) {
@@ -75,7 +81,6 @@ export default function TerritoryList({
       const result = await addTerritoryToCampaign({
         campaignId,
         territoryId: territory.territory_id || territory.id,
-        territoryName: territory.territory_name
       });
 
       if (!result.success) {
@@ -96,7 +101,7 @@ export default function TerritoryList({
       toast.success(`Added ${territory.territory_name} to campaign`);
     } catch (error) {
       console.error('Error adding territory:', error);
-      toast.error("Failed to add territory");
+      toast.error(error instanceof Error ? error.message : "Failed to add territory");
     } finally {
       setIsAdding(null);
     }
@@ -139,6 +144,9 @@ export default function TerritoryList({
 
   const filteredTerritories = allTerritories
     .filter(territory => {
+      if (!sameEditionForDisplay(territory.edition_slug, editionSlug)) {
+        return false;
+      }
       if (territory.campaign_type_id && selectedTypes.includes(territory.campaign_type_id)) {
         return true;
       }
@@ -187,9 +195,12 @@ export default function TerritoryList({
           </span>
         </h3>
         <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4">
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mx-auto">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
             {[...campaignTypes]
-              .filter(type => type.campaign_type_name.toLowerCase() !== 'custom')
+              .filter(type =>
+                type.campaign_type_name.toLowerCase() !== 'custom' &&
+                sameEditionForDisplay(type.edition_slug, editionSlug)
+              )
               .sort((a, b) => {
                 const rankA = campaignRank[a.campaign_type_name.toLowerCase()] ?? Infinity;
                 const rankB = campaignRank[b.campaign_type_name.toLowerCase()] ?? Infinity;

--- a/components/campaigns/[id]/campaign-add-territory-modal.tsx
+++ b/components/campaigns/[id]/campaign-add-territory-modal.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react'
 import { createPortal } from 'react-dom'
-import { Button } from "@/components/ui/button"
 import Modal from "@/components/ui/modal"
 import TerritoryList from "@/components/campaigns/[id]/campaign-add-territory-list"
 import type { CampaignType } from '@/types/campaign';
@@ -12,6 +11,7 @@ interface Territory {
   territory_name: string;
   campaign_type_id: string | null;
   territory_id?: string | null;
+  edition_slug?: string | null;
 }
 
 interface CampaignTerritory {
@@ -24,6 +24,7 @@ interface CampaignAddTerritoryModalProps {
   onClose: () => void;
   campaignId: string;
   campaignTypeId: string;
+  editionSlug?: string | null;
   campaignTypes: CampaignType[];
   allTerritories: Territory[];
   existingCampaignTerritories: CampaignTerritory[];
@@ -36,6 +37,7 @@ export default function CampaignAddTerritoryModal({
   onClose,
   campaignId,
   campaignTypeId,
+  editionSlug,
   campaignTypes,
   allTerritories,
   existingCampaignTerritories,
@@ -66,6 +68,7 @@ export default function CampaignAddTerritoryModal({
           isAdmin={isAdmin}
           campaignId={campaignId}
           campaignTypeId={campaignTypeId}
+          editionSlug={editionSlug}
           campaignTypes={campaignTypes}
           allTerritories={allTerritories}
           existingCampaignTerritories={existingCampaignTerritories}

--- a/components/campaigns/[id]/campaign-members-table.tsx
+++ b/components/campaigns/[id]/campaign-members-table.tsx
@@ -629,7 +629,9 @@ export default function MembersTable({
 
   const gangModalContent = useMemo(() => (
     <div className="space-y-4">
-      <p className="text-sm text-muted-foreground">Select a gang to add to the campaign:</p>
+      <p className="text-sm text-muted-foreground">
+        Choose a gang for <span className="font-bold">{selectedMember?.profile.username}</span>:
+      </p>
       <div className="space-y-2">
         {[...userGangs].sort((a, b) => a.name.localeCompare(b.name)).map(gang => (
           <button
@@ -685,7 +687,7 @@ export default function MembersTable({
         </div>
       )}
     </div>
-  ), [userGangs, selectedGang, availableAllegiances, selectedAllegiance]);
+  ), [userGangs, selectedGang, availableAllegiances, selectedAllegiance, selectedMember]);
 
   const roleModalContent = useMemo(() => (
     <div className="space-y-4">
@@ -1197,6 +1199,15 @@ export default function MembersTable({
       {showGangModal && (
         <Modal
           title="Add Gang to Campaign"
+          helper={
+            campaignEditionSlug ? (
+              <>
+                Only <span className="font-bold">{campaignEditionSlug.toUpperCase()}</span> gangs can be added.
+              </>
+            ) : (
+              <>Only gangs matching this campaign&apos;s edition can be added.</>
+            )
+          }
           content={gangModalContent}
           onClose={() => {
             setShowGangModal(false);

--- a/components/campaigns/[id]/campaign-page-content.tsx
+++ b/components/campaigns/[id]/campaign-page-content.tsx
@@ -96,6 +96,7 @@ interface AllTerritory {
   territory_name: string;
   campaign_type_id: string | null;
   territory_id?: string | null;
+  edition_slug?: string | null;
 }
 
 
@@ -1150,6 +1151,7 @@ export default function CampaignPageContent({
           onClose={() => setShowTerritoryModal(false)}
           campaignId={campaignData.id}
           campaignTypeId={campaignData.campaign_type_id}
+          editionSlug={campaignData.edition_slug ?? null}
           campaignTypes={campaignTypes}
           allTerritories={allTerritories}
           existingCampaignTerritories={campaignData.territories.map(territory => ({

--- a/components/create-campaign.tsx
+++ b/components/create-campaign.tsx
@@ -84,6 +84,8 @@ export function CreateCampaignModal({ onClose, initialCampaignTypes, initialTrad
     [tradingPostTypes, editionSlug]
   );
 
+  const campaignRank = getCampaignRank(editionSlug);
+
   const isFormValid = campaignName.trim() !== "" && campaignType !== ""
 
   // Clear campaign type / trading posts that no longer belong to the active edition
@@ -249,7 +251,6 @@ export function CreateCampaignModal({ onClose, initialCampaignTypes, initialTrad
                 .sort((a, b) => {
                   const typeA = a.campaign_type_name.toLowerCase();
                   const typeB = b.campaign_type_name.toLowerCase();
-                  const campaignRank = getCampaignRank(editionSlug);
 
                   const rankA = campaignRank[typeA] ?? Infinity;
                   const rankB = campaignRank[typeB] ?? Infinity;

--- a/components/create-campaign.tsx
+++ b/components/create-campaign.tsx
@@ -9,7 +9,7 @@ import { toast } from 'sonner';
 import { useRouter, useSearchParams } from 'next/navigation'
 import { SubmitButton } from "./submit-button"
 import { tradingPostRank } from "@/utils/tradingPostRank"
-import { campaignRank } from '@/utils/campaigns/campaignRank'
+import { getCampaignRank } from '@/utils/campaigns/campaignRank'
 import { ImInfo } from "react-icons/im"
 import { Tooltip } from 'react-tooltip';
 import React from "react"
@@ -249,6 +249,7 @@ export function CreateCampaignModal({ onClose, initialCampaignTypes, initialTrad
                 .sort((a, b) => {
                   const typeA = a.campaign_type_name.toLowerCase();
                   const typeB = b.campaign_type_name.toLowerCase();
+                  const campaignRank = getCampaignRank(editionSlug);
 
                   const rankA = campaignRank[typeA] ?? Infinity;
                   const rankB = campaignRank[typeB] ?? Infinity;

--- a/utils/cache-tags.ts
+++ b/utils/cache-tags.ts
@@ -115,6 +115,7 @@ export const CACHE_TAGS = {
   GLOBAL_GANG_TYPES: () => `global-gang-types`,                       // gang type options
   GLOBAL_FIGHTER_TYPES: () => `global-fighter-types`,                 // fighter type options
   GLOBAL_TERRITORIES_LIST: () => `global-territories-list`,           // territory options
+  GLOBAL_CAMPAIGN_TYPES: () => `campaign-types`,                      // campaign type options
   GLOBAL_PATREON_SUPPORTERS: () => `global-patreon-supporters`,       // patreon supporters list
   GLOBAL_USER_COUNT: () => `global-user-count`,                       // total user count for homepage
   GLOBAL_GANG_COUNT: () => `global-gang-count`,                       // total gang count for homepage
@@ -366,6 +367,29 @@ export function invalidateCampaignTerritory(params: {
  */
 export function invalidateUserCustomizations() {
   revalidateTag(CACHE_TAGS.GLOBAL_TERRITORIES_LIST(), { expire: 0 });
+}
+
+/**
+ * Global campaign catalog lists (campaign types + territory templates).
+ * Call after admin edits, or to drop every unstable_cache entry that shares these tags
+ * (including older key names after a key rename).
+ */
+export function invalidateCampaignCatalogLists() {
+  revalidateTag(CACHE_TAGS.GLOBAL_CAMPAIGN_TYPES(), { expire: 0 });
+  revalidateTag(CACHE_TAGS.GLOBAL_TERRITORIES_LIST(), { expire: 0 });
+}
+
+let didPurgePreEditionCampaignCatalogCaches = false;
+
+/**
+ * One-shot per process: expire pre-rename catalog cache keys that still share
+ * GLOBAL_CAMPAIGN_TYPES / GLOBAL_TERRITORIES_LIST tags (e.g. `campaign-types`
+ * after the move to `campaign-types-with-edition`).
+ */
+export function purgePreEditionCampaignCatalogCachesOnce() {
+  if (didPurgePreEditionCampaignCatalogCaches) return;
+  didPurgePreEditionCampaignCatalogCaches = true;
+  invalidateCampaignCatalogLists();
 }
 
 /**

--- a/utils/campaigns/campaignRank.ts
+++ b/utils/campaigns/campaignRank.ts
@@ -1,13 +1,23 @@
-export const campaignRank: { [key: string]: number } = {
-  "custom": 0,
-  "dominion campaign": 1,
-  "law and misrule campaign": 2,
-  "uprising campaign": 3,
-  "outlander campaign": 4,
-  "ash wastes campaign": 5,
-  "succession campaign: part 1 - cinderak burning": 6,
-  "succession campaign: part 2 - road to temenos": 7,
-  "succession campaign: part 3 - fall of helmawr": 8,
-  "underhells campaign": 9,
-  "succession campaign: part 4 - reconquest of primus": 10,
+import type { EditionSlug } from '@/types/edition';
+import { campaignRankN23 } from '@/utils/campaigns/campaignRankN23';
+import { campaignRankN26 } from '@/utils/campaigns/campaignRankN26';
+
+/**
+ * Keyed by EditionSlug so a new edition is a compile error here until it states
+ * its own order, matching getAllianceRank / ALLIANCE_RANK_BY_EDITION.
+ */
+const CAMPAIGN_RANK_BY_EDITION: Record<EditionSlug, { [key: string]: number }> = {
+  n23: campaignRankN23,
+  n26: campaignRankN26,
 };
+
+/**
+ * Edition-scoped campaign-type sort order. An unset or unrecognised slug gets no
+ * ranking, so callers fall back rather than borrowing another edition's order.
+ */
+export function getCampaignRank(
+  editionSlug?: string | null
+): { [key: string]: number } {
+  if (!editionSlug) return {};
+  return CAMPAIGN_RANK_BY_EDITION[editionSlug as EditionSlug] ?? {};
+}

--- a/utils/campaigns/campaignRankN23.ts
+++ b/utils/campaigns/campaignRankN23.ts
@@ -1,0 +1,13 @@
+export const campaignRankN23: { [key: string]: number } = {
+  "custom": 0,
+  "dominion campaign": 1,
+  "law and misrule campaign": 2,
+  "uprising campaign": 3,
+  "outlander campaign": 4,
+  "ash wastes campaign": 5,
+  "succession campaign: part 1 - cinderak burning": 6,
+  "succession campaign: part 2 - road to temenos": 7,
+  "succession campaign: part 3 - fall of helmawr": 8,
+  "underhells campaign": 9,
+  "succession campaign: part 4 - reconquest of primus": 10,
+};

--- a/utils/campaigns/campaignRankN26.ts
+++ b/utils/campaigns/campaignRankN26.ts
@@ -1,0 +1,4 @@
+export const campaignRankN26: { [key: string]: number } = {
+  "custom": 0,
+  "core campaign": 1,
+};


### PR DESCRIPTION
Filter and rank campaign catalogs by edition, reject cross-edition territory adds, and align campaign ranking/cache invalidation with existing alliance and edition helpers.