### PR TITLE
Remove the N26 "Level Up" badge from the fighter cards

### DIFF
--- a/components/fighter/fighter-details-card.tsx
+++ b/components/fighter/fighter-details-card.tsx
@@ -9,7 +9,6 @@ import {
 } from '@/types/edition';
 import { memo } from 'react';
 import { calculateAdjustedStats } from '@/utils/effect-modifiers';
-import { countAdvancementsTaken, openAdvancementsFor } from '@/utils/advancementRanks';
 import { FighterProps, FighterEffect, Vehicle } from '@/types/fighter';
 import { TbMeatOff } from "react-icons/tb";
 import { GiHandcuffs, GiImprisoned } from "react-icons/gi";
@@ -373,15 +372,6 @@ export const FighterDetailsCard = memo(function FighterDetailsCard({
   // consistency rather than a live case — but the statline and its limits must agree either way.
   const showsVehicleProfile = isCrew && !isVehicle;
 
-  // Advancements earned but not yet taken. Zero in editions that do not rank by
-  // XP, so the badge is N26-only without an explicit edition check here.
-  const openAdvancements = openAdvancementsFor(
-    edition_slug,
-    starting_xp,
-    xp,
-    countAdvancementsTaken(effects, skills)
-  );
-
   const handleImageClick = () => {
     if (canShowEditButtons) {
       setIsImageModalOpen(true);
@@ -487,11 +477,6 @@ export const FighterDetailsCard = memo(function FighterDetailsCard({
             {starved && <TbMeatOff className="text-red-500" />}
             {recovery && <FaMedkit className="text-blue-500" />}
             {captured && <GiHandcuffs className="text-sky-300" />}
-            {openAdvancements > 0 && (
-              <span className="text-xs font-bold text-amber-500 whitespace-nowrap">
-                {openAdvancements} Level Up{openAdvancements === 1 ? '' : 's'}
-              </span>
-            )}
           </div>
 
           {/* Profile picture of the fighter */}

--- a/components/gang/fighter-card.tsx
+++ b/components/gang/fighter-card.tsx
@@ -6,7 +6,6 @@ import { Equipment } from '@/types/equipment';
 import { FighterProps, FighterEffect, Vehicle, VehicleEquipment, FighterSkills } from '@/types/fighter';
 import { hasSaveCharacteristic } from '@/types/edition';
 import { calculateAdjustedStats, applySpecialRulesModifiers } from '@/utils/effect-modifiers';
-import { countAdvancementsTaken, openAdvancementsFor } from '@/utils/advancementRanks';
 import { injuryAggregationLabel } from '@/utils/injuryTarget';
 import { TbMeatOff } from "react-icons/tb";
 import { GiHandcuffs, GiImprisoned } from "react-icons/gi";
@@ -456,15 +455,6 @@ const FighterCard = memo(function FighterCard({
 
   const isInactive = killed || retired || enslaved || recovery;
 
-  // Advancements earned but not yet taken. Zero in editions that do not rank by
-  // XP, so the badge is N26-only without an explicit edition check here.
-  const openAdvancements = openAdvancementsFor(
-    edition_slug,
-    starting_xp,
-    xp,
-    countAdvancementsTaken(effects, skills)
-  );
-
   // Determine a unique and valid id for the fighter card based on its status.
   // The combined state 'is_inactive_and_recovery' takes precedence over the individual states.
   const fighterCardId =
@@ -622,11 +612,6 @@ const FighterCard = memo(function FighterCard({
             {starved && <TbMeatOff className="text-red-500" />}
             {recovery && <FaMedkit className="text-blue-500" />}
             {captured && <GiHandcuffs className="text-sky-300" />}
-            {openAdvancements > 0 && (
-              <span className="text-xs font-bold text-amber-500 whitespace-nowrap">
-                {openAdvancements} Level Up{openAdvancements === 1 ? '' : 's'}
-              </span>
-            )}
           </div>
           {/* Render image if image_url is present, before credits box */}
           {image_url && (


### PR DESCRIPTION
The badge counts Advancements earned but not yet taken, and it is currently reporting numbers that were never earned. The migration that introduced fighters.starting_xp backfilled every pre-existing row to a flat 0, while fighters.xp kept the recruitment value already seeded from the fighter type. A Champion recruited on 13 XP therefore reads as "recruited on 0, now on 13" and the badge counts four rank tiers crossed for a fighter that has not played a game. 15 of the 16 affected N26 fighters carry starting_xp = 0.

Pulled from both places it renders: the fighter page's details card and the gang page's fighter cards. openAdvancements had no other use in either file, so the derivation and its import go with it.

utils/advancementRanks.ts is left alone. openAdvancementsFor still caps how many Advancements the add-advancement action will accept, so removing the display does not correct that path -- affected fighters can still claim Advancements they have not earned. That needs the data backfill, which is deliberately not part of this change.