### PR TITLE
Give N26 an Advancement picker in place of the static table

### DIFF
--- a/components/dice-roller.tsx
+++ b/components/dice-roller.tsx
@@ -99,8 +99,10 @@ export default function DiceRoller<T>({
   return (
     <>
       <div className="flex items-center gap-3">
+        {/* shrink-0 so a long inline result wraps rather than squeezing the
+            button until its own label breaks across lines. */}
         <button
-          className={`px-3 py-2 bg-neutral-900 text-white rounded-sm hover:bg-gray-800 disabled:opacity-50 ${className || ''}`}
+          className={`shrink-0 whitespace-nowrap px-3 py-2 bg-neutral-900 text-white rounded-sm hover:bg-gray-800 disabled:opacity-50 ${className || ''}`}
           onClick={performRoll}
           disabled={disabled || rolling}
           type="button"

--- a/components/dice-roller.tsx
+++ b/components/dice-roller.tsx
@@ -99,8 +99,7 @@ export default function DiceRoller<T>({
   return (
     <>
       <div className="flex items-center gap-3">
-        {/* shrink-0 so a long inline result wraps rather than squeezing the
-            button until its own label breaks across lines. */}
+        {/* shrink-0: a long inline result should wrap, not squeeze the button. */}
         <button
           className={`shrink-0 whitespace-nowrap px-3 py-2 bg-neutral-900 text-white rounded-sm hover:bg-gray-800 disabled:opacity-50 ${className || ''}`}
           onClick={performRoll}

--- a/components/fighter/fighter-advancement-list.tsx
+++ b/components/fighter/fighter-advancement-list.tsx
@@ -33,7 +33,8 @@ import {
   resolveGangerExoticBeastAdvancementFromUtil,
   N26_ADVANCEMENT_TABLE,
   resolveN26AdvancementFromUtil,
-  type TableEntry
+  type TableEntry,
+  type N26AdvancementEntry
 } from '@/utils/dice';
 import { hasCumulativeXp } from '@/types/edition';
 
@@ -422,10 +423,23 @@ const GANGER_ADVANCEMENT_COMBO_OPTIONS: GangerAdvancementComboRow[] = GANGER_EXO
   })
 );
 
-function formatGangerAdvancementRangeLabel(entry: TableEntry): string {
+/** Both advancement tables key their rows by a 2D6 range, so the label is shared. */
+function formatAdvancementRangeLabel(entry: { range: readonly [number, number] }): string {
   const [a, b] = entry.range;
   return a === b ? `${a}` : `${a}-${b}`;
 }
+
+/**
+ * The N26 Advancement table as picker rows. N26 applies one table to every
+ * subtype — there is no Ganger/Exotic Beast split — so every N26 fighter picks
+ * from these.
+ */
+type N26AdvancementComboRow = N26AdvancementEntry & { id: string };
+
+const N26_ADVANCEMENT_COMBO_OPTIONS: N26AdvancementComboRow[] = N26_ADVANCEMENT_TABLE.map((entry) => ({
+  ...entry,
+  id: `n26-adv-${entry.range[0]}-${entry.range[1]}`
+}));
 
 /**
  * One entry of the `characteristics` map returned by
@@ -498,6 +512,11 @@ export function AdvancementModal({
   const [gangerSelectedRowId, setGangerSelectedRowId] = useState('');
   const [gangerRollCooldown, setGangerRollCooldown] = useState(false);
   const [n26RollCooldown, setN26RollCooldown] = useState(false);
+  /** Selected row of the N26 Advancement table, and the characteristic chosen
+   *  within it. The row drives the ordinary characteristic/skill flow rather than
+   *  running a purchase path of its own. */
+  const [n26SelectedRowId, setN26SelectedRowId] = useState('');
+  const [n26CharacteristicName, setN26CharacteristicName] = useState('');
   const [characteristicAdvancements, setCharacteristicAdvancements] = useState<Record<string, CharacteristicAdvancement>>({});
   /** Whether the RPC has answered — distinct from it having returned rows, so an
    *  edition with no Advancements ends the spinner instead of hanging on it. */
@@ -506,6 +525,12 @@ export function AdvancementModal({
    *  the fetch can fail before an advancement type is picked — the characteristic
    *  UI surfaces it whenever it renders, and the Ganger roll UI ignores it. */
   const [characteristicsError, setCharacteristicsError] = useState<string | null>(null);
+
+  // N26 earns Advancements by rank and spends no XP, so every fighter rolls on
+  // one table and no XP price is ever paid. The N23 subtype-specific tables and
+  // escalating costs do not apply. Declared here because the picker, the catalog
+  // fetch and the cost fields all branch on it.
+  const isCumulativeXp = hasCumulativeXp(editionSlug);
 
   /**
    * The characteristic list is derived from the RPC's map, not fetched and stored:
@@ -732,11 +757,21 @@ export function AdvancementModal({
     [gangerSelectedRowId]
   );
 
+  const n26SelectedRow = useMemo(
+    () => N26_ADVANCEMENT_COMBO_OPTIONS.find((r) => r.id === n26SelectedRowId),
+    [n26SelectedRowId]
+  );
+
   const isGangerOrExoticBeastSubtype =
     fighterSubtypes.includes('Ganger') || fighterSubtypes.includes('Exotic Beast');
 
+  // The N23 Ganger roll-and-buy flow. Edition matters as much as subtype: N26 has
+  // no Ganger table and never renders its picker, so an N26 fighter that happens
+  // to carry a Ganger subtype would otherwise route Buy through a flow whose
+  // preconditions it can never satisfy, leaving the button permanently disabled.
   const gangerModalRollBuy =
     isGangerOrExoticBeastSubtype &&
+    !isCumulativeXp &&
     !!userPermissions &&
     !!onFighterDetailsUpdate;
 
@@ -770,8 +805,11 @@ export function AdvancementModal({
    * xp_cost and has_enough_xp, all of which move the moment an Advancement is
    * added.
    */
+  // N26 resolves a characteristic to its effect type id the moment a table
+  // result's radio is clicked, which happens before an advancement type is set —
+  // so the catalog has to be in hand from the moment the modal opens.
   const needsAdvancementCatalog =
-    isGangerOrExoticBeastSubtype || advancementType === 'characteristic';
+    isGangerOrExoticBeastSubtype || isCumulativeXp || advancementType === 'characteristic';
 
   useEffect(() => {
     if (!needsAdvancementCatalog || !fighterId) return;
@@ -1553,7 +1591,7 @@ export function AdvancementModal({
   const gangerAdvancementComboboxOptions = useMemo(
     () =>
       GANGER_ADVANCEMENT_COMBO_OPTIONS.flatMap((row) => {
-        const range = formatGangerAdvancementRangeLabel(row);
+        const range = formatAdvancementRangeLabel(row);
         const displayText = `${range}: ${row.name}`;
         return [
           {
@@ -1570,6 +1608,63 @@ export function AdvancementModal({
       }),
     []
   );
+
+  const n26AdvancementComboboxOptions = useMemo(
+    () =>
+      N26_ADVANCEMENT_COMBO_OPTIONS.map((row) => {
+        const range = formatAdvancementRangeLabel(row);
+        return {
+          value: row.id,
+          label: (
+            <>
+              <span className="text-muted-foreground inline-block w-14 text-center mr-1">{range}</span>
+              {row.name}
+            </>
+          ),
+          displayValue: `${range}: ${row.name}`
+        };
+      }),
+    []
+  );
+
+  /**
+   * Point the ordinary characteristic flow at one of the row's characteristics.
+   * The effect that watches selectedCategory then fills in costs from the RPC
+   * map, exactly as it does when a characteristic is picked directly.
+   */
+  const selectN26Characteristic = useCallback(
+    (name: string) => {
+      setN26CharacteristicName(name);
+      setAdvancementType('characteristic');
+      setSkillAcquisitionType('');
+      setSkillRollResult(null);
+      setSelectedAdvancement(null);
+      setSelectedCategory(characteristicAdvancements[name]?.id ?? '');
+    },
+    [characteristicAdvancements]
+  );
+
+  /** Hand the row's skill options to the ordinary skill flow. */
+  const selectN26SkillOutcome = useCallback(() => {
+    setN26CharacteristicName('');
+    setAdvancementType('skill');
+    setSelectedCategory('');
+    setSelectedAdvancement(null);
+    setSkillAcquisitionType('');
+    setSkillRollResult(null);
+    setAvailableAdvancements([]);
+  }, []);
+
+  const selectN26Row = useCallback((rowId: string) => {
+    setN26SelectedRowId(rowId);
+    setN26CharacteristicName('');
+    setAdvancementType('');
+    setSelectedCategory('');
+    setSelectedAdvancement(null);
+    setSkillAcquisitionType('');
+    setSkillRollResult(null);
+    setAvailableAdvancements([]);
+  }, []);
 
   const gangerSpecialistSkillSetComboboxOptions = useMemo(
     () =>
@@ -1762,15 +1857,28 @@ export function AdvancementModal({
     const allTypes = sample?.available_acquisition_types ?? [];
     if (allTypes.length === 0) return [];
     const allowedIds = new Set(getAllowedAcquisitionTypeIds(selectedSkillSetAccess, allTypes));
+    // An N26 result names the acquisition types it may award, so the row narrows
+    // the list further. Its credits are fixed per result and no XP is spent, so
+    // the N23 per-type prices are not shown.
+    const rowIds = n26SelectedRow?.skillAcquisitionTypeIds;
     return allTypes
       .filter((t) => allowedIds.has(t.type_id))
+      .filter((t) => !rowIds || rowIds.includes(t.type_id))
       .sort((a, b) => a.xp_cost - b.xp_cost)
-      .map((t) => ({
-        value: t.type_id,
-        label: `${t.name} (${t.xp_cost} XP, ${t.credit_cost} credits)`,
-        displayValue: `${t.name} (${t.xp_cost} XP, ${t.credit_cost} credits)`
-      }));
-  }, [advancementType, selectedCategory, availableAdvancements, selectedSkillSetAccess]);
+      .map((t) => {
+        const label = isCumulativeXp
+          ? t.name
+          : `${t.name} (${t.xp_cost} XP, ${t.credit_cost} credits)`;
+        return { value: t.type_id, label, displayValue: label };
+      });
+  }, [
+    advancementType,
+    selectedCategory,
+    availableAdvancements,
+    selectedSkillSetAccess,
+    n26SelectedRow,
+    isCumulativeXp
+  ]);
 
   /** Skill combobox options for the selected Skill Set; already-owned skills are disabled. */
   const skillComboboxOptions = useMemo(() => {
@@ -1801,6 +1909,13 @@ export function AdvancementModal({
       const sample = availableAdvancements.find(
         (a) => a.available_acquisition_types && a.available_acquisition_types.length > 0
       );
+      // N26 spends no XP and prices a skill by the table result rather than by
+      // acquisition type, so the per-type N23 costs do not apply.
+      if (isCumulativeXp) {
+        setEditableXpCost(0);
+        setEditableCreditsIncrease(n26SelectedRow?.credits ?? 0);
+        return;
+      }
       const matched = sample?.available_acquisition_types?.find((t) => t.type_id === typeId);
       if (matched) {
         setEditableXpCost(matched.xp_cost);
@@ -1810,7 +1925,7 @@ export function AdvancementModal({
         setEditableCreditsIncrease(0);
       }
     },
-    [availableAdvancements]
+    [availableAdvancements, isCumulativeXp, n26SelectedRow]
   );
 
   // Fetch skill sets. Characteristics need no fetch here — they are derived from
@@ -2059,11 +2174,6 @@ export function AdvancementModal({
   const isGangerOrExoticBeastRestricted =
     fighterSubtypes.includes('Ganger') || fighterSubtypes.includes('Exotic Beast');
 
-  // N26 earns Advancements by rank and spends no XP, so every fighter rolls on
-  // one table and no XP price is ever paid. The N23 subtype-specific tables and
-  // escalating costs do not apply.
-  const isCumulativeXp = hasCumulativeXp(editionSlug);
-
   const handleAdvancementPurchase = async () => {
     if (gangerModalRollBuy) {
       setGangerPurchaseBusy(true);
@@ -2206,7 +2316,7 @@ export function AdvancementModal({
           <div className="mb-4">
             <p className="text-sm text-muted-foreground mb-2">
               {isCumulativeXp
-                ? 'Advancements are earned by rank and cost no XP. Roll 2D6, then take any result you rolled high enough for.'
+                ? 'Rating increase is automatically calculated based on the type and number of advancements. The roll is recorded in your gang log. You can select or adjust the outcome below, whether using this roll or applying your own.'
                 : 'XP cost and rating increase are automatically calculated based on the type and number of advancements.'}
             </p>
           </div>
@@ -2225,7 +2335,15 @@ export function AdvancementModal({
                     if (rolled.length > 0) {
                       const { roll: total, dice } = rolled[0];
                       const row = resolveN26AdvancementFromUtil(total);
-                      if (row) logN26RollWithCooldown(row.name, total, dice);
+                      if (row) {
+                        // Preselect what was rolled; the player may still pick a
+                        // lower result, which the table explicitly allows.
+                        const combo = N26_ADVANCEMENT_COMBO_OPTIONS.find(
+                          (o) => o.range[0] === row.range[0] && o.range[1] === row.range[1]
+                        );
+                        if (combo) selectN26Row(combo.id);
+                        logN26RollWithCooldown(row.name, total, dice);
+                      }
                     }
                   }}
                   onRoll={(total, dice) => {
@@ -2237,24 +2355,65 @@ export function AdvancementModal({
                 />
               </div>
 
-              <div className="space-y-1 pt-2 border-t">
-                <p className="text-sm font-medium">Advancement table</p>
-                <p className="text-xs text-muted-foreground">
-                  The roll is recorded in your gang log. Choose the result below — you may take any result you
-                  rolled high enough for.
-                </p>
-                <ul className="text-xs text-muted-foreground pt-1 space-y-0.5">
-                  {N26_ADVANCEMENT_TABLE.map((row) => (
-                    <li key={`${row.range[0]}-${row.range[1]}`} className="flex gap-2">
-                      <span className="font-mono w-10 shrink-0">
-                        {row.range[0] === row.range[1] ? row.range[0] : `${row.range[0]}-${row.range[1]}`}
-                      </span>
-                      <span className="grow">{row.name}</span>
-                      <span className="shrink-0">+{row.credits}</span>
-                    </li>
-                  ))}
-                </ul>
+              <div className="space-y-2 pt-2 border-t">
+                <label className="text-sm font-medium">Advancements</label>
+                <Combobox
+                  value={n26SelectedRowId}
+                  onValueChange={selectN26Row}
+                  placeholder="Select an Advancement"
+                  options={n26AdvancementComboboxOptions}
+                  dropdownPlacement="down"
+                />
               </div>
+
+              {/* A result may offer characteristics, skills or both, so each kind
+                  gets its own section and choosing in one clears the other. */}
+              {n26SelectedRow?.characteristics?.length ? (
+                <div className="space-y-3 border-t pt-3">
+                  <p className="text-sm font-medium">Choose a characteristic</p>
+                  <div className="flex flex-col gap-2">
+                    {n26SelectedRow.characteristics.map((name) => (
+                      <label key={name} className="flex items-center gap-2 text-sm cursor-pointer">
+                        <input
+                          type="radio"
+                          name="n26-characteristic"
+                          checked={n26CharacteristicName === name}
+                          onChange={() => selectN26Characteristic(name)}
+                          disabled={!characteristicsLoaded || !characteristicAdvancements[name]}
+                        />
+                        {name}
+                      </label>
+                    ))}
+                  </div>
+                  {n26CharacteristicName && characteristicAdvancements[n26CharacteristicName] && (
+                    <p className="text-xs text-muted-foreground">
+                      Times increased on this characteristic:{' '}
+                      {characteristicAdvancements[n26CharacteristicName].times_increased ?? 0}
+                    </p>
+                  )}
+                </div>
+              ) : null}
+
+              {n26SelectedRow?.skillAcquisitionTypeIds?.length ? (
+                <div className="space-y-3 border-t pt-3">
+                  <p className="text-sm font-medium">Choose a skill</p>
+                  {advancementType !== 'skill' ? (
+                    <Button
+                      type="button"
+                      variant="default"
+                      className="w-full sm:w-auto"
+                      onClick={selectN26SkillOutcome}
+                      disabled={!userPermissions.canEdit}
+                    >
+                      Take a skill instead
+                    </Button>
+                  ) : (
+                    <p className="text-xs text-muted-foreground">
+                      Pick a Skill Set below, then the skill this result awards.
+                    </p>
+                  )}
+                </div>
+              ) : null}
             </div>
           )}
 
@@ -2469,7 +2628,11 @@ export function AdvancementModal({
           <div className="space-y-4">
           {(!isGangerOrExoticBeastRestricted || isCumulativeXp) && (
             <>
-            <div className="relative">
+            {/* N26 picks a table result first, which sets the advancement type
+                itself, so the free-choice type picker would be a second, untied
+                route to the same purchase. N23 Gangers are hidden from it for the
+                same reason. */}
+            <div className={isCumulativeXp ? 'hidden' : 'relative'}>
               <Combobox
                 value={advancementType}
                 onValueChange={(v) => {
@@ -2613,7 +2776,10 @@ export function AdvancementModal({
               </div>
             )}
 
-            {advancementType === 'characteristic' && !loading && (
+            {/* On N26 the characteristic comes from the chosen table result's
+                radios, so this free-choice list is N23-only. The skill flow below
+                is shared: an N26 result hands off to it. */}
+            {advancementType === 'characteristic' && !loading && !isCumulativeXp && (
               <div className="relative">
                 <Combobox
                   value={selectedCategory}

--- a/components/fighter/fighter-advancement-list.tsx
+++ b/components/fighter/fighter-advancement-list.tsx
@@ -2405,7 +2405,9 @@ export function AdvancementModal({
                       onClick={selectN26SkillOutcome}
                       disabled={!userPermissions.canEdit}
                     >
-                      Take a skill instead
+                      {/* Only roll 2 offers characteristics as well, so only
+                          there is a skill taken "instead" of something. */}
+                      {n26SelectedRow.characteristics?.length ? 'Take a skill instead' : 'Take a skill'}
                     </Button>
                   ) : (
                     <p className="text-xs text-muted-foreground">

--- a/components/fighter/fighter-advancement-list.tsx
+++ b/components/fighter/fighter-advancement-list.tsx
@@ -2367,12 +2367,6 @@ export function AdvancementModal({
                       </label>
                     ))}
                   </div>
-                  {n26CharacteristicName && characteristicAdvancements[n26CharacteristicName] && (
-                    <p className="text-xs text-muted-foreground">
-                      Times increased on this characteristic:{' '}
-                      {characteristicAdvancements[n26CharacteristicName].times_increased ?? 0}
-                    </p>
-                  )}
                 </div>
               ) : null}
 

--- a/components/fighter/fighter-advancement-list.tsx
+++ b/components/fighter/fighter-advancement-list.tsx
@@ -423,17 +423,13 @@ const GANGER_ADVANCEMENT_COMBO_OPTIONS: GangerAdvancementComboRow[] = GANGER_EXO
   })
 );
 
-/** Both advancement tables key their rows by a 2D6 range, so the label is shared. */
 function formatAdvancementRangeLabel(entry: { range: readonly [number, number] }): string {
   const [a, b] = entry.range;
   return a === b ? `${a}` : `${a}-${b}`;
 }
 
-/**
- * The N26 Advancement table as picker rows. N26 applies one table to every
- * subtype — there is no Ganger/Exotic Beast split — so every N26 fighter picks
- * from these.
- */
+/** N26 applies one table to every subtype — no Ganger/Exotic Beast split — so
+ *  every N26 fighter picks from these. */
 type N26AdvancementComboRow = N26AdvancementEntry & { id: string };
 
 const N26_ADVANCEMENT_COMBO_OPTIONS: N26AdvancementComboRow[] = N26_ADVANCEMENT_TABLE.map((entry) => ({
@@ -512,9 +508,7 @@ export function AdvancementModal({
   const [gangerSelectedRowId, setGangerSelectedRowId] = useState('');
   const [gangerRollCooldown, setGangerRollCooldown] = useState(false);
   const [n26RollCooldown, setN26RollCooldown] = useState(false);
-  /** Selected row of the N26 Advancement table, and the characteristic chosen
-   *  within it. The row drives the ordinary characteristic/skill flow rather than
-   *  running a purchase path of its own. */
+  /** The chosen N26 result drives the ordinary flow; it has no purchase path. */
   const [n26SelectedRowId, setN26SelectedRowId] = useState('');
   const [n26CharacteristicName, setN26CharacteristicName] = useState('');
   const [characteristicAdvancements, setCharacteristicAdvancements] = useState<Record<string, CharacteristicAdvancement>>({});
@@ -528,8 +522,7 @@ export function AdvancementModal({
 
   // N26 earns Advancements by rank and spends no XP, so every fighter rolls on
   // one table and no XP price is ever paid. The N23 subtype-specific tables and
-  // escalating costs do not apply. Declared here because the picker, the catalog
-  // fetch and the cost fields all branch on it.
+  // escalating costs do not apply.
   const isCumulativeXp = hasCumulativeXp(editionSlug);
 
   /**
@@ -765,10 +758,8 @@ export function AdvancementModal({
   const isGangerOrExoticBeastSubtype =
     fighterSubtypes.includes('Ganger') || fighterSubtypes.includes('Exotic Beast');
 
-  // The N23 Ganger roll-and-buy flow. Edition matters as much as subtype: N26 has
-  // no Ganger table and never renders its picker, so an N26 fighter that happens
-  // to carry a Ganger subtype would otherwise route Buy through a flow whose
-  // preconditions it can never satisfy, leaving the button permanently disabled.
+  // Edition matters as much as subtype: N26 never renders the Ganger picker, so a
+  // Ganger-subtyped N26 fighter would route Buy through a flow it can never satisfy.
   const gangerModalRollBuy =
     isGangerOrExoticBeastSubtype &&
     !isCumulativeXp &&
@@ -805,9 +796,8 @@ export function AdvancementModal({
    * xp_cost and has_enough_xp, all of which move the moment an Advancement is
    * added.
    */
-  // N26 resolves a characteristic to its effect type id the moment a table
-  // result's radio is clicked, which happens before an advancement type is set —
-  // so the catalog has to be in hand from the moment the modal opens.
+  // N26 resolves a characteristic to its effect type id when a result's radio is
+  // clicked, which happens before an advancement type is set — so it loads on open.
   const needsAdvancementCatalog =
     isGangerOrExoticBeastSubtype || isCumulativeXp || advancementType === 'characteristic';
 
@@ -1627,11 +1617,7 @@ export function AdvancementModal({
     []
   );
 
-  /**
-   * Point the ordinary characteristic flow at one of the row's characteristics.
-   * The effect that watches selectedCategory then fills in costs from the RPC
-   * map, exactly as it does when a characteristic is picked directly.
-   */
+  /** The effect watching selectedCategory fills in costs from the RPC map. */
   const selectN26Characteristic = useCallback(
     (name: string) => {
       setN26CharacteristicName(name);
@@ -1644,7 +1630,6 @@ export function AdvancementModal({
     [characteristicAdvancements]
   );
 
-  /** Hand the row's skill options to the ordinary skill flow. */
   const selectN26SkillOutcome = useCallback(() => {
     setN26CharacteristicName('');
     setAdvancementType('skill');
@@ -1656,9 +1641,12 @@ export function AdvancementModal({
   }, []);
 
   const selectN26Row = useCallback((rowId: string) => {
+    const row = N26_ADVANCEMENT_COMBO_OPTIONS.find((r) => r.id === rowId);
+    // Nothing to disambiguate on a skill-only result, so skip the confirm step.
+    const skillOnly = !!row?.skillAcquisitionTypeIds?.length && !row?.characteristics?.length;
     setN26SelectedRowId(rowId);
     setN26CharacteristicName('');
-    setAdvancementType('');
+    setAdvancementType(skillOnly ? 'skill' : '');
     setSelectedCategory('');
     setSelectedAdvancement(null);
     setSkillAcquisitionType('');
@@ -1858,8 +1846,7 @@ export function AdvancementModal({
     if (allTypes.length === 0) return [];
     const allowedIds = new Set(getAllowedAcquisitionTypeIds(selectedSkillSetAccess, allTypes));
     // An N26 result names the acquisition types it may award, so the row narrows
-    // the list further. Its credits are fixed per result and no XP is spent, so
-    // the N23 per-type prices are not shown.
+    // the list; it prices them itself, so the N23 per-type prices are hidden.
     const rowIds = n26SelectedRow?.skillAcquisitionTypeIds;
     return allTypes
       .filter((t) => allowedIds.has(t.type_id))
@@ -1909,8 +1896,6 @@ export function AdvancementModal({
       const sample = availableAdvancements.find(
         (a) => a.available_acquisition_types && a.available_acquisition_types.length > 0
       );
-      // N26 spends no XP and prices a skill by the table result rather than by
-      // acquisition type, so the per-type N23 costs do not apply.
       if (isCumulativeXp) {
         setEditableXpCost(0);
         setEditableCreditsIncrease(n26SelectedRow?.credits ?? 0);
@@ -2336,8 +2321,7 @@ export function AdvancementModal({
                       const { roll: total, dice } = rolled[0];
                       const row = resolveN26AdvancementFromUtil(total);
                       if (row) {
-                        // Preselect what was rolled; the player may still pick a
-                        // lower result, which the table explicitly allows.
+                        // Preselect the roll; picking a lower result stays allowed.
                         const combo = N26_ADVANCEMENT_COMBO_OPTIONS.find(
                           (o) => o.range[0] === row.range[0] && o.range[1] === row.range[1]
                         );
@@ -2366,8 +2350,6 @@ export function AdvancementModal({
                 />
               </div>
 
-              {/* A result may offer characteristics, skills or both, so each kind
-                  gets its own section and choosing in one clears the other. */}
               {n26SelectedRow?.characteristics?.length ? (
                 <div className="space-y-3 border-t pt-3">
                   <p className="text-sm font-medium">Choose a characteristic</p>
@@ -2405,9 +2387,7 @@ export function AdvancementModal({
                       onClick={selectN26SkillOutcome}
                       disabled={!userPermissions.canEdit}
                     >
-                      {/* Only roll 2 offers characteristics as well, so only
-                          there is a skill taken "instead" of something. */}
-                      {n26SelectedRow.characteristics?.length ? 'Take a skill instead' : 'Take a skill'}
+                      Take a skill instead
                     </Button>
                   ) : (
                     <p className="text-xs text-muted-foreground">
@@ -2630,10 +2610,9 @@ export function AdvancementModal({
           <div className="space-y-4">
           {(!isGangerOrExoticBeastRestricted || isCumulativeXp) && (
             <>
-            {/* N26 picks a table result first, which sets the advancement type
-                itself, so the free-choice type picker would be a second, untied
-                route to the same purchase. N23 Gangers are hidden from it for the
-                same reason. */}
+            {/* The N26 result sets the advancement type itself, so this free-choice
+                picker would be a second route to the same purchase, untied to the
+                table. N23 Gangers are hidden from it for the same reason. */}
             <div className={isCumulativeXp ? 'hidden' : 'relative'}>
               <Combobox
                 value={advancementType}
@@ -2778,9 +2757,6 @@ export function AdvancementModal({
               </div>
             )}
 
-            {/* On N26 the characteristic comes from the chosen table result's
-                radios, so this free-choice list is N23-only. The skill flow below
-                is shared: an N26 result hands off to it. */}
             {advancementType === 'characteristic' && !loading && !isCumulativeXp && (
               <div className="relative">
                 <Combobox


### PR DESCRIPTION
The N26 branch of the modal offered a Roll 2D6 button and a read-only list of the nine 2-12 results, with nothing to select an outcome with. N23 has that selector but gates it to Ganger / Exotic Beast subtypes, and N26 applies one table to every subtype, so no equivalent was ever built. A player rolled, read a list, and was left with the free-choice Characteristic/Skill pickers, which are tied to nothing.

N26AdvancementEntry already carried what a picker needs -- characteristics[] and skillAcquisitionTypeIds[], the latter documented as "the ids get_available_skills returns, so a skill result feeds the existing skill picker directly". Only the UI was missing.

The row picker drives the ordinary flow rather than repeating the Ganger purchase path. Choosing a characteristic points advancementType and selectedCategory at it, and the effect already watching those fills in costs from the RPC map and feeds the existing Buy button; choosing a skill hands off to the existing skill set / acquisition type / skill flow with the acquisition types narrowed to the ones that result awards. No new mutation, no second buy path.

A result may offer characteristics, skills or both -- rolling a 2 offers +1 Leadership, +1 Intelligence or a random Primary skill -- so each kind gets its own section and choosing in one clears the other. Rolls 5, 7-8 and 12 are skills only; 11 offers three characteristics rather than the pair N23's table is limited to, which is why the Ganger row shape could not simply be reused.

The free-choice type and characteristic pickers are hidden on N26 for the same reason N23 Gangers never see them: the table result decides the type, so a second untied route to the same purchase is a way to get it wrong.

Two fixes fall out of this. gangerModalRollBuy was edition-blind, so an N26 fighter carrying a Ganger subtype routed Buy through the N23 flow and could never satisfy its preconditions -- the button was permanently disabled. And the catalog fetch was gated on the advancement type being 'characteristic', which on N26 is set by clicking a radio that needs the catalog already loaded to resolve its effect type id.

Skill results are priced by the result, not the acquisition type, and cost no XP, so the N23 per-type prices are neither applied nor shown on N26.