### PR TITLE
Fix duplicate skills in admin fighter type default skill dropdown

### DIFF
--- a/components/admin/admin-edit-fighter-type.tsx
+++ b/components/admin/admin-edit-fighter-type.tsx
@@ -546,10 +546,18 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
         );
 
         if (missingSkills.length > 0) {
-          setSkills(prevSkills => [...prevSkills, ...missingSkills]);
-          // Mark these skills as fetched
-          missingSkillIds.forEach(id => fetchedSkillDetailsRef.current.add(id));
+          // Key by id: skills accumulate across every fighter type opened in
+          // this modal, so appending blindly repeats a skill once per fighter
+          // type that carries it as a default.
+          setSkills(previous => {
+            const merged = new Map([...previous, ...missingSkills].map(skill => [skill.id, skill]));
+            return Array.from(merged.values());
+          });
         }
+
+        // Mark these skills as fetched even when the lookup returned nothing
+        // for them, so it is not retried on every selection change.
+        missingSkillIds.forEach(id => fetchedSkillDetailsRef.current.add(id));
       } catch (error) {
         console.error('Error fetching selected skill details:', error);
       }

--- a/components/admin/admin-edit-fighter-type.tsx
+++ b/components/admin/admin-edit-fighter-type.tsx
@@ -52,6 +52,17 @@ interface Skill {
   skill_type_id: string;
 }
 
+/**
+ * Folds newly fetched skills into the ones already held, keyed by id. The
+ * skills list accumulates across every fighter type opened in the modal, so
+ * appending blindly repeats a skill once per fighter type that carries it as a
+ * default. Later entries win, keeping the freshest copy of a skill's metadata.
+ */
+function mergeSkillsById(previous: Skill[], incoming: Skill[]): Skill[] {
+  const merged = new Map([...previous, ...incoming].map(skill => [skill.id, skill]));
+  return Array.from(merged.values());
+}
+
 interface Specialisation {
   id: string;
   specialisation_name: string;
@@ -509,10 +520,7 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
         const skillsArray = Array.isArray(data) ? data : data.skills || [];
         // Preserve metadata for saved selections while the fighter record is
         // loading so their chips can still be rendered.
-        setSkills(previous => {
-          const merged = new Map([...previous, ...skillsArray].map(skill => [skill.id, skill]));
-          return Array.from(merged.values());
-        });
+        setSkills(previous => mergeSkillsById(previous, skillsArray));
       } catch (error) {
         console.error('Error fetching skills:', error);
         toast.error('Failed to load skills');
@@ -546,13 +554,7 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
         );
 
         if (missingSkills.length > 0) {
-          // Key by id: skills accumulate across every fighter type opened in
-          // this modal, so appending blindly repeats a skill once per fighter
-          // type that carries it as a default.
-          setSkills(previous => {
-            const merged = new Map([...previous, ...missingSkills].map(skill => [skill.id, skill]));
-            return Array.from(merged.values());
-          });
+          setSkills(previous => mergeSkillsById(previous, missingSkills));
         }
 
         // Mark these skills as fetched even when the lookup returned nothing


### PR DESCRIPTION
The edit-fighter-type modal keeps one `skills` state list that is never reset while the modal is open, but `fetchedSkillDetailsRef` is cleared every time a fighter type is loaded. The effect that back-fills details for a fighter type's saved default skills then appended its results without keying by id, so each fighter type opened re-appended the skills it shares with earlier ones. Opening three n26 leaders in a row left three "Inspiring" options in the default skill dropdown, even though only one such skill row exists.

Merge by id the same way the skill-set fetch already does, and mark ids as fetched even when the lookup returns nothing for them so it is not retried on every selection change.