### PR TITLE
Hide Sell to Guilders on N26 fighter pages

### DIFF
--- a/components/fighter/fighter-actions.tsx
+++ b/components/fighter/fighter-actions.tsx
@@ -15,7 +15,7 @@ import { Tooltip } from 'react-tooltip';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Combobox } from '@/components/ui/combobox';
 import { buildGangComboboxOption } from '@/utils/gang-combobox-option';
-import { beastSubtypeName } from '@/types/edition';
+import { beastSubtypeName, hasGuilderSales } from '@/types/edition';
 
 interface Fighter {
   id: string;
@@ -34,7 +34,6 @@ interface Fighter {
   is_spyrer?: boolean;
   fighter_subtypes?: string[];
   owner_name?: string;
-  edition_slug?: string | null;
   campaigns?: Array<{
     campaign_id: string;
     resources?: Array<{ resource_name: string }>;
@@ -57,6 +56,7 @@ interface FighterActionsProps {
   fighter: Fighter;
   gang: Gang;
   fighterId: string;
+  editionSlug: string | null;
   userPermissions: UserPermissions;
   onFighterUpdate?: () => void;
   onStatusMutate?: (optimistic: Partial<Fighter>, gangCreditsDelta?: number, action?: 'kill' | 'retire' | 'sell' | 'release' | 'rescue' | 'starve' | 'recover' | 'capture' | 'delete') => any;
@@ -76,9 +76,10 @@ interface ActionModals {
 }
 
 export function FighterActions({ 
-  fighter, 
-  gang, 
-  fighterId, 
+  fighter,
+  gang,
+  fighterId,
+  editionSlug,
   userPermissions,
   onFighterUpdate,
   onStatusMutate,
@@ -169,7 +170,9 @@ export function FighterActions({
     ) ?? false;
   }, [fighter.campaigns]);
 
-  const beastNoun = beastSubtypeName(fighter?.edition_slug);
+  const beastNoun = beastSubtypeName(editionSlug);
+  // Selling a fighter to the Guilders is an N23 rule; N26 has no Guilders.
+  const showGuilderSale = hasGuilderSales(editionSlug);
   const isOwnedExoticBeast = fighter?.fighter_subtypes?.some(c => c.toLowerCase().startsWith('exotic beast') || c.toLowerCase() === 'pet') && !!fighter?.owner_name;
 
   // Calculate total vehicle equipment cost
@@ -306,15 +309,17 @@ export function FighterActions({
           >
             {fighter?.retired ? 'Unretire Fighter' : 'Retire Fighter'}
           </Button>
-          <Button
-            variant={fighter?.enslaved ? 'success' : 'default'}
-            className="flex-1"
-            onClick={() => handleModalToggle('enslave', true)}
-            disabled={!userPermissions.canEdit || isStatusIncompatible(fighter, 'enslave')}
-            title={isStatusIncompatible(fighter, 'enslave') ? 'Cannot sell to guilders: fighter is killed, retired, captured, or in recovery' : undefined}
-          >
-            {fighter?.enslaved ? 'Release from Guilders' : 'Sell to Guilders'}
-          </Button>
+          {showGuilderSale && (
+            <Button
+              variant={fighter?.enslaved ? 'success' : 'default'}
+              className="flex-1"
+              onClick={() => handleModalToggle('enslave', true)}
+              disabled={!userPermissions.canEdit || isStatusIncompatible(fighter, 'enslave')}
+              title={isStatusIncompatible(fighter, 'enslave') ? 'Cannot sell to guilders: fighter is killed, retired, captured, or in recovery' : undefined}
+            >
+              {fighter?.enslaved ? 'Release from Guilders' : 'Sell to Guilders'}
+            </Button>
+          )}
           {isMeatEnabled() && (
             <Button
               variant={fighter?.starved ? 'success' : 'default'}

--- a/components/fighter/fighter-page.tsx
+++ b/components/fighter/fighter-page.tsx
@@ -1238,7 +1238,6 @@ export default function FighterPage({
               is_spyrer: fighterData.fighter.is_spyrer,
               // Both feed the owned-beast delete guard.
               fighter_subtypes: fighterData.fighter?.fighter_subtypes,
-              edition_slug: fighterData.fighter?.edition_slug,
               owner_name: fighterData.fighter?.owner_name,
               campaigns: fighterData.fighter?.campaigns,
               vehicles: fighterData.fighter?.vehicles?.map(v => ({
@@ -1252,6 +1251,7 @@ export default function FighterPage({
             }}
             gang={{ id: fighterData.gang?.id || '', gang_name: fighterData.gang?.gang_affiliation_name || '', credits: fighterData.gang?.credits }}
             fighterId={fighterId}
+            editionSlug={editionSlug}
             userPermissions={userPermissions}
             onFighterUpdate={() => {}}
             onStatusMutate={(optimistic, gangCreditsDelta, action) => {

--- a/types/edition.ts
+++ b/types/edition.ts
@@ -146,6 +146,8 @@ const EDITION_CAPABILITIES = {
   masterCraftedWeapons:     { n23: true,  n26: false },
   /** Gang / fighter-type Law Abiding vs Outlaw alignment */
   alignment:                { n23: true,  n26: false },
+  /** Fighters can be sold to the Guilders (the enslaved status) */
+  sellToGuilders:           { n23: true,  n26: false },
   /**
    * Gang additions are picked by category (Brutes, Hangers-on, Pets, Hired
    * Guns, then one entry per alliance) rather than by raw fighter subtype.
@@ -247,6 +249,9 @@ export const hasMasterCraftedWeapons = (editionSlug?: string | null): boolean =>
 
 export const hasAlignment = (editionSlug?: string | null): boolean =>
   can('alignment', editionSlug);
+
+export const hasGuilderSales = (editionSlug?: string | null): boolean =>
+  can('sellToGuilders', editionSlug);
 
 export const hasGangAdditionCategories = (
   editionSlug?: string | null


### PR DESCRIPTION
Selling a fighter to the Guilders is an N23 rule with no N26 equivalent, but the fighter page rendered the button for every fighter.

Add a sellToGuilders row to EDITION_CAPABILITIES with a hasGuilderSales accessor, and gate the button on it.

FighterActions was the only child of the fighter page that did not receive editionSlug; it read the fighter-only slug smuggled through the fighter prop object. Pass the page's combined slug (gang first, fighter as fallback) as an explicit editionSlug prop, matching every sibling. This also gives beastSubtypeName the better-resolved gang slug.


Claude-Session: https://claude.ai/code/session_01U2dzpAy6EAvHZ6aFAD7Hze