### PR TITLE
Group multi-subtype fighter variants under one catalog entry

### DIFF
--- a/app/api/fighter-types/route.ts
+++ b/app/api/fighter-types/route.ts
@@ -103,6 +103,10 @@ const containsAllSubtypes = (subtypes: string[], base: string[]) => {
   return base.every(name => have.has(name.toLowerCase().trim()));
 };
 
+// include_all_types returns every edition at once and is only narrowed to the gang's own
+// edition on the client, so the edition is part of the bucket: a family never spans two.
+const familyBucket = (row: any) => `${row.edition_slug ?? ''}::${row.fighter_type}`;
+
 /**
  * Tags each row with its variant family — same fighter_type, and one row's subtype set
  * containing the other's — named after the family's smallest (base) set. N26 variants can
@@ -111,16 +115,16 @@ const containsAllSubtypes = (subtypes: string[], base: string[]) => {
  * "Gunner (Ganger)" and "Gunner (Specialist)" keep their own entries.
  */
 function withVariantGroups(rows: any[]) {
-  const byFighterType = new Map<string, any[]>();
+  const byBucket = new Map<string, any[]>();
   for (const row of rows) {
-    const group = byFighterType.get(row.fighter_type);
+    const group = byBucket.get(familyBucket(row));
     if (group) group.push(row);
-    else byFighterType.set(row.fighter_type, [row]);
+    else byBucket.set(familyBucket(row), [row]);
   }
 
   const baseOfSet = new Map<string, { key: string; names: string[] }>();
 
-  for (const [fighterType, group] of byFighterType) {
+  for (const [bucket, group] of byBucket) {
     const sets = new Map<string, string[]>();
     for (const row of group) {
       if (!sets.has(subtypeKey(row))) sets.set(subtypeKey(row), row.fighter_subtypes ?? []);
@@ -136,19 +140,19 @@ function withVariantGroups(rows: any[]) {
         .filter(candidate => containsAllSubtypes(names, candidate.names))
         .sort((a, b) => b.names.length - a.names.length)[0];
       if (!base) bases.push({ key, names });
-      baseOfSet.set(`${fighterType}::${key}`, base ?? { key, names });
+      baseOfSet.set(`${bucket}::${key}`, base ?? { key, names });
     }
   }
 
   return rows.map(row => {
-    const base = baseOfSet.get(`${row.fighter_type}::${subtypeKey(row)}`)!;
+    const base = baseOfSet.get(`${familyBucket(row)}::${subtypeKey(row)}`)!;
     const inBase = new Set(base.names.map(name => name.toLowerCase().trim()));
     const added = ((row.fighter_subtypes ?? []) as string[]).filter(
       name => !inBase.has(name.toLowerCase().trim())
     );
     return {
       ...row,
-      typeSubtypeKey: `${row.fighter_type}::${base.key}`,
+      typeSubtypeKey: `${familyBucket(row)}::${base.key}`,
       variantLabel: row.specialisation?.specialisation_name || added.join(', ') || 'Default',
     };
   });

--- a/app/api/fighter-types/route.ts
+++ b/app/api/fighter-types/route.ts
@@ -95,6 +95,65 @@ function transformCustomFighter(cf: any) {
   };
 }
 
+const subtypeKey = (row: any) =>
+  ((row.fighter_subtypes ?? []) as string[]).map(s => s.toLowerCase().trim()).sort().join(',');
+
+const containsAllSubtypes = (subtypes: string[], base: string[]) => {
+  const have = new Set(subtypes.map(s => s.toLowerCase().trim()));
+  return base.every(name => have.has(name.toLowerCase().trim()));
+};
+
+/**
+ * Tags each row with its variant family — same fighter_type, and one row's subtype set
+ * containing the other's — named after the family's smallest (base) set. N26 variants can
+ * add a subtype, "Master of Shadow (Leader)" next to "(Leader, Wyrd)", which an exact
+ * subtype match lists as unrelated fighters. Disjoint sets stay apart, so N23's
+ * "Gunner (Ganger)" and "Gunner (Specialist)" keep their own entries.
+ */
+function withVariantGroups(rows: any[]) {
+  const byFighterType = new Map<string, any[]>();
+  for (const row of rows) {
+    const group = byFighterType.get(row.fighter_type);
+    if (group) group.push(row);
+    else byFighterType.set(row.fighter_type, [row]);
+  }
+
+  const baseOfSet = new Map<string, { key: string; names: string[] }>();
+
+  for (const [fighterType, group] of byFighterType) {
+    const sets = new Map<string, string[]>();
+    for (const row of group) {
+      if (!sets.has(subtypeKey(row))) sets.set(subtypeKey(row), row.fighter_subtypes ?? []);
+    }
+
+    const bases: Array<{ key: string; names: string[] }> = [];
+    const smallestFirst = [...sets].sort(([keyA, a], [keyB, b]) =>
+      a.length - b.length || keyA.localeCompare(keyB)
+    );
+
+    for (const [key, names] of smallestFirst) {
+      const base = bases
+        .filter(candidate => containsAllSubtypes(names, candidate.names))
+        .sort((a, b) => b.names.length - a.names.length)[0];
+      if (!base) bases.push({ key, names });
+      baseOfSet.set(`${fighterType}::${key}`, base ?? { key, names });
+    }
+  }
+
+  return rows.map(row => {
+    const base = baseOfSet.get(`${row.fighter_type}::${subtypeKey(row)}`)!;
+    const inBase = new Set(base.names.map(name => name.toLowerCase().trim()));
+    const added = ((row.fighter_subtypes ?? []) as string[]).filter(
+      name => !inBase.has(name.toLowerCase().trim())
+    );
+    return {
+      ...row,
+      typeSubtypeKey: `${row.fighter_type}::${base.key}`,
+      variantLabel: row.specialisation?.specialisation_name || added.join(', ') || 'Default',
+    };
+  });
+}
+
 // null means "no filter", which is what callers outside the gang add-modals want.
 function filterByIsVehicle(rows: any[], isVehicleParam: string | null) {
   if (isVehicleParam === null) return rows;
@@ -212,7 +271,7 @@ export async function GET(request: Request) {
         data = mergeById(data, await getAvailableToAllFighterTypes(supabase, gangTypeId, customGangTypeId));
       }
 
-      return NextResponse.json(filterByIsVehicle(data, isVehicleParam));
+      return NextResponse.json(withVariantGroups(filterByIsVehicle(data, isVehicleParam)));
     }
 
     if (includeAllTypes) {
@@ -392,7 +451,7 @@ export async function GET(request: Request) {
       data = mergeById(data, await getAvailableToAllFighterTypes(supabase, gangTypeId, customGangTypeId));
     }
 
-    return NextResponse.json(filterByIsVehicle(data, isVehicleParam));
+    return NextResponse.json(withVariantGroups(filterByIsVehicle(data, isVehicleParam)));
   } catch (error) {
     console.error('Error fetching fighter types:', error);
     return NextResponse.json({ error: 'Error fetching fighter types' }, { status: 500 });

--- a/components/fighter/edit-fighter/fighter-edit-modal.tsx
+++ b/components/fighter/edit-fighter/fighter-edit-modal.tsx
@@ -21,6 +21,14 @@ import { CharacterStatsModal } from './character-stats-modal';
 
 const normalizeSpecialRule = (rule: string) => rule.replace(/^"|"$/g, '');
 
+/** Variants of one fighter share a typeSubtypeKey; see /api/fighter-types. */
+function sameVariantFamily(
+  a: { id: string; typeSubtypeKey?: string },
+  b: { id: string; typeSubtypeKey?: string }
+): boolean {
+  return (a.typeSubtypeKey ?? a.id) === (b.typeSubtypeKey ?? b.id);
+}
+
 /** fighter_subtypes is a set of names, so order carries no meaning here. */
 function sameFighterSubtypes(a?: string[] | null, b?: string[] | null): boolean {
   const left = a ?? [];
@@ -150,6 +158,7 @@ export function EditFighterModal({
     custom_gang_type_id?: string | null;
     total_cost: number;
     typeSubtypeKey?: string;
+    variantLabel?: string;
     is_gang_variant?: boolean;
     gang_variant_name?: string;
     fighter_specialisation?: string | null;
@@ -169,6 +178,7 @@ export function EditFighterModal({
       custom_gang_type_id: type.custom_gang_type_id ?? null,
       total_cost: type.total_cost,
       typeSubtypeKey: type.typeSubtypeKey,
+      variantLabel: type.variantLabel,
       is_gang_variant: type.is_gang_variant,
       gang_variant_name: type.gang_variant_name,
       specialisation: type.specialisation || {},
@@ -371,12 +381,13 @@ export function EditFighterModal({
     return options;
   }, [availableDefaultSpecialRules]);
 
-  // Group by type+subtype, prefer default (empty specialisation) versions, then cheapest
+  // One entry per variant family, preferring the default (empty specialisation) version,
+  // then the cheapest.
   const fighterTypeComboboxOptions = useMemo(() => {
     const typeSubtypeMap = new Map<string, { fighter: typeof fighterTypes[number]; cost: number }>();
 
     fighterTypes.forEach(ft => {
-      const key = `${ft.fighter_type}-${ft.fighter_subtypes.join(',')}`;
+      const key = ft.typeSubtypeKey ?? ft.id;
 
       if (!typeSubtypeMap.has(key)) {
         typeSubtypeMap.set(key, { fighter: ft, cost: ft.total_cost });
@@ -612,27 +623,20 @@ export function EditFighterModal({
     const currentType = fighterTypes.find(ft => ft.id === currentFighterTypeId);
     if (!currentType) return null;
 
-    const allVariantsOfType = fighterTypes.filter(ft =>
-      ft.fighter_type === currentType.fighter_type &&
-      sameFighterSubtypes(ft.fighter_subtypes, currentType.fighter_subtypes)
-    );
+    // The fighter's own type may be a variant, so the dropdown lands on its family.
+    const fighterTypeGroup = fighterTypes.filter(t => sameVariantFamily(t, currentType));
 
-    let dropdownType = allVariantsOfType.find(ft =>
+    let dropdownType = fighterTypeGroup.find(ft =>
       !(ft as any).specialisation || Object.keys((ft as any).specialisation).length === 0
     );
 
-    if (!dropdownType && allVariantsOfType.length > 0) {
-      dropdownType = allVariantsOfType.reduce((cheapest, current) =>
+    if (!dropdownType && fighterTypeGroup.length > 0) {
+      dropdownType = fighterTypeGroup.reduce((cheapest, current) =>
         current.total_cost < cheapest.total_cost ? current : cheapest
       );
     }
 
     const dropdownId = dropdownType ? dropdownType.id : currentFighterTypeId;
-
-    const fighterTypeGroup = fighterTypes.filter(t =>
-      t.fighter_type === currentType.fighter_type &&
-      sameFighterSubtypes(t.fighter_subtypes, currentType.fighter_subtypes)
-    );
 
     const specialisationOptions: Array<{ value: string; label: string; cost: number; fighterTypeId: string }> = [];
     const defaultFighterType = fighterTypeGroup.find(ft => !(ft as any).specialisation || Object.keys((ft as any).specialisation).length === 0);
@@ -652,7 +656,7 @@ export function EditFighterModal({
       if (specialisationName && specialisationId) {
         specialisationOptions.push({
           value: specialisationId,
-          label: specialisationName,
+          label: ft.variantLabel || specialisationName,
           cost: (ft as any).specialisation?.cost || 0,
           fighterTypeId: ft.id
         });
@@ -735,13 +739,10 @@ export function EditFighterModal({
       // Update available legacies for the selected fighter type
       setAvailableLegacies(selectedType.available_legacies || []);
 
-      // Get all fighters with the same fighter_type name and fighter_subtypes to check for specialisations
-      const fighterTypeGroup = fighterTypes.filter(t =>
-        t.fighter_type === selectedType.fighter_type &&
-        sameFighterSubtypes(t.fighter_subtypes, selectedType.fighter_subtypes)
-      );
-      
-      // If we have multiple entries with the same fighter_type + subtype, they represent different specialisations
+      // Get all variants of the selected fighter to check for specialisations
+      const fighterTypeGroup = fighterTypes.filter(t => sameVariantFamily(t, selectedType));
+
+      // If we have multiple entries in the family, they represent different specialisations
       if (fighterTypeGroup.length > 1) {
         // Create specialisation options from all variants
         const specialisationOptions: Array<{ value: string; label: string; cost: number; fighterTypeId: string }> = [];
@@ -767,7 +768,7 @@ export function EditFighterModal({
           if (specialisationName && specialisationId) {
             specialisationOptions.push({
               value: specialisationId,
-              label: specialisationName,
+              label: ft.variantLabel || specialisationName,
               cost: (ft as any).specialisation?.cost || 0,
               fighterTypeId: ft.id
             });
@@ -815,6 +816,23 @@ export function EditFighterModal({
     setSelectedSpecialisationId(specialisationId);
     setSelectedSpecialRuleOption('');
     setCustomSpecialRule('');
+
+    // A variant can carry subtypes the base row does not, so the selection follows the
+    // chosen row. Subtypes no row in the family owns were granted or hand-added; keep them.
+    const option = availableSpecialisations.find(st => st.value === specialisationId);
+    const variantType = fighterTypes.find(ft => ft.id === option?.fighterTypeId);
+    if (!variantType) return;
+
+    const familySubtypes = new Set(
+      fighterTypes.filter(ft => sameVariantFamily(ft, variantType)).flatMap(ft => ft.fighter_subtypes)
+    );
+    const next = [
+      ...variantType.fighter_subtypes,
+      ...selectedFighterSubtypes.filter(name => !familySubtypes.has(name)),
+    ];
+
+    setFormValues(prev => ({ ...prev, fighter_subtypes: next }));
+    applySelectedFighterSubtypes(allowMultipleSubtypes ? next : next.slice(0, 1));
   };
 
   // Add handler for gang legacy change
@@ -997,24 +1015,13 @@ export function EditFighterModal({
       } else if (selectedSpecialisation) {
         // User changed specialisation (either explicitly or implicitly) - always update fighter type ID
         if (selectedSpecialisation.fighter_specialisation !== 'Default' && selectedSpecialisation.id) {
-          // User selected a specific specialisation - find the fighter type with that specialisation
-          
-          // Get the actual fighter type and subtype values
-          const currentFighterType = (fighter.fighter_type as any)?.fighter_type || fighter.fighter_type;
-          // Prefer the selected catalog type's subtypes for group matching so N26
-          // multi-subtype types resolve correctly even if the fighter override differs.
+          // User selected a specific specialisation - find the fighter type with that
+          // specialisation, within the selected catalog entry's family.
           const typeForGroup = fighterTypes.find(ft => ft.id === selectedFighterTypeId);
-          const groupSubtypes = typeForGroup?.fighter_subtypes ?? fighter.fighter_subtypes ?? [];
 
-          const availableFighterTypes = fighterTypes.filter(ft =>
-            ft.fighter_type === currentFighterType &&
-            sameFighterSubtypes(ft.fighter_subtypes, groupSubtypes)
-          );
-
-          const fighterTypeWithSpecialisation = fighterTypes.find(ft =>
+          const fighterTypeWithSpecialisation = typeForGroup && fighterTypes.find(ft =>
             ft.fighter_specialisation_id === selectedSpecialisation!.id &&
-            ft.fighter_type === currentFighterType &&
-            sameFighterSubtypes(ft.fighter_subtypes, groupSubtypes)
+            sameVariantFamily(ft, typeForGroup)
           );
           if (fighterTypeWithSpecialisation) {
             fighterTypeToUse = fighterTypeWithSpecialisation;

--- a/components/gang/fighter-add/FighterAddModal.tsx
+++ b/components/gang/fighter-add/FighterAddModal.tsx
@@ -129,6 +129,8 @@ function mapFighterType(type: any): FighterType {
     equipment_selection: type.equipment_selection,
     specialisation: type.specialisation,
     fighter_specialisation_id: type.specialisation?.id,
+    typeSubtypeKey: type.typeSubtypeKey,
+    variantLabel: type.variantLabel,
     available_legacies: type.available_legacies || [],
     is_custom_fighter: type.is_custom_fighter || false,
     free_skill: type.free_skill || false,
@@ -337,15 +339,13 @@ export default function FighterAddModal({
       }
     }
 
-    const fighterTypeGroup = fighterTypes.filter(t =>
-      t.fighter_type === selectedType?.fighter_type &&
-      t.fighter_subtypes?.[0] === selectedType?.fighter_subtypes?.[0]
-    );
+    const familyKey = selectedType?.typeSubtypeKey ?? typeId;
+    const fighterTypeGroup = filteredTypes.filter(t => (t.typeSubtypeKey ?? t.id) === familyKey);
 
     if (fighterTypeGroup.length > 1) {
       const specialisations = fighterTypeGroup.map(ft => ({
         id: ft.id,
-        specialisation_name: ft.specialisation?.specialisation_name || 'Default',
+        specialisation_name: ft.variantLabel || 'Default',
         cost: ft.total_cost,
       }));
       setAvailableSpecialisations(specialisations);
@@ -734,7 +734,8 @@ export default function FighterAddModal({
   const buildTypeOptions = () => {
     const typeSubtypeMap = new Map<string, { fighter: FighterType; cost: number }>();
     filteredTypes.forEach(fighter => {
-      const key = `${fighter.fighter_type}-${fighter.fighter_subtypes?.join(',')}`;
+      // Variants of one fighter share a key, so the list shows the family once.
+      const key = fighter.typeSubtypeKey ?? fighter.id;
       if (!typeSubtypeMap.has(key)) {
         typeSubtypeMap.set(key, { fighter, cost: fighter.total_cost });
       } else {

--- a/types/fighter-type.ts
+++ b/types/fighter-type.ts
@@ -85,6 +85,9 @@ export interface FighterType {
     specialisation_name: string;
   };
   fighter_specialisation_id?: string;
+  /** Variant family and this row's name within it, both set by /api/fighter-types. */
+  typeSubtypeKey?: string;
+  variantLabel?: string;
   available_legacies?: Array<{id: string, name: string}>;
   is_spyrer?: boolean;
   free_skill?: boolean;


### PR DESCRIPTION
N23 fighter types carried exactly one subtype, so "same fighter, different
variant" was expressed purely through fighter_specialisation and the Add/Edit
Fighter modals collapsed rows sharing fighter_type plus an identical
fighter_subtypes array.

N26 lets a variant add a subtype of its own: "Master of Shadow (Leader)" 140
sits alongside "Master of Shadow (Leader, Wyrd)" 175. The arrays differ, so
both surfaced as unrelated catalog entries and the specialisation picker never
appeared.

/api/fighter-types now tags each row with the variant family it belongs to:
same fighter_type, and one row's subtype set containing the other's. Disjoint
sets stay separate, so N23's "Gunner (Ganger)" and "Gunner (Specialist)" keep
their own entries. This fills in typeSubtypeKey, which the Edit Fighter modal
already expected but nothing ever set, and replaces the two disagreeing rules
FighterAddModal carried (the option list keyed on the joined subtype array, the
picker on fighter_subtypes[0]).

Also sync the subtype selection when the Edit Fighter specialisation changes,
keeping subtypes no row in the family owns, so switching to a Wyrd variant no
longer saves the fighter without its Wyrd subtype.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UQ5wzES1hfr5Pk3AAc3miz