### PR TITLE
Restore the gap above the N26 weapon table

### DIFF
--- a/components/gang/fighter-card-weapon-table.tsx
+++ b/components/gang/fighter-card-weapon-table.tsx
@@ -195,17 +195,24 @@ const WeaponTable: React.FC<WeaponTableProps> = ({ weapons, entity, viewMode, ed
         </colgroup>
         <thead>
           {usesLethality ? (
-            <tr>
-              <th className={`${pClass} text-left`}>
-                {entity === 'vehicle' ? 'Vehicle Weapon' : entity === 'crew' ? 'Crew Weapon' : 'Weapon'}
-              </th>
-              <th className={`${pClass} text-center border-l border-black`}>SR</th>
-              <th className={`${pClass} text-center border-l border-black`}>LR</th>
-              <th className={`${pClass} text-center border-l border-black`}>Str</th>
-              <th className={`${pClass} text-center border-l border-black`}>AP</th>
-              <th className={`${pClass} text-center border-l border-black`}>L</th>
-              <th className={`${pClass} text-left border-l border-black`}>Traits</th>
-            </tr>
+            <>
+              {/* Empty stand-in for N23's Rng/Acc group row, so both editions leave
+                  the same gap under the characteristics table. */}
+              <tr aria-hidden="true">
+                <th className={`${pClass} ${rngAccHeaderSizeClass}`} colSpan={7}>&nbsp;</th>
+              </tr>
+              <tr>
+                <th className={`${pClass} text-left`}>
+                  {entity === 'vehicle' ? 'Vehicle Weapon' : entity === 'crew' ? 'Crew Weapon' : 'Weapon'}
+                </th>
+                <th className={`${pClass} text-center border-l border-black`}>SR</th>
+                <th className={`${pClass} text-center border-l border-black`}>LR</th>
+                <th className={`${pClass} text-center border-l border-black`}>Str</th>
+                <th className={`${pClass} text-center border-l border-black`}>AP</th>
+                <th className={`${pClass} text-center border-l border-black`}>L</th>
+                <th className={`${pClass} text-left border-l border-black`}>Traits</th>
+              </tr>
+            </>
           ) : (
             <>
               <tr>


### PR DESCRIPTION
N23 weapon tables render a two-row header: a small Rng/Acc group row above
the S/L/Str/AP/D/Am row. That group row carries no borders, so it reads as a
gap between the fighter's characteristics and the weapon profiles.

N26 has no grouped columns and so emitted a single header row, leaving
Weapon/SR/LR/Str/AP/L flush against the characteristics table.

Add an empty stand-in row to the N26 header using the same padding and font
size classes, so the gap matches N23 in every view mode and in print rather
than relying on a hardcoded margin.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PgBtMSzgToXpYniKWJaeT1