### PR TITLE
Hide XP cost from advancements list in cumulative-XP editions

### DIFF
--- a/components/fighter/fighter-advancement-list.tsx
+++ b/components/fighter/fighter-advancement-list.tsx
@@ -2957,6 +2957,10 @@ export function AdvancementsList({
   const [isStandalonePromotionOpen, setIsStandalonePromotionOpen] = useState(false);
   const [deleteModalData, setDeleteModalData] = useState<{ id: string; name: string; type: string } | null>(null);
 
+  // No XP is spent on Advancements in a rank-based edition, so there is no XP
+  // cost to list and nothing to refund when one is undone.
+  const isCumulativeXp = hasCumulativeXp(editionSlug);
+
   const showPromoteButton = fighterSubtypes.some(c => ['Ganger', 'Juve', 'Prospect', 'Champion', 'Specialist', 'Exotic Beast', 'Exotic Beast Specialist'].includes(c));
 
   const { data: preFetchedFighterTypes = [] } = useQuery({
@@ -3254,7 +3258,18 @@ export function AdvancementsList({
       <List
         title={title}
         items={transformedAdvancements}
-        columns={[
+        columns={isCumulativeXp ? [
+          {
+            key: 'name',
+            label: 'Name',
+            width: '75%'
+          },
+          {
+            key: 'credits_increase',
+            label: 'Cost',
+            align: 'right'
+          }
+        ] : [
           {
             key: 'name',
             label: 'Name',
@@ -3354,7 +3369,11 @@ export function AdvancementsList({
             <div>
               <p>Are you sure you want to undo <strong>{deleteModalData.name}</strong>?</p>
               <br />
-              <p>XP spent will be refunded and the fighter&apos;s value will be adjusted accordingly.</p>
+              <p>
+                {isCumulativeXp
+                  ? "The fighter's value will be adjusted accordingly."
+                  : "XP spent will be refunded and the fighter's value will be adjusted accordingly."}
+              </p>
             </div>
           }
           onClose={() => setDeleteModalData(null)}


### PR DESCRIPTION
N26 fighters earn Advancements by rank rather than spending XP, so the advancements table's XP column carries no meaning and the undo dialog's promise of an XP refund is wrong — the delete action already leaves fighter XP untouched in that edition.

Derive isCumulativeXp from the editionSlug prop AdvancementsList already receives, drop the XP column (widening Name to fill the space), and reword the undo confirmation to mention only the value adjustment.