### PR TITLE
Add edition_id support to fighter_gang_legacy table

### DIFF
--- a/app/api/admin/gang-lineages/route.ts
+++ b/app/api/admin/gang-lineages/route.ts
@@ -36,12 +36,7 @@ export async function GET(request: Request) {
 
   const type = typeParam as LineageType;
   const table = getTableName(type);
-  // edition_id only exists on gang_affiliation, not fighter_gang_legacy.
-  // Cast to the wider literal so the supabase query parser can type the result;
-  // for the legacy branch edition_id is simply absent (undefined) at runtime.
-  const lineageColumns = (type === 'affiliation'
-    ? 'id, name, fighter_type_id, created_at, updated_at, edition_id'
-    : 'id, name, fighter_type_id, created_at, updated_at') as 'id, name, fighter_type_id, created_at, updated_at, edition_id';
+  const lineageColumns = 'id, name, fighter_type_id, created_at, updated_at, edition_id';
 
   try {
     if (id) {
@@ -175,13 +170,13 @@ export async function POST(request: Request) {
 
     const table = getTableName(data.type as LineageType);
 
-    // Create the lineage in the specific table (edition_id only exists on gang_affiliation)
+    // Create the lineage in the specific table
     const { data: newLineage, error: insertError } = await supabase
       .from(table)
       .insert({
         name: data.name,
         fighter_type_id: data.fighter_type_id,
-        ...(data.type === 'affiliation' && { edition_id: data.edition_id || null })
+        edition_id: data.edition_id || null
       })
       .select()
       .single();
@@ -254,7 +249,7 @@ export async function PATCH(request: Request) {
         .update({
           name: data.name,
           fighter_type_id: data.fighter_type_id,
-          ...(currentType === 'affiliation' && { edition_id: data.edition_id || null }),
+          edition_id: data.edition_id || null,
           updated_at: new Date().toISOString()
         })
         .eq('id', id);
@@ -288,13 +283,13 @@ export async function PATCH(request: Request) {
     const oldFightersFk = currentType === 'legacy' ? 'fighter_gang_legacy_id' : 'gang_affiliation_id';
     const newFightersFk = newType === 'legacy' ? 'fighter_gang_legacy_id' : 'gang_affiliation_id';
 
-    // Create new record in new table (edition_id only exists on gang_affiliation)
+    // Create new record in new table
     const { data: insertedNew, error: insertNewErr } = await supabase
       .from(newTable)
       .insert({
         name: data.name,
         fighter_type_id: data.fighter_type_id,
-        ...(newType === 'affiliation' && { edition_id: data.edition_id || null })
+        edition_id: data.edition_id || null
       })
       .select()
       .single();

--- a/app/api/admin/gang-lineages/route.ts
+++ b/app/api/admin/gang-lineages/route.ts
@@ -17,6 +17,22 @@ function getTableName(type: LineageType) {
 // Always uses fighter_gang_legacy_id as the foreign key
 const JUNCTION_FK_COLUMN = 'fighter_gang_legacy_id';
 
+// edition_id is derived from the associated fighter type, never taken from the
+// client, so a lineage can never disagree with the edition it belongs to
+async function getFighterTypeEditionId(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  fighterTypeId: string
+) {
+  const { data, error } = await supabase
+    .from('fighter_types')
+    .select('edition_id')
+    .eq('id', fighterTypeId)
+    .single();
+
+  if (error) throw error;
+  return data.edition_id ?? null;
+}
+
 // GET - Fetch gang lineages (requires type param); with id returns one, without returns list
 export async function GET(request: Request) {
   const supabase = await createClient();
@@ -169,6 +185,7 @@ export async function POST(request: Request) {
     }
 
     const table = getTableName(data.type as LineageType);
+    const editionId = await getFighterTypeEditionId(supabase, data.fighter_type_id);
 
     // Create the lineage in the specific table
     const { data: newLineage, error: insertError } = await supabase
@@ -176,7 +193,7 @@ export async function POST(request: Request) {
       .insert({
         name: data.name,
         fighter_type_id: data.fighter_type_id,
-        edition_id: data.edition_id || null
+        edition_id: editionId
       })
       .select()
       .single();
@@ -239,6 +256,7 @@ export async function PATCH(request: Request) {
     }
 
     const currentTable = getTableName(currentType);
+    const editionId = await getFighterTypeEditionId(supabase, data.fighter_type_id);
 
     const newType = data.type as LineageType;
 
@@ -249,7 +267,7 @@ export async function PATCH(request: Request) {
         .update({
           name: data.name,
           fighter_type_id: data.fighter_type_id,
-          edition_id: data.edition_id || null,
+          edition_id: editionId,
           updated_at: new Date().toISOString()
         })
         .eq('id', id);
@@ -289,7 +307,7 @@ export async function PATCH(request: Request) {
       .insert({
         name: data.name,
         fighter_type_id: data.fighter_type_id,
-        edition_id: data.edition_id || null
+        edition_id: editionId
       })
       .select()
       .single();

--- a/app/api/gang-types/route.ts
+++ b/app/api/gang-types/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { createClient } from "@/utils/supabase/server";
 import { getUserIdFromClaims } from "@/utils/auth";
-import { editionSlugFromJoin, withEditionSlug } from "@/types/edition";
+import { editionSlugFromJoin, sameEditionForDisplay, withEditionSlug } from "@/types/edition";
 
 export async function GET(request: Request) {
   const supabase = await createClient();
@@ -46,7 +46,7 @@ export async function GET(request: Request) {
     // Run gang_types and affiliations in parallel (independent queries)
     const [gangTypesResult, affiliationsResult] = await Promise.all([
       query,
-      supabase.from('gang_affiliation').select('id, name').order('name'),
+      supabase.from('gang_affiliation').select('id, name, editions:edition_id (slug)').order('name'),
     ]);
 
     const { data: gangTypes, error } = gangTypesResult;
@@ -55,7 +55,11 @@ export async function GET(request: Request) {
     let allAffiliations: any[] = [];
     const { data: affiliations, error: affiliationError } = affiliationsResult;
     if (!affiliationError && affiliations) {
-      allAffiliations = affiliations;
+      allAffiliations = affiliations.map((affiliation) => ({
+        id: affiliation.id,
+        name: affiliation.name,
+        edition_slug: editionSlugFromJoin((affiliation as any).editions)
+      }));
     }
 
     // Get unique origin category IDs from gang types that have them
@@ -104,9 +108,13 @@ export async function GET(request: Request) {
         ? (originsByCategory[gangType.gang_origin_category_id] || [])
         : [];
 
+      const gangTypeWithEdition = withEditionSlug(gangType);
+
       return {
-        ...withEditionSlug(gangType),
-        available_affiliations: gangType.affiliation ? allAffiliations : [],
+        ...gangTypeWithEdition,
+        available_affiliations: gangType.affiliation
+          ? allAffiliations.filter(a => sameEditionForDisplay(a.edition_slug, gangTypeWithEdition.edition_slug))
+          : [],
         available_origins: availableOrigins
       };
     });

--- a/components/admin/admin-gang-lineage.tsx
+++ b/components/admin/admin-gang-lineage.tsx
@@ -34,6 +34,7 @@ interface FighterType {
   fighter_type: string;
   gang_type: string;
   gang_type_id: string;
+  edition_id?: string | null;
   fighter_subtypes?: string[];
   fighter_specialisation?: string | null;
 }
@@ -41,6 +42,7 @@ interface FighterType {
 interface GangType {
   gang_type_id: string;
   gang_type: string;
+  edition_id?: string | null;
 }
 
 interface AdminGangLineageModalProps {
@@ -176,28 +178,26 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
     }
   }
 
-  // Edition is the top-level filter for affiliations (legacies have no edition):
-  // only affiliations of the chosen edition are offered, and saved rows keep it
-  const editionFilteredLineages = selectedType === 'affiliation' && editionId
+  // Edition is the top-level filter: only lineages of the chosen edition are
+  // offered for editing, and created/saved lineages keep that edition
+  const editionFilteredLineages = editionId
     ? filteredGangLineages.filter(lineage => lineage.edition_id === editionId)
     : filteredGangLineages;
 
-  const handleEditionChange = (newEditionId: string) => {
-    setEditionId(newEditionId);
-    if (newEditionId && selectedGangLineageId) {
-      const lineage = filteredGangLineages.find(l => l.id === selectedGangLineageId);
-      if (lineage && lineage.edition_id !== newEditionId) {
-        setSelectedGangLineageId('');
-      }
-    }
-  };
+  // Derived: filter gang types by selected edition
+  const filteredGangTypes = useMemo(
+    () => editionId
+      ? gangTypes.filter(gt => gt.edition_id === editionId)
+      : gangTypes,
+    [gangTypes, editionId]
+  );
 
-  // Derived: filter fighter types by selected gang type
+  // Derived: filter fighter types by selected gang type and edition
   const filteredFighterTypes = useMemo(
     () => selectedGangTypeId
-      ? fighterTypes.filter(ft => ft.gang_type_id === selectedGangTypeId)
+      ? fighterTypes.filter(ft => ft.gang_type_id === selectedGangTypeId && (!editionId || ft.edition_id === editionId))
       : [],
-    [selectedGangTypeId, fighterTypes]
+    [selectedGangTypeId, fighterTypes, editionId]
   );
 
   // Handle user changing the gang type dropdown — clear fighter type if no longer valid
@@ -210,6 +210,35 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
     } else {
       setAssociatedFighterTypeId('');
     }
+  };
+
+  const handleEditionChange = (newEditionId: string) => {
+    setEditionId(newEditionId);
+    if (!newEditionId) return;
+
+    if (selectedGangLineageId) {
+      const lineage = filteredGangLineages.find(l => l.id === selectedGangLineageId);
+      if (lineage && lineage.edition_id !== newEditionId) {
+        setSelectedGangLineageId('');
+      }
+    }
+
+    // Only blank a selection when the target is found with a confirmed different edition
+    const conflicts = (gangTypeId: string) => {
+      const gangType = gangTypes.find(gt => gt.gang_type_id === gangTypeId);
+      return !!gangType?.edition_id && gangType.edition_id !== newEditionId;
+    };
+
+    if (selectedGangTypeId && conflicts(selectedGangTypeId)) {
+      handleGangTypeChange('');
+    }
+    if (accessRuleGangTypeId && conflicts(accessRuleGangTypeId)) {
+      setAccessRuleGangTypeId('');
+    }
+    setFighterTypeAccess(prev => prev.filter(id => {
+      const fighterType = fighterTypes.find(ft => ft.id === id);
+      return !fighterType?.edition_id || fighterType.edition_id === newEditionId;
+    }));
   };
 
   const isLoading = isLineagesLoading || isDetailsLoading || isSubmitting;
@@ -363,9 +392,23 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
     return displayName;
   };
 
+  // Derived: fighter types selectable as access rules, scoped to edition and gang type
+  const accessFighterTypeOptions = useMemo(
+    () => accessRuleGangTypeId
+      ? fighterTypes
+          .filter(ft => ft.gang_type_id === accessRuleGangTypeId
+            && (!editionId || ft.edition_id === editionId)
+            && !fighterTypeAccess.includes(ft.id))
+          .sort((a, b) => getFighterTypeDisplayName(a).localeCompare(getFighterTypeDisplayName(b)))
+      : [],
+    [accessRuleGangTypeId, fighterTypes, editionId, fighterTypeAccess]
+  );
+
   // Create modal content
   const createModalContent = (
     <div className="space-y-4">
+      <EditionSelect value={editionId} onChange={handleEditionChange} defaultToCurrent />
+
       <div>
         <label className="block text-sm font-medium text-muted-foreground mb-1">
           Type *
@@ -380,11 +423,6 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
           <option value="affiliation">Affiliation</option>
         </select>
       </div>
-
-      {/* Only gang_affiliation carries an edition; legacies do not */}
-      {lineageType === 'affiliation' && (
-        <EditionSelect value={editionId} onChange={setEditionId} defaultToCurrent />
-      )}
 
       <div>
         <label className="block text-sm font-medium text-muted-foreground mb-1">
@@ -409,7 +447,7 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
           className="w-full p-2 border rounded-md"
         >
           <option value="">Select a gang type</option>
-          {gangTypes.map((gangType) => (
+          {filteredGangTypes.map((gangType) => (
             <option key={gangType.gang_type_id} value={gangType.gang_type_id}>
               {gangType.gang_type}
             </option>
@@ -455,7 +493,7 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
                 className="w-full p-2 border rounded-md"
               >
                 <option value="">Select gang type</option>
-                {gangTypes.map((gangType) => (
+                {filteredGangTypes.map((gangType) => (
                   <option key={gangType.gang_type_id} value={gangType.gang_type_id}>
                     {gangType.gang_type}
                   </option>
@@ -484,14 +522,11 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
                     : "Add fighter type access"
                   }
                 </option>
-                {accessRuleGangTypeId && fighterTypes
-                  .filter(ft => ft.gang_type_id === accessRuleGangTypeId && !fighterTypeAccess.includes(ft.id))
-                  .sort((a, b) => getFighterTypeDisplayName(a).localeCompare(getFighterTypeDisplayName(b)))
-                  .map((fighterType) => (
-                    <option key={fighterType.id} value={fighterType.id}>
-                      {getFighterTypeDisplayName(fighterType)}
-                    </option>
-                  ))}
+                {accessFighterTypeOptions.map((fighterType) => (
+                  <option key={fighterType.id} value={fighterType.id}>
+                    {getFighterTypeDisplayName(fighterType)}
+                  </option>
+                ))}
               </select>
             </div>
           </div>
@@ -545,7 +580,7 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
         <div className="px-[10px] py-4 overflow-y-auto grow">
           <div className="space-y-6">
             {/* Type and Gang Lineage Selection */}
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 lg:grid-cols-4 gap-4">
               <div>
                 <label className="block text-sm font-medium text-muted-foreground mb-1">
                   Select Type
@@ -562,10 +597,7 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
                 </select>
               </div>
 
-              {/* Only gang_affiliation carries an edition; legacies do not */}
-              {selectedType === 'affiliation' && (
-                <EditionSelect value={editionId} onChange={handleEditionChange} defaultToCurrent />
-              )}
+              <EditionSelect value={editionId} onChange={handleEditionChange} defaultToCurrent />
 
               <div>
                 <label className="block text-sm font-medium text-muted-foreground mb-1">
@@ -655,7 +687,7 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
                       disabled={isLoading}
                     >
                       <option value="">Select a gang type</option>
-                      {gangTypes.map((gangType) => (
+                      {filteredGangTypes.map((gangType) => (
                         <option key={gangType.gang_type_id} value={gangType.gang_type_id}>
                           {gangType.gang_type}
                         </option>
@@ -707,7 +739,7 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
                           disabled={isLoading}
                         >
                           <option value="">Select gang type</option>
-                          {gangTypes.map((gangType) => (
+                          {filteredGangTypes.map((gangType) => (
                             <option key={gangType.gang_type_id} value={gangType.gang_type_id}>
                               {gangType.gang_type}
                             </option>
@@ -736,14 +768,11 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
                               : "Add fighter type access"
                             }
                           </option>
-                          {accessRuleGangTypeId && fighterTypes
-                            .filter(ft => ft.gang_type_id === accessRuleGangTypeId && !fighterTypeAccess.includes(ft.id))
-                            .sort((a, b) => getFighterTypeDisplayName(a).localeCompare(getFighterTypeDisplayName(b)))
-                            .map((fighterType) => (
-                              <option key={fighterType.id} value={fighterType.id}>
-                                {getFighterTypeDisplayName(fighterType)}
-                              </option>
-                            ))}
+                          {accessFighterTypeOptions.map((fighterType) => (
+                            <option key={fighterType.id} value={fighterType.id}>
+                              {getFighterTypeDisplayName(fighterType)}
+                            </option>
+                          ))}
                         </select>
                       </div>
                     </div>

--- a/components/admin/admin-gang-lineage.tsx
+++ b/components/admin/admin-gang-lineage.tsx
@@ -260,7 +260,6 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
           name: gangLineageName,
           fighter_type_id: associatedFighterTypeId,
           type: lineageType,
-          edition_id: editionId || null,
           fighter_type_access: fighterTypeAccess
         }),
       });
@@ -302,7 +301,6 @@ export function AdminGangLineageModal({ onClose, onSubmit }: AdminGangLineageMod
           name: gangLineageName,
           fighter_type_id: associatedFighterTypeId,
           type: lineageType,
-          edition_id: editionId || null,
           fighter_type_access: fighterTypeAccess
         }),
       });

--- a/components/gang/gang-edit-modal.tsx
+++ b/components/gang/gang-edit-modal.tsx
@@ -304,9 +304,12 @@ export default function GangEditModal({
       if (!response.ok) throw new Error('Failed to fetch gang types');
       const data = await response.json();
       
-      // Extract all available affiliations from the first gang type that has them
+      // Extract all available affiliations from the first gang type of this
+      // gang's edition that has them
       if (!affiliationListLoaded) {
-        const gangTypeWithAffiliations = data.find((type: any) => type.available_affiliations && type.available_affiliations.length > 0);
+        const gangTypeWithAffiliations = data.find((type: any) =>
+          sameEditionForDisplay(type.edition_slug, editionSlug)
+          && type.available_affiliations && type.available_affiliations.length > 0);
         if (gangTypeWithAffiliations) {
           setAffiliationList(gangTypeWithAffiliations.available_affiliations);
         }

--- a/supabase/migrations/20260814120000_add_edition_id_to_fighter_gang_legacy.sql
+++ b/supabase/migrations/20260814120000_add_edition_id_to_fighter_gang_legacy.sql
@@ -1,0 +1,19 @@
+-- Mirror the edition_id column gang_affiliation already carries.
+ALTER TABLE public.fighter_gang_legacy
+  ADD COLUMN IF NOT EXISTS edition_id uuid
+    REFERENCES public.editions(id) ON DELETE RESTRICT;
+
+CREATE INDEX IF NOT EXISTS fighter_gang_legacy_edition_id_idx
+  ON public.fighter_gang_legacy (edition_id);
+
+-- Backfill from the associated fighter type, then n23 for any remainder.
+UPDATE public.fighter_gang_legacy fgl
+SET edition_id = ft.edition_id
+FROM public.fighter_types ft
+WHERE ft.id = fgl.fighter_type_id
+  AND fgl.edition_id IS NULL
+  AND ft.edition_id IS NOT NULL;
+
+UPDATE public.fighter_gang_legacy
+SET edition_id = (SELECT id FROM public.editions WHERE slug = 'n23')
+WHERE edition_id IS NULL;

--- a/supabase/migrations/20260814120000_add_edition_id_to_fighter_gang_legacy.sql
+++ b/supabase/migrations/20260814120000_add_edition_id_to_fighter_gang_legacy.sql
@@ -14,6 +14,13 @@ WHERE ft.id = fgl.fighter_type_id
   AND fgl.edition_id IS NULL
   AND ft.edition_id IS NOT NULL;
 
-UPDATE public.fighter_gang_legacy
-SET edition_id = (SELECT id FROM public.editions WHERE slug = 'n23')
-WHERE edition_id IS NULL;
+DO $$
+DECLARE
+  base_edition_id uuid;
+BEGIN
+  SELECT id INTO STRICT base_edition_id FROM public.editions WHERE slug = 'n23';
+
+  UPDATE public.fighter_gang_legacy
+  SET edition_id = base_edition_id
+  WHERE edition_id IS NULL;
+END $$;


### PR DESCRIPTION
## Summary
This PR extends edition filtering support to the `fighter_gang_legacy` table, which previously only existed on `gang_affiliation`. This enables consistent edition-scoped management of both gang affiliation and legacy lineages throughout the admin interface.

## Key Changes

- **Database Migration**: Added `edition_id` column to `fighter_gang_legacy` table with foreign key constraint and index, backfilled from associated fighter types with fallback to 'n23' edition
- **Type Definitions**: Added optional `edition_id` field to `FighterType` and `GangType` interfaces
- **Edition Filtering**: 
  - Moved edition selection to always appear (not just for affiliations) in both create and edit modals
  - Created `filteredGangTypes` derived state to filter gang types by selected edition
  - Updated `filteredFighterTypes` to filter by both gang type and edition
  - Created `accessFighterTypeOptions` derived state for edition-scoped fighter type access rules
- **Edition Change Handler**: Enhanced `handleEditionChange` to clear conflicting selections across gang types, fighter types, and access rules when edition changes
- **API Updates**: Simplified backend logic to always include `edition_id` in queries and mutations for both lineage types, removing conditional branching
- **UI Layout**: Adjusted grid layout from 3 to 4 columns to accommodate edition selector in edit view

## Implementation Details

- Edition filtering now applies uniformly to both affiliation and legacy lineages
- The edition selector is always visible and functional, providing consistent UX
- Derived state uses `useMemo` to efficiently filter options based on edition and gang type selections
- Edition conflicts are automatically resolved by clearing incompatible selections rather than blocking operations