### PR TITLE
Add lethality field to weapon data in equipment details

### DIFF
--- a/supabase/functions/get_equipment_detailed_data.sql
+++ b/supabase/functions/get_equipment_detailed_data.sql
@@ -315,6 +315,7 @@ AS $$
                     'strength', wp.strength,
                     'ap', wp.ap,
                     'damage', wp.damage,
+                    'lethality', wp.lethality,
                     'ammo', wp.ammo,
                     'traits', wp.traits,
                     'sort_order', wp.sort_order
@@ -524,6 +525,7 @@ AS $$
                     'strength', cwp.strength,
                     'ap', cwp.ap,
                     'damage', cwp.damage,
+                    'lethality', cwp.lethality,
                     'ammo', cwp.ammo,
                     'traits', cwp.traits,
                     'sort_order', cwp.sort_order


### PR DESCRIPTION
## Summary
This PR adds the `lethality` field to weapon data returned by the `get_equipment_detailed_data` SQL function, ensuring this attribute is included in both regular weapons and class-specific weapons.

## Key Changes
- Added `'lethality', wp.lethality` to the weapon JSON object construction (line 318)
- Added `'lethality', cwp.lethality` to the class weapon JSON object construction (line 528)

## Implementation Details
The `lethality` field is now consistently included alongside other weapon attributes such as strength, AP, damage, ammo, traits, and sort_order. This change applies to both weapon types queried in the function, ensuring complete weapon data is returned to clients.