### PR TITLE
Fix rig glitch roll not selecting a result on N26

### DIFF
--- a/supabase/migrations/20260814130000_fix_n26_rig_glitch_effect_names.sql
+++ b/supabase/migrations/20260814130000_fix_n26_rig_glitch_effect_names.sql
@@ -1,0 +1,58 @@
+-- Correct four misspelled N26 rig glitch effect names.
+--
+-- The D66 range shown against a rig glitch, and the row a roll resolves to, are
+-- both a name-keyed lookup between RIG_GLITCH_TABLE_N26 in utils/dice.ts and
+-- fighter_effect_types.effect_name. Four of the twenty N26 rows were entered
+-- through Admin -> Injuries with names that do not match the rulebook, so a
+-- roll of 11-14 resolved to nothing and left the combobox on its placeholder:
+--
+--     Lesson Learned  -> Lesson Learnt     (11, the N23 spelling carried over)
+--     Eternal Emnity  -> Eternal Enmity    (12, 'nm' transposed)
+--     Bitter Emnity   -> Bitter Enmity     (13, 'nm' transposed)
+--     Personal Emnity -> Personal Enmity   (14, 'nm' transposed)
+--
+-- 'Bitter Enmity' additionally has to match BITTER_ENMITY_EFFECT_NAME in
+-- utils/injuryTarget.ts, which LASTING_INJURY_TABLE_N26 and
+-- VEHICLE_DAMAGE_TABLE_N26 already key on.
+--
+-- Scoped to edition n26 AND the rig-glitches category, both of which matter:
+-- the N23 rig glitch table has its own 'Lesson Learned' at 11 and the N26
+-- lasting injury and vehicle damage tables have their own Enmity trio. Those
+-- are separate rows and are correct as they stand.
+--
+-- Renaming rather than re-seeding keeps the ids, so fighter_effects rows
+-- already pointing at these four types stay attached.
+--
+-- Re-runnable: each update is a no-op once applied, and is skipped outright if
+-- a correctly named row somehow already exists alongside the misspelled one
+-- (fighter_effect_types has no unique constraint on the name).
+
+BEGIN;
+
+WITH target AS (
+  SELECT
+    (SELECT id FROM public.fighter_effect_categories WHERE category_name = 'rig-glitches') AS category_id,
+    (SELECT id FROM public.editions WHERE slug = 'n26') AS edition_id
+),
+renames(old_name, new_name) AS (
+  VALUES
+    ('Lesson Learned',  'Lesson Learnt'),
+    ('Eternal Emnity',  'Eternal Enmity'),
+    ('Bitter Emnity',   'Bitter Enmity'),
+    ('Personal Emnity', 'Personal Enmity')
+)
+UPDATE public.fighter_effect_types fet
+SET effect_name = r.new_name,
+    updated_at = now()
+FROM renames r, target t
+WHERE fet.effect_name = r.old_name
+  AND fet.fighter_effect_category_id = t.category_id
+  AND fet.edition_id = t.edition_id
+  AND NOT EXISTS (
+    SELECT 1 FROM public.fighter_effect_types existing
+    WHERE existing.effect_name = r.new_name
+      AND existing.fighter_effect_category_id = t.category_id
+      AND existing.edition_id = t.edition_id
+  );
+
+COMMIT;

--- a/supabase/migrations/20260814140000_add_n26_rig_glitch_status_flags.sql
+++ b/supabase/migrations/20260814140000_add_n26_rig_glitch_status_flags.sql
@@ -1,0 +1,81 @@
+-- Add the two status flags the N26 rig glitch rows were created without.
+--
+-- Runs after 20260814130000_fix_n26_rig_glitch_effect_names.sql and matches on
+-- the corrected spellings ('Eternal Enmity', not 'Eternal Emnity').
+--
+-- 1. killed on Critical Overload (66)
+--
+-- 20260504163000_mark_fatal_effects_killed.sql already sets this for both
+-- 'Memorable Death' and 'Critical Overload' across both categories, but it ran
+-- in May and the N26 rig glitch rows were entered in August, so the N26 row
+-- missed it. Same shape as that migration, including the fighter_effects
+-- backfill: hasKilledStatusFlag reads the flag off instances too, and
+-- fighter-injury-list uses it to decide whether clearing glitches should clear
+-- the fighter's Killed status.
+--
+-- Written as the string 'true', not a JSON boolean, matching the existing rows.
+-- hasKilledStatusFlag in utils/fighter-status.ts accepts either.
+--
+-- 2. hatred_target on the Enmity trio (12, 13, 14)
+--
+-- Same fix 20260806170000_add_hatred_target_to_enmity_injuries.sql applied to
+-- the lasting injury rows, which likewise predates these. Without the key
+-- requiredHatredTarget returns null and the target picker never renders, so the
+-- Hatred (X) target goes unrecorded. add_fighter_injury.sql reads the same key
+-- and already handles all three kinds, so nothing else needs to change.
+--
+-- Values must match HatredTargetKind in utils/injuryTarget.ts, and the mapping
+-- is the same as the N26 lasting injuries: Eternal = the gang TYPE that took
+-- them Out of Action, Bitter = the GANG, Personal = the MODEL.
+--
+-- Re-runnable: `||` overwrites with the same value.
+
+BEGIN;
+
+-- 1. Critical Overload kills the fighter outright.
+WITH target AS (
+  SELECT
+    (SELECT id FROM public.fighter_effect_categories WHERE category_name = 'rig-glitches') AS category_id,
+    (SELECT id FROM public.editions WHERE slug = 'n26') AS edition_id
+), updated_types AS (
+  UPDATE public.fighter_effect_types fet
+  SET type_specific_data =
+        COALESCE(fet.type_specific_data, '{}'::jsonb) || jsonb_build_object('killed', 'true'),
+      updated_at = now()
+  FROM target t
+  WHERE fet.effect_name = 'Critical Overload'
+    AND fet.fighter_effect_category_id = t.category_id
+    AND fet.edition_id = t.edition_id
+  RETURNING fet.id
+)
+UPDATE public.fighter_effects fe
+SET type_specific_data =
+      COALESCE(fe.type_specific_data, '{}'::jsonb) || jsonb_build_object('killed', 'true'),
+    updated_at = now()
+FROM updated_types u
+WHERE fe.fighter_effect_type_id = u.id;
+
+-- 2. Each Enmity result declares which kind of Hatred (X) target it needs.
+WITH target AS (
+  SELECT
+    (SELECT id FROM public.fighter_effect_categories WHERE category_name = 'rig-glitches') AS category_id,
+    (SELECT id FROM public.editions WHERE slug = 'n26') AS edition_id
+),
+assignments(effect_name, hatred_target) AS (
+  VALUES
+    ('Eternal Enmity',  'gang_type'),
+    ('Bitter Enmity',   'gang'),
+    ('Personal Enmity', 'fighter')
+)
+UPDATE public.fighter_effect_types fet
+SET type_specific_data =
+      COALESCE(fet.type_specific_data, '{}'::jsonb)
+      || jsonb_build_object('hatred_target', a.hatred_target),
+    updated_at = now()
+FROM assignments a
+CROSS JOIN target t
+WHERE fet.effect_name = a.effect_name
+  AND fet.fighter_effect_category_id = t.category_id
+  AND fet.edition_id = t.edition_id;
+
+COMMIT;

--- a/utils/dice.ts
+++ b/utils/dice.ts
@@ -187,6 +187,41 @@ export const RIG_GLITCH_TABLE: TableEntry[] = [
   { range: [66, 66], name: 'Critical Overload' },
 ];
 
+// D66 table for Rig Glitches (Spyrers), N26 ruleset.
+//
+// Not a reskin of the N23 rig glitch table: N26 opens with the same six results
+// as its lasting injury table (Lesson Learnt, the Enmity trio, the two Scars),
+// widens Superficial Damage to 21-26, replaces Convalescence with Grievous
+// Wound over 31-46, and drops Weakened Polymers, Jammed Articulation, Disrupted
+// Ammo Cables, System Downgrade, Cracked Power Cell and Reduced Power
+// Distribution. Only 51-64 raise the Glitch Count.
+//
+// effect_name must match the edition's fighter_effect_types rows exactly, since
+// ranges are a name-keyed reverse lookup. Note 11 is 'Lesson Learnt' here and
+// 'Lesson Learned' in RIG_GLITCH_TABLE; both are correct for their own edition.
+export const RIG_GLITCH_TABLE_N26: TableEntry[] = [
+  { range: [11, 11], name: 'Lesson Learnt' },
+  { range: [12, 12], name: 'Eternal Enmity' },
+  { range: [13, 13], name: BITTER_ENMITY_EFFECT_NAME },
+  { range: [14, 14], name: 'Personal Enmity' },
+  { range: [15, 15], name: 'Horrid Scars' },
+  { range: [16, 16], name: 'Impressive Scars' },
+  { range: [21, 26], name: 'Superficial Damage' },
+  { range: [31, 46], name: 'Grievous Wound' },
+  { range: [51, 51], name: 'Anxiety Suppression Damaged' },
+  { range: [52, 52], name: 'Neural Feedback' },
+  { range: [53, 53], name: 'Humbled' },
+  { range: [54, 54], name: 'Vox Ghosts' },
+  { range: [55, 55], name: 'Gyroscopic Destabilisation' },
+  { range: [56, 56], name: 'Seized Locomotors' },
+  { range: [61, 61], name: 'Targeting Uplink Disruption' },
+  { range: [62, 62], name: 'Stuttering Servos' },
+  { range: [63, 63], name: 'Damaged Musculature' },
+  { range: [64, 64], name: 'Reduced Plate Density' },
+  { range: [65, 65], name: 'Multiple Glitches' },
+  { range: [66, 66], name: 'Critical Overload' },
+];
+
 // ============================================================================
 // Edition-scoped injury table selection
 // ============================================================================
@@ -208,7 +243,7 @@ type InjuryTables = {
  */
 const INJURY_TABLES_BY_EDITION: Record<EditionSlug, InjuryTables> = {
   n23: { base: LASTING_INJURY_TABLE, crew: LASTING_INJURY_CREW_TABLE, spyrer: RIG_GLITCH_TABLE },
-  n26: { base: LASTING_INJURY_TABLE_N26, crew: null, spyrer: null },
+  n26: { base: LASTING_INJURY_TABLE_N26, crew: null, spyrer: RIG_GLITCH_TABLE_N26 },
 };
 
 /**


### PR DESCRIPTION
## The bug

On an **N26** gang, rolling for a Rig Glitch on the fighter details page showed the roll but never selected anything in the dropdown — the combobox stayed on its placeholder, so the **Add Rig Glitch** button stayed disabled.

N26 declared no Spyrer rig glitch D66 table:

```ts
n23: { base: LASTING_INJURY_TABLE, crew: LASTING_INJURY_CREW_TABLE, spyrer: RIG_GLITCH_TABLE },
n26: { base: LASTING_INJURY_TABLE_N26, crew: null, spyrer: null },
```

`lastingInjuryTableFor` returns `tables.spyrer ?? []` for a Spyrer — deliberately *not* falling back to the base table, since rolling normal injuries for a hunting rig would be wrong. So `resolveInjuryFor` resolved nothing, and the roll handler bailed on its guard before ever setting the selection:

```ts
onRoll={(roll) => {
  const util = resolveInjuryFor(roll, editionSlug, injuryTableOpts);
  if (!util) return;   // N26 Spyrer always bailed here
```

`DiceRoller`'s own range-based lookup couldn't cover for it either: it reads `type_specific_data.d66_min/d66_max`, and the N26 seed migrations deliberately omit those keys — N26 relies entirely on the code-side tables. The same empty table is why no D66 ranges showed against the glitches in the dropdown; `formatInjuryRange` is a reverse lookup on the same data.

**N23 was never affected** — its table is wired, and its rows also carry the legacy `d66_*` keys.

## The fix

**1. `utils/dice.ts` — add `RIG_GLITCH_TABLE_N26` and wire it into `INJURY_TABLES_BY_EDITION`.**

Transcribed from the Spyrer Hunting Rig Glitches table. Not a reskin of N23: it opens with the same six results as the N26 lasting injury table (`Lesson Learnt`, the Enmity trio, the two Scars), widens `Superficial Damage` to 21-26, replaces `Convalescence` with `Grievous Wound` over 31-46, and drops `Weakened Polymers`, `Jammed Articulation`, `Disrupted Ammo Cables`, `System Downgrade`, `Cracked Power Cell` and `Reduced Power Distribution`. Only 51-64 raise the Glitch Count. Mirrors how `VEHICLE_DAMAGE_TABLE_N26` was added.

**2. `20260814130000_fix_n26_rig_glitch_effect_names.sql` — correct four misspelled rows.**

The range shown against a glitch and the row a roll resolves to are both a **name-keyed** lookup against `fighter_effect_types.effect_name`, so four rows entered through Admin → Injuries with off-book names left 11-14 broken even with the table wired up:

| D66 | Was | Now |
|---|---|---|
| 11 | `Lesson Learned` | `Lesson Learnt` |
| 12 | `Eternal Emnity` | `Eternal Enmity` |
| 13 | `Bitter Emnity` | `Bitter Enmity` |
| 14 | `Personal Emnity` | `Personal Enmity` |

`Bitter Enmity` additionally has to match `BITTER_ENMITY_EFFECT_NAME`, which `LASTING_INJURY_TABLE_N26` and `VEHICLE_DAMAGE_TABLE_N26` already key on. Renamed rather than re-seeded so the ids survive and existing `fighter_effects` stay attached. Scoped to the `n26` + `rig-glitches` rows: N23 has its own legitimate `Lesson Learned` at 11, and the N26 lasting injury and vehicle damage tables have their own Enmity trio.

**3. `20260814140000_add_n26_rig_glitch_status_flags.sql` — two missing status flags.**

Both have the same cause: the migrations that set them predate these rows (entered 2026-08-06).

- **`killed` on `Critical Overload` (66).** `20260504163000_mark_fatal_effects_killed.sql` covers this name across both categories but ran in May, so the N26 row missed it — rolling 66 added the effect without marking the fighter Killed. Backfills `fighter_effects` too, same as that migration: `hasKilledStatusFlag` reads instances as well, and `fighter-injury-list` uses it to decide whether clearing glitches should clear the Killed status.
- **`hatred_target` on the Enmity trio (12-14).** Without it `requiredHatredTarget` returns `null` and the Hatred (X) picker never renders, so the target went unrecorded. Mirrors `20260806170000_add_hatred_target_to_enmity_injuries.sql`. `add_fighter_injury.sql` already reads the key and handles all three kinds, so no function change.

## Testing

- `npx tsc --noEmit` clean; `npm run lint` reports nothing in the changed file.
- **Table coverage** — scripted over all 36 D66 values: every one now resolves for `{ isSpyrer: true }` on `n26` (previously all 36 returned `undefined`), and every name reverse-resolves to a range so the dropdown gets its D66 prefixes and sorts correctly. `n23` spyrer 43 → `Neural Feedback` unchanged; `n26` non-spyrer 43 → `Grievous Wound` unchanged; unknown slug still `undefined`, preserving `NO_INJURY_TABLES` semantics.
- **Both migrations** run against a local fixture reproducing the production rows plus decoys, applied twice, then rolled back. Renames hit exactly 4 rows and are a true no-op on re-run; the N23 `Critical Overload`, the N26 lasting-injury `Bitter Enmity` and unrelated N26 glitches were all left untouched; the instance backfill reached its row.

The flag updates rewrite the same values on re-run and bump `updated_at` — inherent to the `||` pattern and consistent with the precedent migrations.

## Deploying

Neither migration runs on `db reset`, and none of these rows exist in `seed.sql`, so there is no seed counterpart to keep in sync. **Both need applying to the remote by hand, in timestamp order.** Worth a pass on staging against a real N26 Spyrer before merge.

One stale comment left alone as out of scope: `app/api/fighters/injuries/route.ts` still cites "e.g. N26 rig glitches" as an example of a category an edition may have none of. The general statement holds; the example no longer does.
