### PR TITLE
Fix stale weapon cost when switching N26 Spyrer weapon choices

### DIFF
--- a/components/gang/fighter-add/EquipmentSelection.tsx
+++ b/components/gang/fighter-add/EquipmentSelection.tsx
@@ -428,16 +428,11 @@ export function EquipmentSelection({
 
                               setSelectedEquipment((prev) => {
                                 const currentCategoryOptions = categoryData.options || [];
-                                const previouslySelectedInThisCategory = selectedEquipmentIds.filter(id =>
-                                  currentCategoryOptions.some((o: any) => `${categoryId}-${o.id}` === id)
+                                let filtered = prev.filter(item =>
+                                  !currentCategoryOptions.some((o: any) =>
+                                    o.id === item.equipment_id && selectedEquipmentIds.includes(`${categoryId}-${o.id}`)
+                                  )
                                 );
-                                let filtered = prev.filter(item => {
-                                  const wasSelectedFromThisCategory = previouslySelectedInThisCategory.some(selectedId => {
-                                    const equipmentIdFromSelected = selectedId.split('-').pop();
-                                    return equipmentIdFromSelected === item.equipment_id;
-                                  });
-                                  return !wasSelectedFromThisCategory;
-                                });
                                 if (categoryData.select_type === 'optional_single' && categoryData.default && categoryData.default.length > 0) {
                                   categoryData.default.forEach((defaultItem: any) => {
                                     filtered = filtered.filter(item => item.equipment_id !== defaultItem.id);


### PR DESCRIPTION
## Problem

Adding a Spyrer to an N26 gang, the starting-equipment weapon choices render as radio buttons. Picking one option and then switching to another added the new option's price but never removed the old one — the **`Equipment cost: N credits`** line under the cost field climbed with every switch.

This is not merely cosmetic. That figure is derived from `selectedEquipment`, which is also the array posted to the server as `selected_equipment`, so:

- the created fighter gained a `fighter_equipment` row for **every** weapon the user cycled through
- with *Use Listed Cost for Rating* enabled, `addFighterToGang` computed `ratingCost = baseCost + SUM(selected_equipment.cost * qty)` across all of them — an inflated rating plus phantom weapons on the roster

The editable `Cost (credits)` input was unaffected.

## Root cause

`components/gang/fighter-add/EquipmentSelection.tsx`, the `single` / `optional_single` radio `onChange` handler. Its `setSelectedEquipment` updater dropped the previous pick by parsing the equipment id back out of the composite selection key:

```ts
const equipmentIdFromSelected = selectedId.split('-').pop();
return equipmentIdFromSelected === item.equipment_id;
```

The key is `` `${categoryId}-${option.id}` `` and `option.id` is a **UUID**, which itself contains `-`. So `.pop()` returned only the last 12-hex-character segment, never equal to the full `item.equipment_id`. The filter removed nothing, and the handler's `[...filtered, { new option }]` push appended on top of the stale entry.

## Fix

Match on `option.id` directly, preserving the original intent of clearing only options from *this* category that were actually selected.

The three sibling branches in the same file already do exactly this — `optional` + flexible, `optional` + strict, and the `optional_single` "Keep Default" radio all compare `o.id === item.equipment_id`. This branch was the odd one out.

The `setFighterCost` delta in the same handler needed no change: it already resolves the previous option via the full composite key, which is why the `Cost (credits)` input stayed correct throughout.

## Scope

Nothing here is edition-conditional — no capability-registry change is involved. N26 Spyrers are simply the fighter types whose `fighter_equipment_selections` data uses the radio patterns (`single` / `optional_single`); N23 gangs use `optional` + flexible checkboxes, which go through an unaffected branch. Any fighter type using a radio selection was equally affected.

Four lines changed, one file.

## Testing

Verified locally against a seeded N26 Spyre Hunters gang whose fighter types exercise all four selection widgets:

- **Radio groups** (`single`, `optional_single`) — cycling options now shows the selected option's cost alone, not a running sum; the created fighter carries only the last-selected weapon
- **`Cost (credits)` input** — still tracks correctly across the same switches (regression guard)
- **Checkbox groups** (`multiple`) and **strict radios** (`optional` + strict) — unchanged behaviour, confirmed as controls

`npm run lint` and `tsc --noEmit` report no issues in the changed file.

The local seed fixture used for this is intentionally **not** part of this PR — it will land separately.
