### PR TITLE
Make Gang-Specific Cost dialog edition-aware

### DIFF
--- a/components/admin/admin-edit-fighter-type.tsx
+++ b/components/admin/admin-edit-fighter-type.tsx
@@ -99,6 +99,7 @@ interface GangAffiliation {
   id: string;
   name: string;
   fighter_type_id: string;
+  edition_id?: string | null;
 }
 
 export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighterTypeModalProps) {
@@ -332,6 +333,11 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
   const filteredGangTypes = useMemo(
     () => editionId ? gangTypes.filter(type => type.edition_id === editionId) : gangTypes,
     [gangTypes, editionId]
+  );
+
+  const filteredGangAffiliations = useMemo(
+    () => editionId ? gangAffiliations.filter(a => a.edition_id === editionId) : gangAffiliations,
+    [gangAffiliations, editionId]
   );
 
   const filteredFighterSubtypes = useMemo(
@@ -1411,7 +1417,7 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
           className="w-full p-2 border rounded-md"
         >
           <option value="">Select a gang type</option>
-          {gangTypes.map((gangType) => (
+          {filteredGangTypes.map((gangType) => (
             <option key={gangType.gang_type_id} value={gangType.gang_type_id}>
               {gangType.gang_type}
             </option>
@@ -1427,7 +1433,7 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
           className="w-full p-2 border rounded-md"
         >
           <option value="">None (applies to all gangs of this type)</option>
-          {gangAffiliations.map((affiliation) => (
+          {filteredGangAffiliations.map((affiliation) => (
             <option key={affiliation.id} value={affiliation.id}>
               {affiliation.name}
             </option>
@@ -2473,9 +2479,11 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
                 {gangTypeCosts.length > 0 && (
                   <div className="flex flex-wrap gap-2">
                     {gangTypeCosts.map((gangCost, index) => {
-                      const gangType = gangTypes.find(g => g.gang_type_id === gangCost.gang_type_id);
-                      const affiliation = gangCost.gang_affiliation_id 
-                        ? gangAffiliations.find(a => a.id === gangCost.gang_affiliation_id)
+                      const gangType = filteredGangTypes.find(g => g.gang_type_id === gangCost.gang_type_id)
+                        ?? gangTypes.find(g => g.gang_type_id === gangCost.gang_type_id);
+                      const affiliation = gangCost.gang_affiliation_id
+                        ? filteredGangAffiliations.find(a => a.id === gangCost.gang_affiliation_id)
+                          ?? gangAffiliations.find(a => a.id === gangCost.gang_affiliation_id)
                         : null;
                       
                       const displayText = affiliation


### PR DESCRIPTION
The Gang Type and Gang Affiliation selects in the Gang-Specific Cost dialog mapped the raw fetched lists, so they showed rows from every edition. Since N23 and N26 seed gang types with identical names ("Ash Waste Nomads", "Available to All", ...), the dropdown listed indistinguishable duplicates and let an admin attach a cost from the wrong edition.

Both selects now use the edition-filtered lists that the rest of the component already relies on, with a new filteredGangAffiliations memo matching the existing filteredGangTypes/filteredEquipment pattern. Saved-cost chips resolve names from the filtered lists first and fall back to the full lists, so a pre-existing cross-edition row still renders its real name instead of "Unknown Gang".

No API change: /api/admin/gang-types and /api/admin/gang-lineages already return edition_id.