### PR TITLE
Don't let Admin save a grants option with no equipment picked

### DIFF
--- a/components/admin/admin-edit-equipment.tsx
+++ b/components/admin/admin-edit-equipment.tsx
@@ -520,9 +520,14 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
 
       const hasEditedFighterTypes = selectedFighterTypes.length !== fighterTypes.filter(ft => selectedFighterTypes.includes(ft.id)).length;
 
-      // Validate and normalize grants_equipment - treat empty options as no grants
-      const normalizedGrantsEquipment = grantsEquipment?.options?.length
-        ? grantsEquipment
+      // Validate and normalize grants_equipment - treat empty options as no grants.
+      // An option with no equipment picked is dropped: a blank equipment_id can never
+      // be granted, and it is not a uuid, so anything casting it downstream breaks.
+      const grantsEquipmentOptions = (grantsEquipment?.options || []).filter(
+        option => Boolean(option.equipment_id)
+      );
+      const normalizedGrantsEquipment = grantsEquipment && grantsEquipmentOptions.length
+        ? { ...grantsEquipment, options: grantsEquipmentOptions }
         : null;
 
       const requestBody = {


### PR DESCRIPTION
"Add Option" in the equipment editor seeds { equipment_id: '', additional_cost: 0 }, and the save-time normaliser only checked options.length — so saving before picking an item stored an empty string where a uuid belongs.

get_equipment_detailed_data casts that value to uuid while attaching each option's equipment_name. One blank id made the whole call fail with 22P02, which surfaced as "Failed to load equipment categories" across the entire list. It reached only the gang stash on an N26 gang: the item involved is core_equipment, which the fighter's-list and Trading Post filters exclude and the stash's Unrestricted list (no fighter_type_id) does not, and Unrestricted also filters by the gang's edition.

Drop options with no equipment_id before sending, and treat a grants block left with none as no grants at all — the same rule the normaliser already applied to an empty options array.