### PR TITLE
Show XP progress toward the next rank on N26 Advancements

### DIFF
--- a/components/fighter/fighter-advancement-list.tsx
+++ b/components/fighter/fighter-advancement-list.tsx
@@ -9,6 +9,7 @@ import { TypeSpecificData } from '@/types/fighter-effect';
 import { createClient } from '@/utils/supabase/client';
 import { getSkillSetRank } from "@/utils/skillSetRank";
 import { characteristicRank } from "@/utils/characteristicRank";
+import { nextTierStartFor } from "@/utils/advancementRanks";
 import { List } from "@/components/ui/list";
 import { UserPermissions } from '@/types/user-permissions';
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -3365,17 +3366,28 @@ export function AdvancementsList({
   }, [advancements, advancementSkills]);
 
   const advancementCount = advancements.length + advancementSkills.length;
+  // Advancements are earned by XP rank rather than bought, so the header tracks
+  // progress toward the next tier instead of counting what has been taken.
+  const nextTierStart = nextTierStartFor(editionSlug, fighterXp);
+  const xpProgress = `${fighterXp}/${nextTierStart ?? '–'}`;
+
   const title = (
     <>
       <span className="sm:hidden">Advanc.</span>
       <span className="hidden sm:inline">Advancements</span>
-      {advancementCount > 0 && (
+      {isCumulativeXp ? (
+        <>
+          {' '}
+          <span className="text-sm sm:hidden">({xpProgress})</span>
+          <span className="text-sm hidden sm:inline">(XP: {xpProgress})</span>
+        </>
+      ) : advancementCount > 0 ? (
         <>
           {' '}
           <span className="text-sm sm:hidden">({advancementCount})</span>
           <span className="text-sm hidden sm:inline">(Adv. count: {advancementCount})</span>
         </>
-      )}
+      ) : null}
     </>
   );
 

--- a/utils/advancementRanks.ts
+++ b/utils/advancementRanks.ts
@@ -71,6 +71,18 @@ export function advancementsEarnedFor(
 }
 
 /**
+ * The XP total that moves a model onto its next tier, or null when there is
+ * none: a Legend of the Underhive has nothing above it, and an edition without
+ * tiers has nothing to reach.
+ */
+export function nextTierStartFor(
+  editionSlug: string | null | undefined,
+  currentXp: number,
+): number | null {
+  return tierStartsFor(editionSlug).find((tierStart) => tierStart > currentXp) ?? null;
+}
+
+/**
  * How many Advancements a model has already taken.
  *
  * A characteristic lands as a fighter_effect in the 'advancements' category, a


### PR DESCRIPTION
The Advancements header counted Advancements taken, which is the right
summary for N23 where they are bought with XP. N26 earns them by rank, so
what matters there is how close the fighter is to the next tier: a fighter
on 37 XP reads 37/49, on 73 XP reads 73/85.

nextTierStartFor inherits the per-edition gating already in tierStartsFor,
and the header branches on the isCumulativeXp local the component already
computes, so N23 keeps its count unchanged. A Legend of the Underhive has
no tier above it and reads 235/–.