### PR TITLE
Stop N26 refusing Advancements, and stop its log claiming XP was spent

### DIFF
--- a/app/actions/fighter-advancement.ts
+++ b/app/actions/fighter-advancement.ts
@@ -12,7 +12,6 @@ import {
   hasGangerChampionKeepTypePromotion,
   hasProspectSpecialisationPromotion,
 } from '@/types/edition';
-import { openAdvancementsFor } from '@/utils/advancementRanks';
 import {
   N26_CHAMPION_PROMOTION_SKILL_ID,
   N26_CHAMPION_PROMOTION_SKILL_NAME,
@@ -71,68 +70,19 @@ function editionSlugOf(fighter: any): string | null {
 }
 
 /**
- * How many Advancements a fighter has already taken, counted from the database.
- *
- * Mirrors countAdvancementsTaken in utils/advancementRanks.ts, which the cards
- * apply to data they already hold: a characteristic is an effect in the
- * 'advancements' category, a skill is a fighter_skill flagged is_advance.
- */
-async function countAdvancementsTakenFor(supabase: any, fighterId: string): Promise<number> {
-  const [characteristics, skillAdvances] = await Promise.all([
-    supabase
-      .from('fighter_effects')
-      .select('id, fighter_effect_types!inner(fighter_effect_categories!inner(category_name))', {
-        count: 'exact',
-        head: true,
-      })
-      .eq('fighter_id', fighterId)
-      .eq('fighter_effect_types.fighter_effect_categories.category_name', 'advancements'),
-    supabase
-      .from('fighter_skills')
-      .select('id', { count: 'exact', head: true })
-      .eq('fighter_id', fighterId)
-      .eq('is_advance', true),
-  ]);
-
-  // This count is half of a server-side limit, so a failed query must not read
-  // as "nothing taken yet" — that would grant an Advancement on the strength of
-  // an error. Fail closed and let the caller refuse.
-  if (characteristics.error || skillAdvances.error) {
-    throw new Error('Failed to count existing advancements');
-  }
-
-  return (characteristics.count ?? 0) + (skillAdvances.count ?? 0);
-}
-
-/**
  * Whether the fighter may take another Advancement right now.
  *
- * The two editions gate on different things: N23 on whether the fighter can
- * afford the XP cost, N26 on whether it has earned an Advancement it has not
- * yet spent. Returns an error message, or null when the Advancement may proceed.
+ * N23 buys Advancements with XP and so can be short of it. N26 earns them by
+ * rank, and that rank is not enforced: groups decide between themselves when a
+ * model may advance, and the app records the decision rather than refusing it.
+ * Returns an error message, or null when the Advancement may proceed.
  */
-async function advancementBlockedReason(
-  supabase: any,
+function advancementBlockedReason(
   fighter: any,
   spendsXp: boolean,
   xpCost: number,
-  isAdvance: boolean = true,
-): Promise<string | null> {
-  if (spendsXp) {
-    return fighter.xp < xpCost ? 'Insufficient XP' : null;
-  }
-
-  // A starting or free skill is not an Advancement and consumes none.
-  if (!isAdvance) return null;
-
-  const open = openAdvancementsFor(
-    editionSlugOf(fighter),
-    fighter.starting_xp ?? 0,
-    fighter.xp,
-    await countAdvancementsTakenFor(supabase, fighter.id),
-  );
-
-  return open > 0 ? null : 'No advancements available';
+): string | null {
+  return spendsXp && fighter.xp < xpCost ? 'Insufficient XP' : null;
 }
 
 // Type for power boost type_specific_data
@@ -293,7 +243,7 @@ export async function addCharacteristicAdvancement(
     // XP total only ever grows and there is nothing to afford.
     const spendsXp = !hasCumulativeXp(editionSlugOf(fighter));
 
-    const blockedReason = await advancementBlockedReason(supabase, fighter, spendsXp, params.xp_cost);
+    const blockedReason = advancementBlockedReason(fighter, spendsXp, params.xp_cost);
     if (blockedReason) {
       return { success: false, error: blockedReason };
     }
@@ -411,7 +361,8 @@ export async function addCharacteristicAdvancement(
       xp_cost: params.xp_cost,
       credits_increase: params.credits_increase,
       remaining_xp: updatedFighter.xp,
-      include_gang_rating: true
+      include_gang_rating: true,
+      spends_xp: spendsXp
     });
 
     // Invalidate cache for fighter advancement (effects for characteristic advancements)
@@ -499,13 +450,7 @@ async function addSkillAdvancementInternal(
     // XP total only ever grows and there is nothing to afford.
     const spendsXp = !hasCumulativeXp(editionSlugOf(fighter));
 
-    const blockedReason = await advancementBlockedReason(
-      supabase,
-      fighter,
-      spendsXp,
-      params.xp_cost,
-      params.is_advance ?? true,
-    );
+    const blockedReason = advancementBlockedReason(fighter, spendsXp, params.xp_cost);
     if (blockedReason) {
       return { success: false, error: blockedReason };
     }
@@ -706,6 +651,7 @@ async function addSkillAdvancementInternal(
       credits_increase: params.credits_increase,
       remaining_xp: updatedFighter.xp,
       is_advance: isAdvance,
+      spends_xp: spendsXp,
       ...(financialsBefore && financialsAfter
         ? { gang_financials_before: financialsBefore, gang_financials_after: financialsAfter }
         : {}),
@@ -1687,6 +1633,7 @@ export async function deleteAdvancement(
       xp_refunded: xpToRefund,
       new_xp_total: updatedFighter.xp,
       include_gang_rating: true,
+      spends_xp: spendsXp,
       ...(refundStash && Math.abs(ratingDelta) > 0 ? { credits_refunded: Math.abs(ratingDelta) } : {})
     });
 

--- a/app/actions/logs/gang-fighter-logs.ts
+++ b/app/actions/logs/gang-fighter-logs.ts
@@ -16,6 +16,9 @@ interface CharacteristicAdvancementLogParams {
   credits_increase: number;
   remaining_xp: number;
   include_gang_rating?: boolean;
+  /** False in a rank-based edition, where nothing is paid and no XP is left
+   *  over, so the description drops its cost and remaining-XP wording. */
+  spends_xp?: boolean;
 }
 
 interface SkillAdvancementLogParams {
@@ -32,6 +35,8 @@ interface SkillAdvancementLogParams {
    *  "Gang Rating: A → B | Wealth: C → D" segment to the summary line. */
   gang_financials_before?: { rating: number; wealth: number };
   gang_financials_after?: { rating: number; wealth: number };
+  /** False in a rank-based edition, where the skill is not paid for. */
+  spends_xp?: boolean;
 }
 
 interface AdvancementDeletionLogParams {
@@ -44,6 +49,8 @@ interface AdvancementDeletionLogParams {
   new_xp_total: number;
   include_gang_rating?: boolean;
   credits_refunded?: number;
+  /** False in a rank-based edition, where undoing an Advancement returns no XP. */
+  spends_xp?: boolean;
 }
 
 interface FighterInjuryLogParams {
@@ -106,8 +113,10 @@ export async function logCharacteristicAdvancement(params: CharacteristicAdvance
   try {
     const supabase = await createClient();
     
-    let description = `Fighter "${params.fighter_name}" advanced "${params.characteristic_name}" for ${params.xp_cost} XP (+${params.credits_increase} credits). Remaining XP: ${params.remaining_xp}`;
-    
+    let description = (params.spends_xp ?? true)
+      ? `Fighter "${params.fighter_name}" advanced "${params.characteristic_name}" for ${params.xp_cost} XP (+${params.credits_increase} credits). Remaining XP: ${params.remaining_xp}`
+      : `Fighter "${params.fighter_name}" advanced "${params.characteristic_name}" (+${params.credits_increase} credits)`;
+
     if (params.include_gang_rating) {
       const gangRating = await calculateGangRating(supabase, params.gang_id);
       description += `. New gang rating: ${gangRating}`;
@@ -131,7 +140,8 @@ export async function logCharacteristicAdvancement(params: CharacteristicAdvance
 export async function logSkillAdvancement(params: SkillAdvancementLogParams): Promise<GangLogActionResult> {
   try {
     const advancementType = params.is_advance ? 'gained' : 'learned';
-    let description = `Fighter "${params.fighter_name}" ${advancementType} skill "${params.skill_name}" for ${params.xp_cost} XP (+${params.credits_increase} credits)`;
+    const xpCostClause = (params.spends_xp ?? true) ? ` for ${params.xp_cost} XP` : '';
+    let description = `Fighter "${params.fighter_name}" ${advancementType} skill "${params.skill_name}"${xpCostClause} (+${params.credits_increase} credits)`;
 
     if (params.credits_deducted && params.credits_deducted > 0) {
       description += `. Gang stash: -${params.credits_deducted} credits`;
@@ -177,7 +187,9 @@ export async function logSkillAdvancementDeletion(params: AdvancementDeletionLog
   try {
     const supabase = await createClient();
     
-    let description = `Fighter "${params.fighter_name}" removed ${params.advancement_type} "${params.advancement_name}" (refunded ${params.xp_refunded} XP). New XP total: ${params.new_xp_total}`;
+    let description = (params.spends_xp ?? true)
+      ? `Fighter "${params.fighter_name}" removed ${params.advancement_type} "${params.advancement_name}" (refunded ${params.xp_refunded} XP). New XP total: ${params.new_xp_total}`
+      : `Fighter "${params.fighter_name}" removed ${params.advancement_type} "${params.advancement_name}"`;
 
     if (params.credits_refunded && params.credits_refunded > 0) {
       description += `. Gang stash: +${params.credits_refunded} credits`;

--- a/utils/advancementRanks.ts
+++ b/utils/advancementRanks.ts
@@ -21,8 +21,8 @@ const N26_TIER_STARTS: readonly number[] = [
 
 /**
  * N23 spends XP on Advancements instead of earning them by rank, so it has no
- * tiers. The empty list self-gates every count to zero without an edition
- * capability flag, the way NO_AWARDS does in utils/xpCases.ts.
+ * tiers. The empty list self-gates every lookup without an edition capability
+ * flag, the way NO_AWARDS does in utils/xpCases.ts.
  *
  * Keyed by EditionSlug so adding an edition is a compile error until it states
  * its own tiers.
@@ -32,42 +32,13 @@ const TIER_STARTS_BY_EDITION: Record<EditionSlug, readonly number[]> = {
   n26: N26_TIER_STARTS,
 };
 
-/** An unset or unrecognised slug means the edition failed to load: award nothing. */
+/** An unset or unrecognised slug means the edition failed to load: it has no tiers. */
 const NO_TIERS: readonly number[] = [];
 
 function tierStartsFor(editionSlug: string | null | undefined): readonly number[] {
   if (!editionSlug) return NO_TIERS;
 
   return TIER_STARTS_BY_EDITION[editionSlug as EditionSlug] ?? NO_TIERS;
-}
-
-const tiersAtOrBelow = (tiers: readonly number[], xp: number): number =>
-  tiers.filter((tierStart) => tierStart <= xp).length;
-
-/**
- * How many Advancements a model has earned in total.
- *
- * N26 never spends XP, so `currentXp` is starting XP plus everything ever
- * awarded, and an Advancement is granted each time that total moves the model
- * onto a new tier. This is a range count rather than `currentXp - startingXp`
- * because tiers widen as XP rises: rebasing to zero would put a Ganger recruited
- * on 13 XP back on the 3-wide Rookie track and advance them twice as fast.
- *
- * A null `startingXp` is N/A — the model's type cannot gain XP — and counts as
- * zero rather than short-circuiting. Such a model sits on 0 XP and so earns
- * nothing anyway; reading it as zero is what lets a group that house-rules XP
- * onto it have that XP rank normally instead of being silently ignored.
- */
-export function advancementsEarnedFor(
-  editionSlug: string | null | undefined,
-  startingXp: number | null,
-  currentXp: number,
-): number {
-  const tiers = tierStartsFor(editionSlug);
-
-  // XP below the recruitment value is only reachable by editing a fighter after
-  // the fact; it means no Advancement, never a negative one.
-  return Math.max(0, tiersAtOrBelow(tiers, currentXp) - tiersAtOrBelow(tiers, startingXp ?? 0));
 }
 
 /**
@@ -80,34 +51,4 @@ export function nextTierStartFor(
   currentXp: number,
 ): number | null {
   return tierStartsFor(editionSlug).find((tierStart) => tierStart > currentXp) ?? null;
-}
-
-/**
- * How many Advancements a model has already taken.
- *
- * A characteristic lands as a fighter_effect in the 'advancements' category, a
- * skill as a fighter_skill flagged is_advance. Starting and free skills are not
- * Advancements and carry is_advance false.
- */
-export function countAdvancementsTaken(
-  effects: { advancements?: unknown[] } | null | undefined,
-  skills: Record<string, { is_advance?: boolean }> | null | undefined,
-): number {
-  const characteristics = effects?.advancements?.length ?? 0;
-  const skillAdvances = Object.values(skills ?? {}).filter((skill) => skill?.is_advance).length;
-
-  return characteristics + skillAdvances;
-}
-
-/**
- * Advancements earned but not yet taken — the "Level Up" state, and the cap the
- * add-advancement actions enforce. Derived on read so it cannot drift.
- */
-export function openAdvancementsFor(
-  editionSlug: string | null | undefined,
-  startingXp: number | null,
-  currentXp: number,
-  advancementsTaken: number,
-): number {
-  return Math.max(0, advancementsEarnedFor(editionSlug, startingXp, currentXp) - advancementsTaken);
 }


### PR DESCRIPTION
Adding an Advancement failed with "No advancements available" once a
fighter had taken as many as its XP had earned. Playing groups house-rule
when a model may advance, and the app records what happened at the table
rather than refereeing it, so the rank is no longer enforced. This was the
only gate: the DB function already leaves the question to its caller, and
every client guard is an XP-affordability check that a zero cost passes.

advancementBlockedReason keeps just the N23 affordability branch, which
makes it synchronous and retires countAdvancementsTakenFor along with the
two count queries it ran on every add. N23 is unchanged — its branch
returned before the removed code was reachable.

The three advancement log lines take spends_xp and drop their cost and
remaining/refunded-XP wording when it is false, so a rank-based edition no
longer reads "for 0 XP" or "(refunded 0 XP)". The flag defaults to true, so
wording outside this flow is untouched.