### PR TITLE
Stop caching permission denials, which locked owners out of their own gangs

### DIFF
--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -3,7 +3,7 @@
 import { createClient } from "@/utils/supabase/server";
 import { headers } from "next/headers";
 import { cookies } from 'next/headers';
-import { invalidateUserCount } from '@/utils/cache-tags';
+import { invalidateUserCount, invalidateUserPermissions } from '@/utils/cache-tags';
 import { safePostSignInPath } from '@/utils/auth';
 
 // Returned instead of calling redirect(), so the caller can do a full document
@@ -123,7 +123,7 @@ export const signInAction = async (formData: FormData): Promise<AuthActionResult
 
   const supabase = await createClient();
 
-  const { error } = await supabase.auth.signInWithPassword({
+  const { data, error } = await supabase.auth.signInWithPassword({
     email,
     password,
   });
@@ -132,7 +132,11 @@ export const signInAction = async (formData: FormData): Promise<AuthActionResult
     return { error: error.message };
   }
 
-  // No revalidatePath - see the note in signOutAction.
+  // Clear this user's permission entries - they are cached with revalidate: false.
+  if (data.user) {
+    invalidateUserPermissions(data.user.id);
+  }
+
   return { redirectTo: safePostSignInPath(nextParam) };
 };
 

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 import { safePostSignInPath } from "@/utils/auth";
+import { invalidateUserPermissions } from "@/utils/cache-tags";
 
 export async function GET(request: Request) {
   const requestUrl = new URL(request.url);
@@ -26,7 +27,13 @@ export async function GET(request: Request) {
 
   if (code) {
     const supabase = await createClient();
-    await supabase.auth.exchangeCodeForSession(code);
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+
+    // Same reason as signInAction: any path that establishes a session clears
+    // that user's permission entries, which are cached with revalidate: false.
+    if (!error && data.user) {
+      invalidateUserPermissions(data.user.id);
+    }
   }
 
   const destination = safePostSignInPath(requestUrl.searchParams.get("next"));

--- a/app/lib/get-user-campaigns.ts
+++ b/app/lib/get-user-campaigns.ts
@@ -137,7 +137,8 @@ export const getUserCampaigns = async (userId: string, supabase: any): Promise<C
           // captureException(error)
         }
 
-        return [];
+        // Rethrow: unstable_cache would persist a returned [] with no TTL.
+        throw error;
       }
     },
     [`user-campaigns-${userId}`],

--- a/app/lib/get-user-gangs.ts
+++ b/app/lib/get-user-gangs.ts
@@ -195,7 +195,8 @@ export const getUserGangs = async (userId: string, supabase: any): Promise<Gang[
           // captureException(error)
         }
 
-        return [];
+        // Rethrow: unstable_cache would persist a returned [] with no TTL.
+        throw error;
       }
     },
     [`user-gangs-${userId}`],

--- a/utils/cache-tags.ts
+++ b/utils/cache-tags.ts
@@ -84,6 +84,7 @@ export const CACHE_TAGS = {
 
   // User permissions
   CHECK_PERMISSION: (userId: string, gangId: string) => `check-permission-${userId}-${gangId}`,
+  USER_PERMISSIONS: (userId: string) => `user-permissions-${userId}`,  // all gangs, one user
 
   // User dashboard data
   USER_DASHBOARD: (userId: string) => `user-dashboard-${userId}`,    // home page data
@@ -417,6 +418,15 @@ export function invalidatePermissionForUser(params: {
 }) {
   revalidateTag(CACHE_TAGS.CHECK_PERMISSION(params.userId, params.gangId), { expire: 0 });
   revalidateTag(CACHE_TAGS.USER_DASHBOARD(params.userId), { expire: 0 });
+}
+
+/**
+ * All Permissions Invalidation Pattern
+ * Triggered when: A user signs in
+ * Data changed: Every cached permission entry for that user, across all gangs
+ */
+export function invalidateUserPermissions(userId: string) {
+  revalidateTag(CACHE_TAGS.USER_PERMISSIONS(userId), { expire: 0 });
 }
 
 // =============================================================================

--- a/utils/user-permissions.ts
+++ b/utils/user-permissions.ts
@@ -37,32 +37,45 @@ export async function checkPermissionCached(
 ): Promise<UserPermissions> {
   const supabase = await createClient();
 
-  return unstable_cache(
-    async (uid: string, gid: string, ownerId: string | null) => {
-      try {
+  // Settled outside the cache so an owner keeps canEdit even if the RPC or cache is broken.
+  const withOwnership = (permissions: UserPermissions): UserPermissions =>
+    gangOwnerId !== null && gangOwnerId === userId
+      ? { ...permissions, isOwner: true, canEdit: true, canDelete: true }
+      : permissions;
+
+  try {
+    const permissions = await unstable_cache(
+      async (uid: string, gid: string, ownerId: string | null) => {
         const { data, error } = await supabase.rpc('check_permission', {
           p_user_id: uid,
           p_campaign_id: null,
           p_gang_id: gid,
         });
 
+        // Must throw: unstable_cache persists a returned deny, and revalidate: false
+        // makes it permanent.
         if (error) {
-          console.error('Error in checkPermissionCached RPC:', error);
-          return { isOwner: false, isAdmin: false, canEdit: false, canDelete: false, canView: true, userId: uid };
+          throw new Error(`check_permission RPC failed: ${error.message}`);
         }
 
         return deriveGangPermissions(uid, ownerId, data as CheckPermissionResult);
-      } catch (err) {
-        console.error('Exception in checkPermissionCached:', err);
-        return { isOwner: false, isAdmin: false, canEdit: false, canDelete: false, canView: true, userId: uid };
+      },
+      [`check-permission-${userId}-${gangId}`],
+      {
+        tags: [
+          CACHE_TAGS.CHECK_PERMISSION(userId, gangId),
+          CACHE_TAGS.USER_PERMISSIONS(userId),
+        ],
+        revalidate: false,
       }
-    },
-    [`check-permission-${userId}-${gangId}`],
-    {
-      tags: [CACHE_TAGS.CHECK_PERMISSION(userId, gangId)],
-      revalidate: false,
-    }
-  )(userId, gangId, gangOwnerId);
+    )(userId, gangId, gangOwnerId);
+
+    return withOwnership(permissions);
+  } catch (err) {
+    console.error('checkPermissionCached failed, falling back to an uncached check:', err);
+    const result = await checkPermission(userId, { gangId });
+    return withOwnership(deriveGangPermissions(userId, gangOwnerId, result));
+  }
 }
 
 export function isArbitrator(result: CheckPermissionResult): boolean {


### PR DESCRIPTION
checkPermissionCached wrapped the check_permission RPC in unstable_cache with
revalidate: false, and both failure branches returned a deny result instead of
throwing:

  if (error) {
    console.error('Error in checkPermissionCached RPC:', error);
    return { isOwner: false, canEdit: false, ... };
  }

unstable_cache cannot tell a failure from an answer, so that deny was written to
the shared Data Cache and, with no TTL, stayed there. One transient RPC error -
an expired JWT, a connection blip - permanently stripped the owner of canEdit on
that gang. getGangBasic gets this right and throws.

Nothing cleared it. CHECK_PERMISSION(userId, gangId) is only revalidated by
invalidatePermissionForUser, called from campaign membership changes and
delete-gang - never from an owner simply loading their gang.

Until ee595ad, signInAction and signOutAction called revalidatePath('/', 'layout'),
which evicted the entire Data Cache and took poisoned permission entries with it.
That flush was wasteful and removing it was right, but it was also the only thing
making this bug self-healing, which is why re-logging-in used to fix it and why
the bug went unnoticed.

Where the failures come from: proxy.ts returns early on any Next-Action header
and its matcher excludes api/, so server actions and API routes get no session
refresh. Two of the four checkPermissionCached call sites are on those paths
(fighter-skill-access.ts, api/fighters/skill-access). An expired token there
reaches PostgREST, the RPC 401s, and the deny is cached under a key of
(userId, gangId, gangOwnerId) - which the gang page then reads back even though
its own token is fresh. Page renders, edit controls gone.

Four changes:

- Ownership is applied outside the cache. gangOwnerId === userId is a plain id
  comparison needing no RPC, so an owner keeps canEdit even if the cached entry,
  the RPC, or Supabase is broken. isAdmin still comes from the RPC, since an owner
  who is also an admin sees extra fields in the gang edit modal.
- The cached callback throws on RPC error. The caller catches outside the cache
  and degrades for that request only via the uncached checkPermission, so nothing
  bad is ever persisted.
- Permission entries carry a new USER_PERMISSIONS(userId) tag alongside the
  per-gang one, giving a handle on all of a user's entries at once.
- signInAction calls invalidateUserPermissions(data.user.id), restoring the
  "log out and back in fixes it" escape hatch ee595ad removed - scoped to one
  user's tag rather than the whole shared cache.

revalidate: false is kept. It matches the convention used by the other 60
unstable_cache sites and adds nothing to page-load cost; recoverability comes
from the sign-in invalidation instead. The one uncovered case is a
profiles.user_role change, which no server action writes, so a newly promoted
admin sees it after signing in again.

Also fixes the same pattern in three other cached callbacks, where a transient
error would have cached an empty gang list, an empty campaign list, or a roster
silently missing a fighter.

No manual cache purge is needed for the users stuck today: unstable_cache derives
its key from cb.toString() (next/dist/server/web/spec-extension/unstable-cache.js:55),
so changing these callbacks orphans every existing check-permission-* entry.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015Q2vJsvkkW8of6CfZmuivN