### PR TITLE
Show outstanding Advancements on the N26 Advancements header

### DIFF
--- a/components/fighter/fighter-advancement-list.tsx
+++ b/components/fighter/fighter-advancement-list.tsx
@@ -9,7 +9,7 @@ import { TypeSpecificData } from '@/types/fighter-effect';
 import { createClient } from '@/utils/supabase/client';
 import { getSkillSetRank } from "@/utils/skillSetRank";
 import { characteristicRank } from "@/utils/characteristicRank";
-import { nextTierStartFor } from "@/utils/advancementRanks";
+import { nextTierStartFor, openAdvancementsFor } from "@/utils/advancementRanks";
 import { List } from "@/components/ui/list";
 import { UserPermissions } from '@/types/user-permissions';
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -180,6 +180,7 @@ interface FighterChanges {
 
 interface AdvancementsListProps {
   fighterXp: number;
+  fighterStartingXp?: number | null;
   fighterChanges?: FighterChanges;
   fighterId: string;
   editionSlug?: string | null;
@@ -2942,6 +2943,7 @@ export function AdvancementModal({
 // AdvancementsList Component
 export function AdvancementsList({
   fighterXp,
+  fighterStartingXp = null,
   fighterChanges = { advancement: [], characteristics: [], skills: [] },
   fighterId,
   editionSlug = null,
@@ -3371,6 +3373,14 @@ export function AdvancementsList({
   const nextTierStart = nextTierStartFor(editionSlug, fighterXp);
   const xpProgress = `${fighterXp}/${nextTierStart ?? '–'}`;
 
+  // advancementCount is the taken count: effects plus is_advance skills.
+  const openAdvancements = openAdvancementsFor(
+    editionSlug,
+    fighterStartingXp,
+    fighterXp,
+    advancementCount,
+  );
+
   const title = (
     <>
       <span className="sm:hidden">Advanc.</span>
@@ -3380,6 +3390,14 @@ export function AdvancementsList({
           {' '}
           <span className="text-sm sm:hidden">({xpProgress})</span>
           <span className="text-sm hidden sm:inline">(XP: {xpProgress})</span>
+          {openAdvancements > 0 && (
+            <>
+              {' '}
+              <span className="align-middle inline-flex items-center rounded-full bg-amber-500 px-2 py-0.5 text-xs font-semibold text-white">
+                {openAdvancements}
+              </span>
+            </>
+          )}
         </>
       ) : advancementCount > 0 ? (
         <>

--- a/components/fighter/fighter-page.tsx
+++ b/components/fighter/fighter-page.tsx
@@ -892,6 +892,7 @@ export default function FighterPage({
 
           <AdvancementsList
             fighterXp={fighterData.fighter?.xp || 0}
+            fighterStartingXp={fighterData.fighter?.starting_xp ?? null}
             fighterId={fighterData.fighter?.id || ''}
             editionSlug={fighterData.gang?.edition_slug ?? fighterData.fighter?.edition_slug ?? null}
             fighterSubtypes={fighterData.fighter?.fighter_subtypes || []}

--- a/utils/advancementRanks.ts
+++ b/utils/advancementRanks.ts
@@ -21,8 +21,8 @@ const N26_TIER_STARTS: readonly number[] = [
 
 /**
  * N23 spends XP on Advancements instead of earning them by rank, so it has no
- * tiers. The empty list self-gates every lookup without an edition capability
- * flag, the way NO_AWARDS does in utils/xpCases.ts.
+ * tiers. The empty list self-gates every count to zero without an edition
+ * capability flag, the way NO_AWARDS does in utils/xpCases.ts.
  *
  * Keyed by EditionSlug so adding an edition is a compile error until it states
  * its own tiers.
@@ -32,13 +32,42 @@ const TIER_STARTS_BY_EDITION: Record<EditionSlug, readonly number[]> = {
   n26: N26_TIER_STARTS,
 };
 
-/** An unset or unrecognised slug means the edition failed to load: it has no tiers. */
+/** An unset or unrecognised slug means the edition failed to load: award nothing. */
 const NO_TIERS: readonly number[] = [];
 
 function tierStartsFor(editionSlug: string | null | undefined): readonly number[] {
   if (!editionSlug) return NO_TIERS;
 
   return TIER_STARTS_BY_EDITION[editionSlug as EditionSlug] ?? NO_TIERS;
+}
+
+const tiersAtOrBelow = (tiers: readonly number[], xp: number): number =>
+  tiers.filter((tierStart) => tierStart <= xp).length;
+
+/**
+ * How many Advancements a model has earned in total.
+ *
+ * N26 never spends XP, so `currentXp` is starting XP plus everything ever
+ * awarded, and an Advancement is granted each time that total moves the model
+ * onto a new tier. This is a range count rather than `currentXp - startingXp`
+ * because tiers widen as XP rises: rebasing to zero would put a Ganger recruited
+ * on 13 XP back on the 3-wide Rookie track and advance them twice as fast.
+ *
+ * A null `startingXp` is N/A — the model's type cannot gain XP — and counts as
+ * zero rather than short-circuiting. Such a model sits on 0 XP and so earns
+ * nothing anyway; reading it as zero is what lets a group that house-rules XP
+ * onto it have that XP rank normally instead of being silently ignored.
+ */
+export function advancementsEarnedFor(
+  editionSlug: string | null | undefined,
+  startingXp: number | null,
+  currentXp: number,
+): number {
+  const tiers = tierStartsFor(editionSlug);
+
+  // XP below the recruitment value is only reachable by editing a fighter after
+  // the fact; it means no Advancement, never a negative one.
+  return Math.max(0, tiersAtOrBelow(tiers, currentXp) - tiersAtOrBelow(tiers, startingXp ?? 0));
 }
 
 /**
@@ -51,4 +80,19 @@ export function nextTierStartFor(
   currentXp: number,
 ): number | null {
   return tierStartsFor(editionSlug).find((tierStart) => tierStart > currentXp) ?? null;
+}
+
+/**
+ * Advancements earned but not yet taken. Derived on read so it cannot drift.
+ *
+ * Floored at zero: taking one is not gated on having earned one, so a fighter
+ * can hold more than its XP accounts for.
+ */
+export function openAdvancementsFor(
+  editionSlug: string | null | undefined,
+  startingXp: number | null,
+  currentXp: number,
+  advancementsTaken: number,
+): number {
+  return Math.max(0, advancementsEarnedFor(editionSlug, startingXp, currentXp) - advancementsTaken);
 }


### PR DESCRIPTION
Crossing an XP rank earns an Advancement, but nothing said so: the header's
progress readout simply slid to the next range, so a fighter could sit on
unspent Advancements indefinitely without the roster hinting at it. An amber
count now sits beside the readout whenever any are outstanding, and is absent
otherwise, so its presence is the whole message.

Amber rather than the green already used for XP pills, which would blur into
the readout it sits next to. Rendered inside the existing isCumulativeXp
branch, so N23 — where Advancements are bought, not earned — is untouched.

advancementsEarnedFor and openAdvancementsFor come back from history to do
the arithmetic, the latter reworded around this use: the count is floored at
zero because taking an Advancement is no longer gated on having earned one,
so a house-ruling group can hold more than its XP accounts for. The taken
count is the header's existing advancementCount, so countAdvancementsTaken
stays deleted rather than computing the same number twice.