### PR TITLE
Make custom-asset sharing edition-aware

### DIFF
--- a/app/actions/customise/custom-share.ts
+++ b/app/actions/customise/custom-share.ts
@@ -147,6 +147,9 @@ export async function shareCustomFighter(customFighterTypeId: string, campaignId
               .from('custom_shared')
               .insert(newSkillShares);
 
+            // Non-fatal by design: the fighter is already shared. Note that a skill whose type
+            // is from another edition would be rejected by the custom_shared trigger, and one
+            // bad row aborts the whole insert, so every skill here fails together.
             if (shareSkillsError) {
               console.error('Error auto-sharing custom skills for fighter:', shareSkillsError);
             }

--- a/app/actions/customise/custom-share.ts
+++ b/app/actions/customise/custom-share.ts
@@ -4,6 +4,45 @@ import { createClient } from '@/utils/supabase/server';
 import { getAuthenticatedUser } from '@/utils/auth';
 import { revalidateTag } from 'next/cache';
 import { CACHE_TAGS } from '@/utils/cache-tags';
+import { editionsConflict, editionSlugFromJoin } from '@/types/edition';
+
+/**
+ * A custom asset may only be shared to campaigns of its own edition. Uses
+ * editionsConflict, not sameEditionForDisplay: this rejects a user action, so an
+ * unresolved edition must not be read as N23 and used to turn someone away.
+ */
+async function assertCampaignsMatchEdition(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  itemEditionSlug: string | null,
+  campaignIds: string[]
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  if (campaignIds.length === 0 || itemEditionSlug == null) return { ok: true };
+
+  const { data: campaigns, error } = await supabase
+    .from('campaigns')
+    .select('id, campaign_types!campaign_type_id (editions:edition_id (slug))')
+    .in('id', campaignIds);
+
+  if (error) {
+    return { ok: false, error: 'Failed to verify campaign editions' };
+  }
+  if ((campaigns?.length ?? 0) !== campaignIds.length) {
+    return { ok: false, error: 'Campaign not found' };
+  }
+
+  const mismatch = (campaigns ?? []).some((campaign: any) =>
+    editionsConflict(itemEditionSlug, editionSlugFromJoin(campaign.campaign_types?.editions))
+  );
+
+  if (mismatch) {
+    return {
+      ok: false,
+      error: 'This custom asset is from a different edition than the campaign'
+    };
+  }
+
+  return { ok: true };
+}
 
 /**
  * Share a custom fighter to selected campaigns
@@ -16,7 +55,7 @@ export async function shareCustomFighter(customFighterTypeId: string, campaignId
     // Verify the custom fighter belongs to the user
     const { data: customFighter, error: fighterError } = await supabase
       .from('custom_fighter_types')
-      .select('id, user_id')
+      .select('id, user_id, editions:edition_id (slug)')
       .eq('id', customFighterTypeId)
       .eq('user_id', user.id)
       .single();
@@ -24,6 +63,11 @@ export async function shareCustomFighter(customFighterTypeId: string, campaignId
     if (fighterError || !customFighter) {
       return { success: false, error: 'Custom fighter not found or not owned by user' };
     }
+
+    const editionCheck = await assertCampaignsMatchEdition(
+      supabase, editionSlugFromJoin((customFighter as any).editions), campaignIds
+    );
+    if (!editionCheck.ok) return { success: false, error: editionCheck.error };
 
     // Delete existing shares for this fighter
     const { error: deleteError } = await supabase
@@ -134,7 +178,7 @@ export async function shareCustomGangType(customGangTypeId: string, campaignIds:
     // Verify the custom gang type belongs to the user
     const { data: customGangType, error: gangTypeError } = await supabase
       .from('custom_gang_types')
-      .select('id, user_id')
+      .select('id, user_id, editions:edition_id (slug)')
       .eq('id', customGangTypeId)
       .eq('user_id', user.id)
       .single();
@@ -142,6 +186,11 @@ export async function shareCustomGangType(customGangTypeId: string, campaignIds:
     if (gangTypeError || !customGangType) {
       return { success: false, error: 'Custom gang type not found or not owned by user' };
     }
+
+    const editionCheck = await assertCampaignsMatchEdition(
+      supabase, editionSlugFromJoin((customGangType as any).editions), campaignIds
+    );
+    if (!editionCheck.ok) return { success: false, error: editionCheck.error };
 
     // Delete existing shares for this gang type
     const { error: deleteError } = await supabase
@@ -293,7 +342,7 @@ export async function shareCustomEquipment(customEquipmentId: string, campaignId
     // Verify the custom equipment belongs to the user
     const { data: customEquipment, error: equipmentError } = await supabase
       .from('custom_equipment')
-      .select('id, user_id')
+      .select('id, user_id, editions:edition_id (slug)')
       .eq('id', customEquipmentId)
       .eq('user_id', user.id)
       .single();
@@ -301,6 +350,11 @@ export async function shareCustomEquipment(customEquipmentId: string, campaignId
     if (equipmentError || !customEquipment) {
       return { success: false, error: 'Custom equipment not found or not owned by user' };
     }
+
+    const editionCheck = await assertCampaignsMatchEdition(
+      supabase, editionSlugFromJoin((customEquipment as any).editions), campaignIds
+    );
+    if (!editionCheck.ok) return { success: false, error: editionCheck.error };
 
     // Delete existing shares for this equipment
     const { error: deleteError } = await supabase
@@ -353,7 +407,7 @@ export async function shareCustomSkill(customSkillId: string, campaignIds: strin
     // Verify the custom skill belongs to the user
     const { data: customSkill, error: skillError } = await supabase
       .from('custom_skills')
-      .select('id, user_id')
+      .select('id, user_id, custom_skill_types:custom_skill_type_id (editions:edition_id (slug))')
       .eq('id', customSkillId)
       .eq('user_id', user.id)
       .single();
@@ -361,6 +415,11 @@ export async function shareCustomSkill(customSkillId: string, campaignIds: strin
     if (skillError || !customSkill) {
       return { success: false, error: 'Custom skill not found or not owned by user' };
     }
+
+    const editionCheck = await assertCampaignsMatchEdition(
+      supabase, editionSlugFromJoin((customSkill as any).custom_skill_types?.editions), campaignIds
+    );
+    if (!editionCheck.ok) return { success: false, error: editionCheck.error };
 
     // Delete existing shares for this skill
     const { error: deleteError } = await supabase
@@ -409,7 +468,7 @@ export async function shareCustomTradingPost(customTradingPostId: string, campai
 
     const { data: customTradingPost, error: tpError } = await supabase
       .from('custom_trading_posts')
-      .select('id, user_id')
+      .select('id, user_id, editions:edition_id (slug)')
       .eq('id', customTradingPostId)
       .eq('user_id', user.id)
       .single();
@@ -417,6 +476,11 @@ export async function shareCustomTradingPost(customTradingPostId: string, campai
     if (tpError || !customTradingPost) {
       return { success: false, error: 'Custom trading post not found or not owned by user' };
     }
+
+    const editionCheck = await assertCampaignsMatchEdition(
+      supabase, editionSlugFromJoin((customTradingPost as any).editions), campaignIds
+    );
+    if (!editionCheck.ok) return { success: false, error: editionCheck.error };
 
     const { data: existingShares } = await supabase
       .from('custom_shared')
@@ -511,7 +575,8 @@ interface CollectionShareRow {
  * Expands the collection's items into per-item custom_shared rows (tagged with custom_collection_id),
  * cascading gang types -> fighters -> skills (mirroring shareCustomGangType), and syncing
  * campaigns.custom_trading_posts for any collected trading posts. campaignIds should be limited
- * to campaigns the caller arbitrates (enforced by the share modal's userCampaigns list).
+ * to campaigns the caller arbitrates (enforced by the share modal's userCampaigns list) and must
+ * all match the collection's edition (enforced here).
  * Passing an empty campaignIds unshares the collection from all campaigns.
  */
 export async function shareCollection(collectionId: string, campaignIds: string[]): Promise<{ success: boolean; error?: string }> {
@@ -521,7 +586,7 @@ export async function shareCollection(collectionId: string, campaignIds: string[
 
     const { data: collection, error: collectionError } = await supabase
       .from('custom_collections')
-      .select('id, user_id, items')
+      .select('id, user_id, items, editions:edition_id (slug)')
       .eq('id', collectionId)
       .eq('user_id', user.id)
       .single();
@@ -529,6 +594,11 @@ export async function shareCollection(collectionId: string, campaignIds: string[
     if (collectionError || !collection) {
       return { success: false, error: 'Collection not found or not owned by user' };
     }
+
+    const editionCheck = await assertCampaignsMatchEdition(
+      supabase, editionSlugFromJoin((collection as any).editions), campaignIds
+    );
+    if (!editionCheck.ok) return { success: false, error: editionCheck.error };
 
     const items = ((collection.items as { type: string; id: string }[]) || []);
     const equipmentIds = new Set(items.filter(i => i.type === 'equipment').map(i => i.id));

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,7 +1,8 @@
 import { createClient } from '@/utils/supabase/server'
 import { NextRequest } from 'next/server'
 import { getUserCustomCollections } from '@/app/lib/customise/custom-collections'
-import { gangEditionSlug } from '@/types/edition'
+import { editionSlugFromJoin, gangEditionSlug } from '@/types/edition'
+import type { UserCampaign } from '@/types/campaign'
 
 export async function GET(
   request: NextRequest,
@@ -65,21 +66,22 @@ export async function GET(
     }
 
     // Step 2: fetch campaigns by ids (if any)
-    let campaignsById: Record<string, { id: string; campaign_name: string; status: string | null }> = {}
+    let campaignsById: Record<string, UserCampaign> = {}
     if (campaignMembers && campaignMembers.length > 0) {
       const ids = Array.from(new Set(campaignMembers.map((m: any) => m.campaign_id).filter(Boolean)))
       if (ids.length > 0) {
         const { data: campaignsData, error: campaignsFetchError } = await supabase
           .from('campaigns')
-          .select('id, campaign_name, status')
+          .select('id, campaign_name, status, campaign_types!campaign_type_id (editions:edition_id (slug))')
           .in('id', ids)
         if (campaignsFetchError) {
           console.error('Error fetching campaigns:', campaignsFetchError)
         } else if (campaignsData) {
-          campaignsById = campaignsData.reduce((acc: any, c: any) => {
-            acc[c.id] = c
+          campaignsById = campaignsData.reduce((acc: Record<string, UserCampaign>, c: any) => {
+            const { campaign_types, ...campaign } = c
+            acc[c.id] = { ...campaign, edition_slug: editionSlugFromJoin(campaign_types?.editions) }
             return acc
-          }, {} as Record<string, { id: string; campaign_name: string; status: string | null }>)
+          }, {} as Record<string, UserCampaign>)
         }
       }
     }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,7 +20,8 @@ import { getUserCustomTradingPosts } from "@/app/lib/customise/custom-trading-po
 import { getUserCustomCollections } from "@/app/lib/customise/custom-collections";
 import { redirect } from "next/navigation";
 import Link from "next/link";
-import { withEditionSlug } from "@/types/edition";
+import { editionSlugFromJoin, withEditionSlug } from "@/types/edition";
+import type { UserCampaign } from "@/types/campaign";
 
 export default async function Home() {
   const supabase = await createClient();
@@ -76,15 +77,18 @@ export default async function Home() {
 
   const campaignIds = campaignMembers?.map(cm => cm.campaign_id) || [];
 
-  let userCampaigns: Array<{ id: string; campaign_name: string; status: string | null }> = [];
+  let userCampaigns: UserCampaign[] = [];
   if (campaignIds.length > 0) {
     const { data: campaignsForShare } = await supabase
       .from('campaigns')
-      .select('id, campaign_name, status')
+      .select('id, campaign_name, status, campaign_types!campaign_type_id (editions:edition_id (slug))')
       .in('id', campaignIds)
       .order('campaign_name');
 
-    userCampaigns = campaignsForShare || [];
+    userCampaigns = (campaignsForShare || []).map(({ campaign_types, ...campaign }: any) => ({
+      ...campaign,
+      edition_slug: editionSlugFromJoin(campaign_types?.editions),
+    }));
   }
 
   if (campaignTypesResult.error) {

--- a/app/user/[id]/page.tsx
+++ b/app/user/[id]/page.tsx
@@ -23,6 +23,7 @@ import { CustomCollectionWithItems } from "@/app/lib/customise/custom-collection
 import { useClaims } from "@/hooks/use-claims";
 import { useHomeEdition } from "@/hooks/use-home-edition";
 import { sameEditionForDisplay } from "@/types/edition";
+import type { UserCampaign } from "@/types/campaign";
 import { toast } from 'sonner';
 
 import Link from "next/link";
@@ -52,11 +53,7 @@ interface UserData {
     role: string;
     joined_at: string;
     campaign_id: string;
-    campaign: {
-      id: string;
-      campaign_name: string;
-      status: string | null;
-    } | null;
+    campaign: UserCampaign | null;
   }>;
   customAssets: {
     equipment: number;
@@ -147,7 +144,8 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
         .map(c => ({
           id: c.campaign!.id,
           campaign_name: c.campaign!.campaign_name,
-          status: c.campaign!.status
+          status: c.campaign!.status,
+          edition_slug: c.campaign!.edition_slug
         }))
     : [];
 

--- a/components/customise/custom-shared.tsx
+++ b/components/customise/custom-shared.tsx
@@ -13,7 +13,7 @@ import { CustomTradingPost } from '@/app/actions/customise/custom-trading-posts'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createClient } from '@/utils/supabase/client';
 import type { UserCampaign } from '@/types/campaign';
-import { EDITION_N23, sameEditionForDisplay } from '@/types/edition';
+import { editionsConflict } from '@/types/edition';
 
 // custom_shared columns that hold a shareable item id.
 type ShareColumn =
@@ -74,8 +74,10 @@ function ShareToCampaignsModal({
   const queryClient = useQueryClient();
   const sharedQueryKey = ['customSharedCampaigns', queryKind, itemId];
 
+  // editionsConflict, not sameEditionForDisplay: this gates an action, and edition_id is still
+  // nullable on the shareable tables, so an unresolved edition must not turn anyone away.
   const eligibleCampaigns = useMemo(
-    () => userCampaigns.filter(c => sameEditionForDisplay(c.edition_slug, itemEditionSlug)),
+    () => userCampaigns.filter(c => !editionsConflict(c.edition_slug, itemEditionSlug)),
     [userCampaigns, itemEditionSlug]
   );
 
@@ -156,7 +158,7 @@ function ShareToCampaignsModal({
               </>
             ) : (
               <>
-                <p>None of your campaigns are {(itemEditionSlug ?? EDITION_N23).toUpperCase()} campaigns.</p>
+                <p>None of your campaigns are {itemEditionSlug?.toUpperCase()} campaigns.</p>
                 <p className="text-sm mt-2">A custom asset can only be shared to a campaign of its own edition.</p>
               </>
             )}

--- a/components/customise/custom-shared.tsx
+++ b/components/customise/custom-shared.tsx
@@ -1,23 +1,26 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { CustomFighterType } from '@/types/fighter';
 import { CustomEquipment } from '@/types/equipment';
 import { toast } from 'sonner';
 import Modal from '@/components/ui/modal';
 import { Checkbox } from '@/components/ui/checkbox';
-import { shareCustomFighter, shareCustomEquipment, shareCustomGangType, shareCustomTradingPost, shareCollection } from '@/app/actions/customise/custom-share';
+import { shareCustomFighter, shareCustomEquipment, shareCustomGangType, shareCustomSkill, shareCustomTradingPost, shareCollection } from '@/app/actions/customise/custom-share';
+import type { CustomSkill } from '@/app/lib/customise/custom-skills';
 import { CustomGangType } from '@/app/actions/customise/custom-gang-types';
 import { CustomTradingPost } from '@/app/actions/customise/custom-trading-posts';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createClient } from '@/utils/supabase/client';
 import type { UserCampaign } from '@/types/campaign';
+import { EDITION_N23, sameEditionForDisplay } from '@/types/edition';
 
 // custom_shared columns that hold a shareable item id.
 type ShareColumn =
   | 'custom_fighter_type_id'
   | 'custom_equipment_id'
   | 'custom_gang_type_id'
+  | 'custom_skill_id'
   | 'custom_trading_post_id'
   | 'custom_collection_id';
 
@@ -36,14 +39,17 @@ interface ShareToCampaignsModalProps {
   invalidateKeys?: string[][];
   share: (campaignIds: string[]) => Promise<{ success: boolean; error?: string }>;
   userCampaigns: UserCampaign[];
+  itemEditionSlug: string | null;
   onClose: () => void;
   onSuccess?: () => void;
 }
 
 /**
- * Shared "apply to campaigns" modal used by every custom asset (fighter, equipment,
+ * Shared "apply to campaigns" modal used by every custom asset (fighter, equipment, skill,
  * gang type, trading post, collection). Loads the campaigns the item is currently shared to,
- * lets the arbitrator toggle the set, and persists via the supplied `share` action.
+ * lets the arbitrator toggle the set, and persists via the supplied `share` action. Only
+ * campaigns of the item's own edition are offered — cross-edition sharing is rejected by the
+ * share actions and by the custom_shared trigger.
  */
 function ShareToCampaignsModal({
   itemId,
@@ -60,12 +66,18 @@ function ShareToCampaignsModal({
   invalidateKeys = [],
   share,
   userCampaigns,
+  itemEditionSlug,
   onClose,
   onSuccess,
 }: ShareToCampaignsModalProps) {
   const [selectedCampaigns, setSelectedCampaigns] = useState<string[]>([]);
   const queryClient = useQueryClient();
   const sharedQueryKey = ['customSharedCampaigns', queryKind, itemId];
+
+  const eligibleCampaigns = useMemo(
+    () => userCampaigns.filter(c => sameEditionForDisplay(c.edition_slug, itemEditionSlug)),
+    [userCampaigns, itemEditionSlug]
+  );
 
   const { data: sharedCampaignIds = [], isLoading, isSuccess, error: fetchError } = useQuery({
     queryKey: sharedQueryKey,
@@ -83,10 +95,13 @@ function ShareToCampaignsModal({
   });
 
   const [prevSharedKey, setPrevSharedKey] = useState('');
-  const sharedKey = `${isSuccess}:${JSON.stringify(sharedCampaignIds)}`;
+  const sharedKey = `${isSuccess}:${JSON.stringify(sharedCampaignIds)}:${JSON.stringify(eligibleCampaigns.map(c => c.id))}`;
   if (sharedKey !== prevSharedKey) {
     setPrevSharedKey(sharedKey);
-    if (isSuccess) setSelectedCampaigns(sharedCampaignIds);
+    if (isSuccess) {
+      const eligibleIds = new Set(eligibleCampaigns.map(c => c.id));
+      setSelectedCampaigns(sharedCampaignIds.filter(id => eligibleIds.has(id)));
+    }
   }
 
   useEffect(() => {
@@ -132,17 +147,26 @@ function ShareToCampaignsModal({
       <div className="space-y-4">
         {isLoading ? (
           <div className="text-center py-8 text-muted-foreground">Loading...</div>
-        ) : userCampaigns.length === 0 ? (
+        ) : eligibleCampaigns.length === 0 ? (
           <div className="text-center py-8 text-muted-foreground">
-            <p>You&apos;re not part of any campaigns yet.</p>
-            <p className="text-sm mt-2">{emptyHint}</p>
+            {userCampaigns.length === 0 ? (
+              <>
+                <p>You&apos;re not part of any campaigns yet.</p>
+                <p className="text-sm mt-2">{emptyHint}</p>
+              </>
+            ) : (
+              <>
+                <p>None of your campaigns are {(itemEditionSlug ?? EDITION_N23).toUpperCase()} campaigns.</p>
+                <p className="text-sm mt-2">A custom asset can only be shared to a campaign of its own edition.</p>
+              </>
+            )}
           </div>
         ) : (
           <div className="space-y-3">
             <p className="text-sm text-muted-foreground mb-4">
               {applyVerb} <strong>{itemName}</strong> to campaigns:
             </p>
-            {userCampaigns.map((campaign) => (
+            {eligibleCampaigns.map((campaign) => (
               <div
                 key={campaign.id}
                 className="flex items-start space-x-3 p-3 border rounded-md hover:bg-muted/50 transition-colors"
@@ -192,6 +216,7 @@ export function ShareCustomFighterModal({ fighter, userCampaigns, onClose, onSuc
       invalidateKeys={[['customFighters']]}
       share={(ids) => shareCustomFighter(fighter.id, ids)}
       userCampaigns={userCampaigns}
+      itemEditionSlug={fighter.edition_slug ?? null}
       onClose={onClose}
       onSuccess={onSuccess}
     />
@@ -221,6 +246,7 @@ export function ShareCustomEquipmentModal({ equipment, userCampaigns, onClose, o
       invalidateKeys={[['customEquipment']]}
       share={(ids) => shareCustomEquipment(equipment.id, ids)}
       userCampaigns={userCampaigns}
+      itemEditionSlug={equipment.edition_slug ?? null}
       onClose={onClose}
       onSuccess={onSuccess}
     />
@@ -250,6 +276,7 @@ export function ShareCustomGangTypeModal({ gangType, userCampaigns, onClose, onS
       invalidateKeys={[['customGangTypes']]}
       share={(ids) => shareCustomGangType(gangType.id, ids)}
       userCampaigns={userCampaigns}
+      itemEditionSlug={gangType.edition_slug ?? null}
       onClose={onClose}
       onSuccess={onSuccess}
     />
@@ -279,6 +306,36 @@ export function ShareCustomTradingPostModal({ tradingPost, userCampaigns, onClos
       invalidateKeys={[['customTradingPosts']]}
       share={(ids) => shareCustomTradingPost(tradingPost.id, ids)}
       userCampaigns={userCampaigns}
+      itemEditionSlug={tradingPost.edition_slug ?? null}
+      onClose={onClose}
+      onSuccess={onSuccess}
+    />
+  );
+}
+
+interface ShareCustomSkillModalProps {
+  skill: CustomSkill;
+  userCampaigns: UserCampaign[];
+  onClose: () => void;
+  onSuccess?: () => void;
+}
+
+export function ShareCustomSkillModal({ skill, userCampaigns, onClose, onSuccess }: ShareCustomSkillModalProps) {
+  return (
+    <ShareToCampaignsModal
+      itemId={skill.id}
+      itemName={skill.skill_name}
+      column="custom_skill_id"
+      queryKind="skill"
+      noun="Custom skill"
+      title="Share Custom Skill"
+      helper="Select campaigns to share this custom skill with"
+      confirmLabel="Share Skill"
+      emptyHint="You need to be an arbitrator of a campaign to share custom skills to it."
+      idPrefix="skill-campaign"
+      share={(ids) => shareCustomSkill(skill.id, ids)}
+      userCampaigns={userCampaigns}
+      itemEditionSlug={skill.edition_slug ?? null}
       onClose={onClose}
       onSuccess={onSuccess}
     />
@@ -286,7 +343,7 @@ export function ShareCustomTradingPostModal({ tradingPost, userCampaigns, onClos
 }
 
 interface ShareCustomCollectionModalProps {
-  collection: { id: string; name: string };
+  collection: { id: string; name: string; edition_slug?: string | null };
   userCampaigns: UserCampaign[];
   onClose: () => void;
   onSuccess?: () => void;
@@ -309,6 +366,7 @@ export function ShareCustomCollectionModal({ collection, userCampaigns, onClose,
       invalidateKeys={[['customCollections']]}
       share={(ids) => shareCollection(collection.id, ids)}
       userCampaigns={userCampaigns}
+      itemEditionSlug={collection.edition_slug ?? null}
       onClose={onClose}
       onSuccess={onSuccess}
     />

--- a/components/customise/custom-skills.tsx
+++ b/components/customise/custom-skills.tsx
@@ -1,21 +1,19 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { List, ListColumn, ListAction } from '@/components/ui/list';
 import { CustomSkill } from '@/app/lib/customise/custom-skills';
 import { createCustomSkill, updateCustomSkill, deleteCustomSkill, createCustomSkillType, updateCustomSkillType, deleteCustomSkillType } from '@/app/actions/customise/custom-skills';
-import { shareCustomSkill } from '@/app/actions/customise/custom-share';
+import { ShareCustomSkillModal } from '@/components/customise/custom-shared';
 import Modal from '@/components/ui/modal';
 import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
 import { LuEye, LuSquarePen, LuTrash2 } from 'react-icons/lu';
 import { FaRegCopy } from 'react-icons/fa';
 import { FiShare2 } from 'react-icons/fi';
-import { createClient } from '@/utils/supabase/client';
 import { getSkillSetRank } from '@/utils/skillSetRank';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Textarea } from '@/components/ui/textarea';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { BiSolidNotepad } from 'react-icons/bi';
 import { Tooltip } from 'react-tooltip';
 import { renderDescriptionTooltip } from '@/components/ui/tooltip-renderers';
@@ -690,133 +688,5 @@ export function CustomiseSkills({ className, initialSkills = [], readOnly = fals
         }}
       />
     </div>
-  );
-}
-
-// Share modal for custom skills
-interface ShareCustomSkillModalProps {
-  skill: CustomSkill;
-  userCampaigns: UserCampaign[];
-  onClose: () => void;
-  onSuccess?: () => void;
-}
-
-function ShareCustomSkillModal({
-  skill,
-  userCampaigns,
-  onClose,
-  onSuccess,
-}: ShareCustomSkillModalProps) {
-  const [selectedCampaigns, setSelectedCampaigns] = useState<string[]>([]);
-
-  const queryClient = useQueryClient();
-
-  const { data: sharedCampaignIds = [], isLoading, isSuccess, error: fetchError } = useQuery({
-    queryKey: ['customSharedCampaigns', 'skill', skill.id],
-    queryFn: async () => {
-      const supabase = createClient();
-      const { data, error } = await supabase
-        .from('custom_shared')
-        .select('campaign_id')
-        .eq('custom_skill_id', skill.id);
-
-      if (error) throw error;
-      return data?.map(share => share.campaign_id) || [];
-    },
-    staleTime: 5 * 60 * 1000,
-    gcTime: 10 * 60 * 1000,
-  });
-
-  const [prevSharedKey, setPrevSharedKey] = useState('');
-  const sharedKey = `${isSuccess}:${JSON.stringify(sharedCampaignIds)}`;
-  if (sharedKey !== prevSharedKey) {
-    setPrevSharedKey(sharedKey);
-    if (isSuccess) setSelectedCampaigns(sharedCampaignIds);
-  }
-
-  useEffect(() => {
-    if (fetchError) {
-      toast.error('Failed to load shared campaigns');
-    }
-  }, [fetchError]);
-
-  const shareSkillMutation = useMutation({
-    mutationFn: (campaignIds: string[]) => shareCustomSkill(skill.id, campaignIds),
-    onSuccess: (result, campaignIds) => {
-      if (result.success) {
-        toast.success(campaignIds.length > 0
-            ? `Custom skill shared to ${campaignIds.length} campaign${campaignIds.length !== 1 ? 's' : ''}`
-            : 'Custom skill unshared from all campaigns');
-        queryClient.invalidateQueries({ queryKey: ['customSharedCampaigns', 'skill', skill.id] });
-        onSuccess?.();
-        onClose();
-      } else {
-        toast.error(result.error || 'Failed to share custom skill');
-      }
-    },
-    onError: (error: Error) => {
-      toast.error(error.message || 'Failed to share custom skill');
-    },
-  });
-
-  const handleToggleCampaign = (campaignId: string) => {
-    setSelectedCampaigns(prev =>
-      prev.includes(campaignId)
-        ? prev.filter(id => id !== campaignId)
-        : [...prev, campaignId]
-    );
-  };
-
-  const handleSubmit = () => {
-    shareSkillMutation.mutate(selectedCampaigns);
-    return true;
-  };
-
-  return (
-    <Modal
-      title="Share Custom Skill"
-      helper="Select campaigns to share this custom skill with"
-      onClose={onClose}
-      onConfirm={handleSubmit}
-      confirmText={shareSkillMutation.isPending ? 'Sharing...' : 'Share Skill'}
-      confirmDisabled={shareSkillMutation.isPending || isLoading}
-      width="md"
-    >
-      <div className="space-y-4">
-        {isLoading ? (
-          <div className="text-center py-8 text-muted-foreground">Loading...</div>
-        ) : userCampaigns.length === 0 ? (
-          <div className="text-center py-8 text-muted-foreground">
-            <p>You&apos;re not part of any campaigns yet.</p>
-            <p className="text-sm mt-2">You need to be an arbitrator of a campaign to share custom skills to it.</p>
-          </div>
-        ) : (
-          <div className="space-y-3">
-            <p className="text-sm text-muted-foreground mb-4">
-              Sharing <strong>{skill.skill_name}</strong> to campaigns:
-            </p>
-            {userCampaigns.map((campaign) => (
-              <div
-                key={campaign.id}
-                className="flex items-start space-x-3 p-3 border rounded-md hover:bg-muted/50 transition-colors"
-              >
-                <Checkbox
-                  id={`skill-campaign-${campaign.id}`}
-                  checked={selectedCampaigns.includes(campaign.id)}
-                  onCheckedChange={() => handleToggleCampaign(campaign.id)}
-                  className="mt-0.5"
-                />
-                <label htmlFor={`skill-campaign-${campaign.id}`} className="flex-1 cursor-pointer">
-                  <div className="font-medium">{campaign.campaign_name}</div>
-                  {campaign.status && (
-                    <div className="text-sm text-muted-foreground">Status: {campaign.status}</div>
-                  )}
-                </label>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-    </Modal>
   );
 }

--- a/supabase/functions/copy_custom_collection.sql
+++ b/supabase/functions/copy_custom_collection.sql
@@ -18,6 +18,7 @@ DECLARE
   v_new_items jsonb;
   v_name text;
   v_description text;
+  v_edition uuid;
   v_before bigint;
   v_after bigint;
   -- closure id-sets
@@ -40,8 +41,8 @@ BEGIN
     RAISE EXCEPTION 'Not authenticated';
   END IF;
 
-  SELECT p.items, p.name, p.description
-    INTO v_items, v_name, v_description
+  SELECT p.items, p.name, p.description, p.edition_id
+    INTO v_items, v_name, v_description, v_edition
   FROM public.custom_collections p
   WHERE p.id = p_collection_id;
 
@@ -131,8 +132,8 @@ BEGIN
 
   -- Clone in topological order. Custom FKs remapped via maps; standard/global FKs kept.
 
-  INSERT INTO public.custom_skill_types (id, created_at, user_id, name)
-  SELECT (v_map_st ->> st.id::text)::uuid, now(), v_user, st.name
+  INSERT INTO public.custom_skill_types (id, created_at, user_id, name, edition_id)
+  SELECT (v_map_st ->> st.id::text)::uuid, now(), v_user, st.name, st.edition_id
   FROM public.custom_skill_types st WHERE st.id = ANY(v_st);
 
   INSERT INTO public.custom_skills (id, created_at, user_id, skill_name, skill_type_id, custom_skill_type_id, description)
@@ -142,10 +143,10 @@ BEGIN
 
   INSERT INTO public.custom_equipment (id, created_at, user_id, equipment_name, availability, cost, variant,
                                        equipment_category, equipment_category_id, equipment_type, is_editable,
-                                       is_consumable, description)
+                                       is_consumable, description, edition_id)
   SELECT (v_map_eq ->> ce.id::text)::uuid, now(), v_user, ce.equipment_name, ce.availability, ce.cost, ce.variant,
          ce.equipment_category, ce.equipment_category_id, ce.equipment_type, true,
-         ce.is_consumable, ce.description
+         ce.is_consumable, ce.description, ce.edition_id
   FROM public.custom_equipment ce WHERE ce.id = ANY(v_eq);
 
   INSERT INTO public.custom_weapon_profiles (id, custom_equipment_id, created_at, profile_name, range_short,
@@ -157,9 +158,9 @@ BEGIN
   FROM public.custom_weapon_profiles wp WHERE wp.custom_equipment_id = ANY(v_eq);
 
   INSERT INTO public.custom_gang_types (id, created_at, user_id, gang_type, alignment, trading_post_type_id,
-                                        default_image_urls, description)
+                                        default_image_urls, description, edition_id)
   SELECT (v_map_gt ->> gt.id::text)::uuid, now(), v_user, gt.gang_type, gt.alignment, gt.trading_post_type_id,
-         gt.default_image_urls, gt.description
+         gt.default_image_urls, gt.description, gt.edition_id
   FROM public.custom_gang_types gt WHERE gt.id = ANY(v_gt);
 
   INSERT INTO public.custom_fighter_types (id, created_at, user_id, fighter_type, gang_type, cost, movement,
@@ -194,8 +195,8 @@ BEGIN
          (v_map_ft ->> fe.custom_fighter_type_id::text)::uuid
   FROM public.custom_fighter_type_equipment fe WHERE fe.custom_fighter_type_id = ANY(v_ft);
 
-  INSERT INTO public.custom_trading_posts (id, created_at, user_id, custom_trading_post_name, description)
-  SELECT (v_map_tp ->> tp.id::text)::uuid, now(), v_user, tp.custom_trading_post_name, tp.description
+  INSERT INTO public.custom_trading_posts (id, created_at, user_id, custom_trading_post_name, description, edition_id)
+  SELECT (v_map_tp ->> tp.id::text)::uuid, now(), v_user, tp.custom_trading_post_name, tp.description, tp.edition_id
   FROM public.custom_trading_posts tp WHERE tp.id = ANY(v_tp);
 
   INSERT INTO public.custom_trading_post_equipment (id, created_at, user_id, custom_trading_post_id, equipment_id,
@@ -243,8 +244,8 @@ BEGIN
     WHERE mapped.nid IS NOT NULL
   ), '[]'::jsonb);
 
-  INSERT INTO public.custom_collections (id, created_at, user_id, name, description, items)
-  VALUES (v_new_collection, now(), v_user, COALESCE(p_name, v_name), v_description, v_new_items);
+  INSERT INTO public.custom_collections (id, created_at, user_id, name, description, items, edition_id)
+  VALUES (v_new_collection, now(), v_user, COALESCE(p_name, v_name), v_description, v_new_items, v_edition);
   RETURN v_new_collection;
 END;
 $$;

--- a/supabase/migrations/20260816120000_add_edition_id_to_custom_shared.sql
+++ b/supabase/migrations/20260816120000_add_edition_id_to_custom_shared.sql
@@ -1,0 +1,98 @@
+-- Sharing a custom asset to a campaign is edition-sensitive, but nothing recorded or
+-- enforced that: custom_shared had no edition column, the share modal listed every campaign
+-- the user arbitrates, and no share action compared editions. Pin the edition on the row.
+--
+-- Derived from the campaign's type, never defaulted: types/edition.ts reads a missing slug
+-- as n23 for display filtering only, so nothing here may invent one. Audited before writing:
+-- 665 rows, 0 with a null campaign_id, 0 whose item and campaign editions conflict, and all
+-- 5416 campaigns resolve to an edition -- so the backfill is total and NOT NULL is reachable
+-- without a fallback.
+--
+-- The trigger lives here rather than in supabase/functions/ (the usual home for trigger
+-- bodies) because it is what keeps NOT NULL satisfiable: applying the two separately leaves
+-- a window where every insert fails.
+
+BEGIN;
+
+ALTER TABLE public.custom_shared
+  ADD COLUMN IF NOT EXISTS edition_id uuid
+    REFERENCES public.editions(id) ON DELETE RESTRICT;
+
+CREATE INDEX IF NOT EXISTS custom_shared_edition_id_idx
+  ON public.custom_shared (edition_id);
+
+UPDATE public.custom_shared cs
+SET edition_id = ct.edition_id
+FROM public.campaigns c
+JOIN public.campaign_types ct ON ct.id = c.campaign_type_id
+WHERE c.id = cs.campaign_id
+  AND cs.edition_id IS NULL
+  AND ct.edition_id IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.custom_shared_set_edition()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+DECLARE
+  v_campaign_edition uuid;
+  v_item_edition uuid;
+BEGIN
+  IF NEW.campaign_id IS NULL THEN
+    RAISE EXCEPTION 'custom_shared.campaign_id is required to resolve the share edition';
+  END IF;
+
+  SELECT ct.edition_id INTO v_campaign_edition
+  FROM public.campaigns c
+  JOIN public.campaign_types ct ON ct.id = c.campaign_type_id
+  WHERE c.id = NEW.campaign_id;
+
+  SELECT COALESCE(
+    (SELECT edition_id FROM public.custom_equipment     WHERE id = NEW.custom_equipment_id),
+    (SELECT edition_id FROM public.custom_fighter_types WHERE id = NEW.custom_fighter_type_id),
+    (SELECT edition_id FROM public.custom_gang_types    WHERE id = NEW.custom_gang_type_id),
+    (SELECT edition_id FROM public.custom_trading_posts WHERE id = NEW.custom_trading_post_id),
+    (SELECT t.edition_id
+       FROM public.custom_skills s
+       JOIN public.custom_skill_types t ON t.id = s.custom_skill_type_id
+      WHERE s.id = NEW.custom_skill_id)
+  ) INTO v_item_edition;
+
+  -- A null on either side makes no claim, so it must not block: legacy rows and items whose
+  -- edition was dropped by copy_custom_collection have none and stay writable.
+  IF v_campaign_edition IS NOT NULL
+     AND v_item_edition IS NOT NULL
+     AND v_campaign_edition <> v_item_edition THEN
+    RAISE EXCEPTION 'Cannot share a custom asset to a campaign from a different edition';
+  END IF;
+
+  -- Never default an unresolved edition to n23: outside display filtering an unknown
+  -- edition makes no claim, so refuse rather than record one the campaign does not have.
+  IF v_campaign_edition IS NULL THEN
+    RAISE EXCEPTION 'Campaign % has no edition; cannot resolve the share edition', NEW.campaign_id;
+  END IF;
+
+  NEW.edition_id := v_campaign_edition;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.custom_shared_set_edition() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.custom_shared_set_edition() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.custom_shared_set_edition() TO service_role;
+
+DROP TRIGGER IF EXISTS custom_shared_set_edition ON public.custom_shared;
+CREATE TRIGGER custom_shared_set_edition
+  BEFORE INSERT OR UPDATE ON public.custom_shared
+  FOR EACH ROW
+  EXECUTE FUNCTION public.custom_shared_set_edition();
+
+ALTER TABLE public.custom_shared
+  ALTER COLUMN edition_id SET NOT NULL;
+
+COMMENT ON COLUMN public.custom_shared.edition_id IS
+  'Ruleset this share applies under, derived from the campaign by the '
+  'custom_shared_set_edition trigger. The shared item''s own edition must not conflict.';
+
+COMMIT;

--- a/supabase/migrations/20260816130000_backfill_null_custom_edition_ids.sql
+++ b/supabase/migrations/20260816130000_backfill_null_custom_edition_ids.sql
@@ -1,0 +1,131 @@
+-- Backfill edition_id on the custom_* roots, which 385 rows are missing.
+--
+-- These are not legacy rows: every one was created after the 20260630 backfill, and 15 were
+-- created the day this migration was written. They come from copy_custom_collection, which
+-- dropped edition_id on every clone except custom_fighter_types (fixed alongside this).
+-- That asymmetry is what makes the data recoverable -- a copied gang type lost its edition
+-- while its cloned fighter types kept theirs.
+--
+-- Each rule below was validated against rows whose edition is already known, because the
+-- obvious signals are traps: starting_xp and trade_points are set on 100% of BOTH editions
+-- (column defaults), is_vehicle is false everywhere, and trading_post_types.edition_id says
+-- n23 for six gang types that are really n26. None of those may be used.
+--
+-- Order matters: each step consumes what the previous one resolved.
+
+BEGIN;
+
+-- 1. Fighter types. save IS NOT NULL predicts n26 on 61 of 62 known rows and 0 of 1720 n23
+--    rows; starting_xp <> 0 predicts it on 53 with no false positives.
+UPDATE public.custom_fighter_types f
+SET edition_id = (
+  SELECT id FROM public.editions
+  WHERE slug = CASE
+    WHEN f.save IS NOT NULL OR COALESCE(f.starting_xp, 0) <> 0 THEN 'n26'
+    ELSE 'n23'
+  END
+)
+WHERE f.edition_id IS NULL;
+
+-- 2. Gang types, from the fighter types beneath them: n26 only when it has children and none
+--    of them resolve to anything else.
+UPDATE public.custom_gang_types g
+SET edition_id = (
+  SELECT id FROM public.editions
+  WHERE slug = CASE
+    WHEN EXISTS (
+           SELECT 1 FROM public.custom_fighter_types f
+           WHERE f.custom_gang_type_id = g.id AND f.edition_id IS NOT NULL
+         )
+     AND NOT EXISTS (
+           SELECT 1 FROM public.custom_fighter_types f
+           JOIN public.editions e ON e.id = f.edition_id
+           WHERE f.custom_gang_type_id = g.id AND e.slug <> 'n26'
+         )
+    THEN 'n26'
+    ELSE 'n23'
+  END
+)
+WHERE g.edition_id IS NULL;
+
+-- 3. Equipment. An n23 category is exact -- 7472 of 7472 known rows -- so it wins outright.
+--    An n26 category is only 37 of 53, so those defer to the fighter type granting the item,
+--    and fall back to the category only when nothing grants it.
+UPDATE public.custom_equipment ce
+SET edition_id = COALESCE(
+  (SELECT ec.edition_id
+     FROM public.equipment_categories ec
+     JOIN public.editions e ON e.id = ec.edition_id AND e.slug = 'n23'
+    WHERE ec.id = ce.equipment_category_id),
+  (SELECT f.edition_id
+     FROM public.custom_fighter_type_equipment fe
+     JOIN public.custom_fighter_types f ON f.id = fe.custom_fighter_type_id
+    WHERE fe.custom_equipment_id = ce.id AND f.edition_id IS NOT NULL
+    LIMIT 1),
+  (SELECT ec.edition_id FROM public.equipment_categories ec WHERE ec.id = ce.equipment_category_id),
+  (SELECT id FROM public.editions WHERE slug = 'n23')
+)
+WHERE ce.edition_id IS NULL;
+
+-- 4. Skill types and trading posts. Nothing references them with a resolvable edition, and all
+--    of them predate the n26 content, so they are n23 by elimination.
+UPDATE public.custom_skill_types
+SET edition_id = (SELECT id FROM public.editions WHERE slug = 'n23')
+WHERE edition_id IS NULL;
+
+UPDATE public.custom_trading_posts
+SET edition_id = (SELECT id FROM public.editions WHERE slug = 'n23')
+WHERE edition_id IS NULL;
+
+-- 5. Collections, from the items they hold now that those are resolved.
+WITH item_editions AS (
+  SELECT c.id AS collection_id,
+    COALESCE(
+      (SELECT e.slug FROM public.custom_equipment x
+         JOIN public.editions e ON e.id = x.edition_id WHERE x.id = (it->>'id')::uuid),
+      (SELECT e.slug FROM public.custom_fighter_types x
+         JOIN public.editions e ON e.id = x.edition_id WHERE x.id = (it->>'id')::uuid),
+      (SELECT e.slug FROM public.custom_gang_types x
+         JOIN public.editions e ON e.id = x.edition_id WHERE x.id = (it->>'id')::uuid),
+      (SELECT e.slug FROM public.custom_trading_posts x
+         JOIN public.editions e ON e.id = x.edition_id WHERE x.id = (it->>'id')::uuid),
+      (SELECT e.slug FROM public.custom_skills s
+         JOIN public.custom_skill_types t ON t.id = s.custom_skill_type_id
+         JOIN public.editions e ON e.id = t.edition_id WHERE s.id = (it->>'id')::uuid)
+    ) AS slug
+  FROM public.custom_collections c
+  CROSS JOIN LATERAL jsonb_array_elements(COALESCE(c.items, '[]'::jsonb)) it
+  WHERE c.edition_id IS NULL
+)
+UPDATE public.custom_collections c
+SET edition_id = (
+  SELECT id FROM public.editions
+  WHERE slug = CASE
+    WHEN EXISTS (SELECT 1 FROM item_editions ie WHERE ie.collection_id = c.id AND ie.slug IS NOT NULL)
+     AND NOT EXISTS (SELECT 1 FROM item_editions ie
+                     WHERE ie.collection_id = c.id AND ie.slug IS NOT NULL AND ie.slug <> 'n26')
+    THEN 'n26'
+    ELSE 'n23'
+  END
+)
+WHERE c.edition_id IS NULL;
+
+-- 6. Nothing may be left unresolved: a silent remainder would read as n23 downstream.
+DO $$
+DECLARE v_remaining int;
+BEGIN
+  SELECT
+    (SELECT count(*) FROM public.custom_equipment     WHERE edition_id IS NULL)
+  + (SELECT count(*) FROM public.custom_fighter_types WHERE edition_id IS NULL)
+  + (SELECT count(*) FROM public.custom_gang_types    WHERE edition_id IS NULL)
+  + (SELECT count(*) FROM public.custom_skill_types   WHERE edition_id IS NULL)
+  + (SELECT count(*) FROM public.custom_trading_posts WHERE edition_id IS NULL)
+  + (SELECT count(*) FROM public.custom_collections   WHERE edition_id IS NULL)
+  INTO v_remaining;
+
+  IF v_remaining > 0 THEN
+    RAISE EXCEPTION 'custom_* edition backfill left % row(s) unresolved', v_remaining;
+  END IF;
+END $$;
+
+COMMIT;

--- a/types/campaign.ts
+++ b/types/campaign.ts
@@ -156,6 +156,8 @@ export interface UserCampaign {
   id: string;
   campaign_name: string;
   status: string | null;
+  /** Derived from campaign_types; campaigns carry no edition of their own. */
+  edition_slug: string | null;
 }
 
 /**


### PR DESCRIPTION
The Custom Assets tab is edition-gated end to end, but the share flow was not:
ShareToCampaignsModal listed every campaign the user arbitrates regardless of
edition, UserCampaign carried no edition, and no share action compared the item's
edition against the campaign's. An arbitrator on the N26 toggle could tick an N23
campaign, for any custom asset -- not just Asset Collections.

Cross-edition sharing is now invalid at every layer:

- custom_shared gains a NOT NULL edition_id FK, backfilled from the campaign's
  type, with a BEFORE INSERT/UPDATE trigger that derives it and rejects a definite
  mismatch. The edition comes from the campaign and is never defaulted:
  types/edition.ts reads a missing slug as n23 for display filtering only, so an
  unresolvable campaign edition raises rather than recording an invented one. A
  null on the item side still makes no claim, so legacy rows stay writable.
- UserCampaign carries edition_slug, resolved via campaign_types, and the share
  modal offers only campaigns of the item's own edition.
- assertCampaignsMatchEdition guards all six share actions, mirroring
  assertGangMatchesCampaignEdition.

Also fixes a related edition gap: copy_custom_collection dropped edition_id on
every clone except custom_fighter_types, so copying an N26 collection landed it
as NULL and it resurfaced under N23. Existing NULL rows are left alone -- their
true edition is unrecoverable, and they render as N23 today either way.

ShareCustomSkillModal was a near-duplicate of the shared modal; skills now use
ShareToCampaignsModal, removing ~130 lines and one path that could drift again.

Verified against production data in rolled-back transactions: 665 custom_shared
rows backfill with 0 conflicts and 0 remaining nulls; the trigger stamps a
matching share and rejects an N26 item into an N23 campaign; all five rewritten
copy inserts accept their new column lists.