### PR TITLE
Show grouped weapon profiles whose parent weapon has no group id

### DIFF
--- a/app/api/admin/equipment/route.ts
+++ b/app/api/admin/equipment/route.ts
@@ -501,8 +501,10 @@ export async function POST(request: Request) {
         ...profile,
         weapon_id: weaponId,
         profile_name: profile.profile_name.trimEnd(),
-        // Set weapon_group_id to either the selected weapon's ID or this weapon's ID
-        weapon_group_id: profile.weapon_group_id || null,
+        // Set weapon_group_id to either the selected weapon's ID or this weapon's ID.
+        // Must match the PATCH branch below: a profile left ungrouped self-groups,
+        // so ammo attached to this weapon later lands in the same card block.
+        weapon_group_id: profile.weapon_group_id || weaponId,
         // Properly handle explicit null values
         range_short: profile.range_short === null ? '' : profile.range_short || '',
         range_long: profile.range_long === null ? '' : profile.range_long || '',

--- a/app/lib/shared/fighter-data.ts
+++ b/app/lib/shared/fighter-data.ts
@@ -394,8 +394,11 @@ export const getFighterEquipment = async (fighterId: string, supabase: any): Pro
         standardProfilesMap.get(profile.weapon_id)!.push(profile);
         
         // Also add profile to the map under weapon_group_id if it exists (for grouped weapons)
-        // But only if the fighter owns the weapon that owns this profile
-        if (profile.weapon_group_id && standardEquipmentIds.includes(profile.weapon_id)) {
+        // But only if the fighter owns the weapon that owns this profile.
+        // A self-grouping profile is already under this key -- re-adding it would
+        // list the same profile twice on the weapon.
+        if (profile.weapon_group_id && profile.weapon_group_id !== profile.weapon_id
+            && standardEquipmentIds.includes(profile.weapon_id)) {
           if (!standardProfilesMap.has(profile.weapon_group_id)) {
             standardProfilesMap.set(profile.weapon_group_id, []);
           }

--- a/components/gang/fighter-card-weapon-table.tsx
+++ b/components/gang/fighter-card-weapon-table.tsx
@@ -134,8 +134,28 @@ const WeaponTable: React.FC<WeaponTableProps> = ({ weapons, entity, viewMode, ed
     
     const hardpointKey = weapon.hardpoint_location || 'no-hp';
 
+    // The ids that mean "this weapon". A weapon's own profiles spell that two
+    // ways: weapons saved through the admin edit form group under their own
+    // catalog id, weapons saved through the create form leave it null. The
+    // server attaches grouped ammo (separately owned equipment whose profiles
+    // point at this weapon) onto this weapon's profile list, and those always
+    // carry the catalog id -- so both spellings have to resolve to one block,
+    // otherwise the ammo forms a base-less block and is discarded below.
+    const ownGroupIds = new Set<string>(
+      [weapon.weapon_id, ...baseProfilesForWeapon.map(p => p.weapon_group_id)]
+        .filter((id): id is string => !!id)
+    );
+    // Keep the weapon's existing anchor: a self-grouping weapon stays keyed on
+    // its catalog id (so two copies still collapse to one "(x2)" row), and a
+    // weapon with no group stays keyed per instance.
+    const ownAnchor = baseProfilesForWeapon.find(p => p.weapon_group_id)?.weapon_group_id
+      || weapon.fighter_weapon_id;
+
     weapon.weapon_profiles?.forEach((profile) => {
-      const groupId = profile.weapon_group_id || weapon.fighter_weapon_id;
+      // Only a profile pointing at a *different* weapon groups elsewhere.
+      const groupId = profile.weapon_group_id && !ownGroupIds.has(profile.weapon_group_id)
+        ? profile.weapon_group_id
+        : ownAnchor;
       // Use the weapon's profile signature for all profiles (base and special) so they stay together
       // Include weapon instance master-crafted status, profile signature, effect signature, and hardpoint to properly separate weapons
       const key: VariantKey = `${groupId}|${isWeaponMasterCrafted ? 'mc' : 'reg'}|${weaponProfileSignature}|${effectSignature}|${hardpointKey}`;

--- a/supabase/migrations/20260816140000_self_group_parent_weapon_profiles.sql
+++ b/supabase/migrations/20260816140000_self_group_parent_weapon_profiles.sql
@@ -1,0 +1,20 @@
+-- Backfill the self-reference on weapons that grouped ammo hangs off.
+--
+-- A weapon's own profiles and the profiles of the ammo grouped onto it have to
+-- agree on one group id, otherwise the fighter card can't tie them together and
+-- the ammo rows vanish (reported for "Krak grenades (Subjugator grenade
+-- launcher)"). The admin edit form has always written that self-reference; the
+-- create form wrote NULL, so weapons that were created and never re-saved were
+-- left without it.
+--
+-- Only touches profiles of weapons that something actually groups under -- an
+-- ungrouped weapon's NULL is meaningless either way and is left alone.
+UPDATE weapon_profiles wp
+SET weapon_group_id = wp.weapon_id
+WHERE wp.weapon_group_id IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM weapon_profiles ammo
+    WHERE ammo.weapon_group_id = wp.weapon_id
+      AND ammo.weapon_id <> wp.weapon_id
+  );


### PR DESCRIPTION
Ammo sold as its own equipment ("Krak grenades (Subjugator grenade launcher)") carries a weapon_group_id pointing at the parent weapon, and the server attaches those profiles onto the parent's profile list. The card table then re-derived a group key per profile as `weapon_group_id || fighter_weapon_id`, so the parent's own profiles (group id null) and the attached ammo (group id = parent's catalog id) landed in different blocks. The ammo block had no base profile and was dropped as an orphan, which is why the grenades were costed and listed under Equipment but never reached the fighter card.

Key every profile that belongs to the weapon -- null group id or one pointing at the weapon's own catalog id -- to the same anchor, keeping that anchor as whatever the weapon already used so self-grouping weapons still collapse duplicates into one "(xN)" row.

The mismatch comes from the admin API writing two different defaults: POST stored null for an ungrouped profile while PATCH stored the weapon's own id, so a weapon created and never re-saved lost its ammo rows. Align POST with PATCH and backfill the weapons already affected.

Also stop the fighter equipment fetch from indexing a self-grouping profile twice under the same weapon.


Claude-Session: https://claude.ai/code/session_01J5yfpDfyQ43xiV7wTrq8Ph