### PR TITLE
Store a weapon's own id on its ungrouped weapon profiles

### DIFF
--- a/app/api/admin/equipment/route.ts
+++ b/app/api/admin/equipment/route.ts
@@ -502,7 +502,7 @@ export async function POST(request: Request) {
         weapon_id: weaponId,
         profile_name: profile.profile_name.trimEnd(),
         // Set weapon_group_id to either the selected weapon's ID or this weapon's ID
-        weapon_group_id: profile.weapon_group_id || null,
+        weapon_group_id: profile.weapon_group_id || weaponId,
         // Properly handle explicit null values
         range_short: profile.range_short === null ? '' : profile.range_short || '',
         range_long: profile.range_long === null ? '' : profile.range_long || '',

--- a/app/lib/shared/fighter-data.ts
+++ b/app/lib/shared/fighter-data.ts
@@ -395,7 +395,8 @@ export const getFighterEquipment = async (fighterId: string, supabase: any): Pro
         
         // Also add profile to the map under weapon_group_id if it exists (for grouped weapons)
         // But only if the fighter owns the weapon that owns this profile
-        if (profile.weapon_group_id && standardEquipmentIds.includes(profile.weapon_id)) {
+        if (profile.weapon_group_id && profile.weapon_group_id !== profile.weapon_id
+            && standardEquipmentIds.includes(profile.weapon_id)) {
           if (!standardProfilesMap.has(profile.weapon_group_id)) {
             standardProfilesMap.set(profile.weapon_group_id, []);
           }

--- a/components/admin/admin-edit-equipment.tsx
+++ b/components/admin/admin-edit-equipment.tsx
@@ -1830,7 +1830,11 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                             Attach this profile to an existing weapon, or leave it as is to use with this weapon.
                           </p>
                           <select
-                            value={profile.weapon_group_id || ''}
+                            value={
+                              profile.weapon_group_id && profile.weapon_group_id !== selectedEquipmentId
+                                ? profile.weapon_group_id
+                                : ''
+                            }
                             onChange={(e) => handleProfileChange(index, 'weapon_group_id', e.target.value)}
                             className="w-full p-2 border rounded-md"
                             disabled={!selectedEquipmentId}


### PR DESCRIPTION
Ammo sold as its own equipment ("Krak grenades (Subjugator grenade
launcher)") carries weapon_group_id pointing at the parent weapon, and
the fighter card groups a weapon's rows by that column. The parent's own
profiles must therefore carry the parent's id as well, or the two end up
in different groups and the ammo rows -- having no base profile of their
own -- are discarded before the card renders. The grenades were costed
and listed under Equipment but appeared nowhere on the card.

The admin API wrote two different defaults for an ungrouped profile:
PATCH stored the weapon's own id, POST stored null. A weapon was only
correct once it had been re-saved through the edit form, and four
weapons had been created and never edited: Subjugator grenade launcher,
Assault grenade launcher*, Grenade launcher array and Twin grenade
launcher. The create modal cannot supply the id itself -- the row does
not have one at submit time -- so the default belongs on the server.

Align POST with PATCH and backfill the nine profile rows already stored
without it, scoped to weapons something actually groups onto so an
ungrouped weapon's inert null is left alone.

The edit modal's Weapon Group select excludes the weapon being edited
from its options, so a self-referencing profile matched no option and
rendered blank instead of "Use This Weapon (Default)". Show it as the
default it is.

Also stop the fighter equipment fetch indexing a profile twice under the
same weapon when its group id is the weapon's own.