### PR TITLE
Carry edition_id when cloning a shared custom gang type

### DIFF
--- a/supabase/migrations/20260817120000_backfill_custom_gang_type_edition_from_children.sql
+++ b/supabase/migrations/20260817120000_backfill_custom_gang_type_edition_from_children.sql
@@ -1,0 +1,23 @@
+-- Repair custom gang types whose edition_id was dropped by duplicateCustomGangType (fixed
+-- alongside this). Same defect as 20260816130000, one layer over, and recoverable the same way:
+-- the sibling custom_fighter_types clone kept its edition, so rule 2 of that migration -- reused
+-- unchanged below -- reads the parent's edition back off its children.
+
+UPDATE public.custom_gang_types g
+SET edition_id = (
+  SELECT id FROM public.editions
+  WHERE slug = CASE
+    WHEN EXISTS (
+           SELECT 1 FROM public.custom_fighter_types f
+           WHERE f.custom_gang_type_id = g.id AND f.edition_id IS NOT NULL
+         )
+     AND NOT EXISTS (
+           SELECT 1 FROM public.custom_fighter_types f
+           JOIN public.editions e ON e.id = f.edition_id
+           WHERE f.custom_gang_type_id = g.id AND e.slug <> 'n26'
+         )
+    THEN 'n26'
+    ELSE 'n23'
+  END
+)
+WHERE g.edition_id IS NULL;

--- a/utils/duplicate-custom-gang-type.ts
+++ b/utils/duplicate-custom-gang-type.ts
@@ -32,14 +32,14 @@ export async function duplicateCustomGangType(
     throw new Error('Source custom gang type not found');
   }
 
+  // Spread, don't enumerate: a dropped edition_id reads as n23 rather than erroring.
+  const { id: _cgtId, created_at: _cgtCa, updated_at: _cgtUa, user_id: _cgtUid, ...cgtData } = sourceCustomGangType;
+
   const { data: newCgt, error: newCgtError } = await supabase
     .from('custom_gang_types')
     .insert({
+      ...cgtData,
       user_id: targetUserId,
-      gang_type: sourceCustomGangType.gang_type,
-      alignment: sourceCustomGangType.alignment,
-      trading_post_type_id: sourceCustomGangType.trading_post_type_id,
-      default_image_urls: sourceCustomGangType.default_image_urls,
     })
     .select('id')
     .single();
@@ -107,10 +107,12 @@ export async function duplicateCustomGangType(
 
       if (sourceSkillTypes) {
         for (const st of sourceSkillTypes) {
+          const { id: _stId, created_at: _stCa, updated_at: _stUa, user_id: _stUid, ...stData } = st;
+
           const { data: newSt, error: newStError } = await supabase
             .from('custom_skill_types')
             .insert({
-              name: st.name,
+              ...stData,
               user_id: targetUserId,
             })
             .select('id')


### PR DESCRIPTION
A user copied an N26 gang and got an N23 one back. The gang used a custom gang type.

Copying an *official* gang is fine — `copy-gang.ts` carries `gang_type_id` across and the edition is derived from it. The break is one branch: when the custom gang type belongs to another user, the copy clones the whole asset tree via `utils/duplicate-custom-gang-type.ts` so it survives the owner deleting their originals. That `custom_gang_types` insert enumerated its columns and omitted `edition_id`, so the clone landed null. Gangs have no edition of their own, and a null slug is read as n23 rather than raising — so the copy came back N23, filtered under the N23 toggle on the home page with every N26 capability switched off. `createGang` shares the helper, so building a gang on someone else's shared custom type had the same result.

This is `20260816130000`'s defect one layer over. That migration fixed `copy_custom_collection`, "which dropped edition_id on every clone except custom_fighter_types", and backfilled the 385 rows it had produced. The TypeScript clone has the identical asymmetry for the identical reason — the `custom_fighter_types` insert beside it spreads its row, the gang-type insert enumerated. `custom_skill_types` dropped `edition_id` the same way.

## Changes

- `utils/duplicate-custom-gang-type.ts` — both inserts spread and override, matching the sibling clones, so a column added to either table is carried instead of silently disappearing. Also restores `description`, which the gang-type insert was dropping too.
- `supabase/migrations/20260817120000_backfill_custom_gang_type_edition_from_children.sql` — recovers the parent's edition from the children that kept theirs, reusing rule 2 of the earlier backfill unchanged. `edition_id` stays nullable.

## Verification

`tsc --noEmit` and eslint clean.

One row is affected in production: a copy of an n26 gang type whose fighter types are all n26, with no gang attached — the reporter appears to have deleted the bad copy. Ran the migration's derivation as a plain `SELECT` rather than applying it; it resolves that row to n26. No gang currently resolves to a null edition.

Copying an official gang, or a custom gang type you own yourself, never reached this helper and was never affected.

## Noted, not fixed

- `app/actions/chem-alchemy.ts:56-69` inserts `custom_equipment` with no `edition_id` — the source of all 17 null-edition equipment rows in production. Same bug class, left for a follow-up.
- `gang_types` is unique on `(gang_type_id, edition_id)`, so one `gang_type_id` could exist in both editions and make `gangEditionJoin`'s "first row wins" nondeterministic. Zero such duplicates today.