### PR TITLE
Show skill acquisition types for every N26 subtype and result

### DIFF
--- a/components/fighter/fighter-advancement-list.tsx
+++ b/components/fighter/fighter-advancement-list.tsx
@@ -1854,13 +1854,14 @@ export function AdvancementModal({
     );
     const allTypes = sample?.available_acquisition_types ?? [];
     if (allTypes.length === 0) return [];
+    // Only the Skill Set's access level narrows this list, as in N23. An N26 result is
+    // deliberately not a second filter: the table is an upper bound the player chooses
+    // from, not a restriction (see N26_ADVANCEMENT_TABLE), and intersecting the two left
+    // valid combinations with no option at all. The result still prices the advancement,
+    // so the N23 per-type prices stay hidden below.
     const allowedIds = new Set(getAllowedAcquisitionTypeIds(selectedSkillSetAccess, allTypes));
-    // An N26 result names the acquisition types it may award, so the row narrows
-    // the list; it prices them itself, so the N23 per-type prices are hidden.
-    const rowIds = n26SelectedRow?.skillAcquisitionTypeIds;
     return allTypes
       .filter((t) => allowedIds.has(t.type_id))
-      .filter((t) => !rowIds || rowIds.includes(t.type_id))
       .sort((a, b) => a.xp_cost - b.xp_cost)
       .map((t) => {
         const label = isCumulativeXp
@@ -1873,7 +1874,6 @@ export function AdvancementModal({
     selectedCategory,
     availableAdvancements,
     selectedSkillSetAccess,
-    n26SelectedRow,
     isCumulativeXp
   ]);
 

--- a/supabase/migrations/20260817130000_get_available_skills_n26_acquisition_types.sql
+++ b/supabase/migrations/20260817130000_get_available_skills_n26_acquisition_types.sql
@@ -1,3 +1,14 @@
+-- N26 skill advancements: stop gating the acquisition types by fighter subtype.
+--
+-- The subtype list gating `available_acquisition_types` is an N23 rule about who
+-- pays these prices. N26 applies one Advancement table to every subtype and prices
+-- the result itself, so the gate only had the effect of returning '[]' for every
+-- subtype outside the list — Pets, Gangers, Hangers-on, vehicles — leaving the
+-- Advancement modal with no acquisition type to offer and therefore no skill list.
+--
+-- The edition is resolved from the fighter's gang as in
+-- get_fighter_available_advancements. The N23 array is unchanged.
+
 CREATE OR REPLACE FUNCTION public.get_available_skills(
     fighter_id UUID
 )


### PR DESCRIPTION
Adding a skill advancement to a Pet showed no acquisition picker and no skill list after choosing a Skill Set. Two independent causes.

get_available_skills gated available_acquisition_types on an N23 subtype list, returning '[]' for every subtype outside it. N26 applies one Advancement table to every subtype and prices the result itself, so the gate only stopped Pets, Gangers, Hangers-on and vehicles from taking any skill at all. Resolve the gang's edition and skip the N23 gate there.

The modal also intersected the Skill Set's access level with the selected N26 result's acquisition types, which is empty for valid combinations: a "new Secondary skill" result against a Primary set, and any result against an Allowed or Legendary Name set. The table is an upper bound the player chooses from rather than a restriction, and it is not enforced elsewhere, so drop that second filter and keep the access-level one.


Claude-Session: https://claude.ai/code/session_01DWPt4JJGnQXV6hxfVZu91v