### PR TITLE
Show N26 XP ladder on the stats table and track Available advancements

### DIFF
--- a/components/equipment/equipment-tooltip.tsx
+++ b/components/equipment/equipment-tooltip.tsx
@@ -4,29 +4,7 @@ import React from 'react';
 import { Tooltip, type TooltipRefProps } from 'react-tooltip';
 import { Equipment, WeaponProfile } from '@/types/equipment';
 import { hasLethalityStatline } from '@/types/edition';
-
-const COARSE_MQ = '(hover: none) and (pointer: coarse)';
-let _coarseMql: MediaQueryList | null = null;
-const getCoarseMql = () => {
-  if (typeof window === 'undefined') return null;
-  return (_coarseMql ??= window.matchMedia(COARSE_MQ));
-};
-
-const subscribeCoarsePointer = (onStoreChange: () => void) => {
-  const mql = getCoarseMql();
-  mql?.addEventListener('change', onStoreChange);
-  return () => mql?.removeEventListener('change', onStoreChange);
-};
-const getCoarsePointerSnapshot = () => getCoarseMql()?.matches ?? false;
-const getCoarsePointerServerSnapshot = () => false;
-
-function useCoarsePointer() {
-  return React.useSyncExternalStore(
-    subscribeCoarsePointer,
-    getCoarsePointerSnapshot,
-    getCoarsePointerServerSnapshot,
-  );
-}
+import { useCoarsePointer } from '@/hooks/use-coarse-pointer';
 
 export interface EquipmentTooltipOptions {
   equipmentListType?: 'fighters-list' | 'fighters-tradingpost' | 'unrestricted';

--- a/components/fighter/fighter-advancement-list.tsx
+++ b/components/fighter/fighter-advancement-list.tsx
@@ -51,7 +51,7 @@ import {
 interface AdvancementModalProps {
   fighterId: string;
   currentXp: number;
-  fighterStartingXp?: number | null;
+  openAdvancements: number;
   editionSlug?: string | null;
   fighterSubtypes: string[];
   advancements: Array<FighterEffectType>;
@@ -478,7 +478,7 @@ type ChampionPendingPromotion = FighterPromotionResult;
 export function AdvancementModal({
   fighterId,
   currentXp,
-  fighterStartingXp = null,
+  openAdvancements,
   editionSlug = null,
   fighterSubtypes,
   advancements,
@@ -536,20 +536,6 @@ export function AdvancementModal({
   // one table and no XP price is ever paid. The N23 subtype-specific tables and
   // escalating costs do not apply.
   const isCumulativeXp = hasCumulativeXp(editionSlug);
-
-  const advancementCount = useMemo(() => {
-    const advanceSkillCount = Object.values(skills).filter(
-      (skill) => skill && (skill as { is_advance?: boolean }).is_advance
-    ).length;
-    return advancements.length + advanceSkillCount;
-  }, [advancements, skills]);
-
-  const openAdvancements = openAdvancementsFor(
-    editionSlug,
-    fighterStartingXp,
-    currentXp,
-    advancementCount,
-  );
 
   /**
    * The characteristic list is derived from the RPC's map, not fetched and stored:
@@ -3511,7 +3497,7 @@ export function AdvancementsList({
         <AdvancementModal
           fighterId={fighterId}
           currentXp={fighterXp}
-          fighterStartingXp={fighterStartingXp}
+          openAdvancements={openAdvancements}
           editionSlug={editionSlug}
           fighterSubtypes={fighterSubtypes}
           advancements={advancements}

--- a/components/fighter/fighter-advancement-list.tsx
+++ b/components/fighter/fighter-advancement-list.tsx
@@ -9,7 +9,7 @@ import { TypeSpecificData } from '@/types/fighter-effect';
 import { createClient } from '@/utils/supabase/client';
 import { getSkillSetRank } from "@/utils/skillSetRank";
 import { characteristicRank } from "@/utils/characteristicRank";
-import { nextTierStartFor, openAdvancementsFor } from "@/utils/advancementRanks";
+import { openAdvancementsFor } from "@/utils/advancementRanks";
 import { List } from "@/components/ui/list";
 import { UserPermissions } from '@/types/user-permissions';
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -51,6 +51,7 @@ import {
 interface AdvancementModalProps {
   fighterId: string;
   currentXp: number;
+  fighterStartingXp?: number | null;
   editionSlug?: string | null;
   fighterSubtypes: string[];
   advancements: Array<FighterEffectType>;
@@ -477,6 +478,7 @@ type ChampionPendingPromotion = FighterPromotionResult;
 export function AdvancementModal({
   fighterId,
   currentXp,
+  fighterStartingXp = null,
   editionSlug = null,
   fighterSubtypes,
   advancements,
@@ -534,6 +536,20 @@ export function AdvancementModal({
   // one table and no XP price is ever paid. The N23 subtype-specific tables and
   // escalating costs do not apply.
   const isCumulativeXp = hasCumulativeXp(editionSlug);
+
+  const advancementCount = useMemo(() => {
+    const advanceSkillCount = Object.values(skills).filter(
+      (skill) => skill && (skill as { is_advance?: boolean }).is_advance
+    ).length;
+    return advancements.length + advanceSkillCount;
+  }, [advancements, skills]);
+
+  const openAdvancements = openAdvancementsFor(
+    editionSlug,
+    fighterStartingXp,
+    currentXp,
+    advancementCount,
+  );
 
   /**
    * The characteristic list is derived from the RPC's map, not fetched and stored:
@@ -2296,8 +2312,16 @@ export function AdvancementModal({
         <div className="border-b px-[10px] py-2 flex justify-between items-center">
           <h3 className="text-xl md:text-2xl font-bold text-foreground">Advancements</h3>
           <div className="flex items-center">
-            <span className="mr-2 text-sm text-muted-foreground">XP</span>
-            <span className="bg-green-500 text-white text-sm rounded-full px-2 py-1">{currentXp}</span>
+            {isCumulativeXp ? (
+              <span className="align-middle inline-flex items-center rounded-full bg-green-500 px-2 py-0.5 text-xs font-semibold text-white">
+                Available: {openAdvancements}
+              </span>
+            ) : (
+              <>
+                <span className="mr-2 text-sm text-muted-foreground">XP</span>
+                <span className="bg-green-500 text-white text-sm rounded-full px-2 py-1">{currentXp}</span>
+              </>
+            )}
             <button
               onClick={onClose}
               className="ml-3 text-muted-foreground hover:text-muted-foreground text-xl"
@@ -2930,7 +2954,7 @@ export function AdvancementModal({
               }`}
                 disabled={buyAdvancementDisabled}
               >
-                Buy Advancement
+                Confirm
               </Button>
             </div>
           </div>
@@ -3368,10 +3392,6 @@ export function AdvancementsList({
   }, [advancements, advancementSkills]);
 
   const advancementCount = advancements.length + advancementSkills.length;
-  // Advancements are earned by XP rank rather than bought, so the header tracks
-  // progress toward the next tier instead of counting what has been taken.
-  const nextTierStart = nextTierStartFor(editionSlug, fighterXp);
-  const xpProgress = `${fighterXp}/${nextTierStart ?? '–'}`;
 
   // advancementCount is the taken count: effects plus is_advance skills.
   const openAdvancements = openAdvancementsFor(
@@ -3386,25 +3406,19 @@ export function AdvancementsList({
       <span className="sm:hidden">Advanc.</span>
       <span className="hidden sm:inline">Advancements</span>
       {isCumulativeXp ? (
-        <>
-          {' '}
-          <span className="text-sm sm:hidden">({xpProgress})</span>
-          <span className="text-sm hidden sm:inline">(XP: {xpProgress})</span>
-          {openAdvancements > 0 && (
-            <>
-              {' '}
-              <span className="align-middle inline-flex items-center rounded-full bg-amber-500 px-2 py-0.5 text-xs font-semibold text-white">
-                {openAdvancements}
-              </span>
-            </>
-          )}
-        </>
+        openAdvancements > 0 ? (
+          <span className="ml-auto inline-flex items-center gap-1 mr-1 whitespace-nowrap">
+            <span className="align-middle inline-flex items-center rounded-full bg-green-500 px-2 py-0.5 text-xs font-semibold text-white">
+              <span className="sm:hidden">Avail: {openAdvancements}</span>
+              <span className="hidden sm:inline">Available: {openAdvancements}</span>
+            </span>
+          </span>
+        ) : null
       ) : advancementCount > 0 ? (
-        <>
-          {' '}
+        <span className="ml-auto whitespace-nowrap">
           <span className="text-sm sm:hidden">({advancementCount})</span>
           <span className="text-sm hidden sm:inline">(Adv. count: {advancementCount})</span>
-        </>
+        </span>
       ) : null}
     </>
   );
@@ -3413,6 +3427,7 @@ export function AdvancementsList({
     <>
       <List
         title={title}
+        titleClassName="flex flex-1 items-center min-w-0"
         items={transformedAdvancements}
         columns={isCumulativeXp ? [
           {
@@ -3496,6 +3511,7 @@ export function AdvancementsList({
         <AdvancementModal
           fighterId={fighterId}
           currentXp={fighterXp}
+          fighterStartingXp={fighterStartingXp}
           editionSlug={editionSlug}
           fighterSubtypes={fighterSubtypes}
           advancements={advancements}

--- a/components/fighter/fighter-details-card.tsx
+++ b/components/fighter/fighter-details-card.tsx
@@ -4,10 +4,12 @@ import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
 import { FighterDetailsStatsTable } from '../ui/fighter-details-stats-table';
 import {
+  hasCumulativeXp,
   hasSaveCharacteristic,
   initiativeAndMentalCharacteristicSuffix,
 } from '@/types/edition';
 import { memo } from 'react';
+import { nextTierStartFor } from '@/utils/advancementRanks';
 import { calculateAdjustedStats } from '@/utils/effect-modifiers';
 import { FighterProps, FighterEffect, Vehicle } from '@/types/fighter';
 import { TbMeatOff } from "react-icons/tb";
@@ -399,7 +401,16 @@ export const FighterDetailsCard = memo(function FighterDetailsCard({
   // A model whose type cannot gain XP has no recruitment value, and reads N/A.
   // The number takes over the moment the model actually holds XP, so a group
   // house-ruling XP onto it still sees it.
-  const xpDisplay = starting_xp == null && !xp ? 'N/A' : (xp ?? 0);
+  // Rank-based editions show progress toward the next Advancement tier.
+  const xpDisplay = (() => {
+    if (starting_xp == null && !xp) return 'N/A';
+    const currentXp = xp ?? 0;
+    if (hasCumulativeXp(edition_slug)) {
+      const nextTierStart = nextTierStartFor(edition_slug, currentXp);
+      return `${currentXp}/${nextTierStart ?? '–'}`;
+    }
+    return currentXp;
+  })();
 
   // Update stats object to handle crew stats - now using modifiedStats instead of adjustedStats
   const stats = useMemo<Record<string, string | number>>(() => ({
@@ -551,7 +562,13 @@ export const FighterDetailsCard = memo(function FighterDetailsCard({
         </div>
       </div>
       <div className="mt-2">
-        <FighterDetailsStatsTable data={stats} isCrew={showsVehicleProfile} editionSlug={edition_slug} />
+        <FighterDetailsStatsTable
+          data={stats}
+          isCrew={showsVehicleProfile}
+          editionSlug={edition_slug}
+          currentXp={xp ?? 0}
+          fighterId={id}
+        />
       </div>
 
       {/* Show owner information for owned fighters */}

--- a/components/fighter/fighter-xp-modal.tsx
+++ b/components/fighter/fighter-xp-modal.tsx
@@ -16,7 +16,7 @@ import { useCampaignGangFighterOptions } from '@/utils/campaign-gang-fighter-opt
 import { XP_CASES, xpAwardsFor, type XpCaseDef, type XpCaseId } from '@/utils/xpCases';
 import { hasCumulativeXp } from '@/types/edition';
 import { nextTierStartFor } from '@/utils/advancementRanks';
-import { XpLadderTooltip } from '@/components/ui/fighter-details-stats-table';
+import { XpLadderTooltip } from '@/components/ui/xp-ladder-tooltip';
 import { toast } from 'sonner';
 
 type OoaEventType = 'out_of_action' | 'vehicle_wrecked';

--- a/components/fighter/fighter-xp-modal.tsx
+++ b/components/fighter/fighter-xp-modal.tsx
@@ -14,6 +14,9 @@ import { fetchCampaignGangsAndFighters } from '@/utils/api/fighter-ooa-records';
 import { buildGangComboboxOption } from '@/utils/gang-combobox-option';
 import { useCampaignGangFighterOptions } from '@/utils/campaign-gang-fighter-options';
 import { XP_CASES, xpAwardsFor, type XpCaseDef, type XpCaseId } from '@/utils/xpCases';
+import { hasCumulativeXp } from '@/types/edition';
+import { nextTierStartFor } from '@/utils/advancementRanks';
+import { XpLadderTooltip } from '@/components/ui/fighter-details-stats-table';
 import { toast } from 'sonner';
 
 type OoaEventType = 'out_of_action' | 'vehicle_wrecked';
@@ -391,10 +394,31 @@ export function FighterXpModal({
       helper={helperFighterName}
       headerContent={
         <div className="flex items-center">
-          <span className="mr-2 text-sm text-muted-foreground">Fighter XP</span>
-          <span className="bg-green-500 text-white text-sm rounded-full px-2 py-1">
-            {currentXp}
-          </span>
+          {hasCumulativeXp(editionSlug) ? (
+            <>
+              <div
+                className="flex items-center cursor-help"
+                data-tooltip-id={`xp-ladder-modal-${fighterId}`}
+              >
+                <span className="mr-2 text-sm text-muted-foreground">XP</span>
+                <span className="bg-green-500 text-white text-sm rounded-full px-2 py-1">
+                  {`${currentXp}/${nextTierStartFor(editionSlug, currentXp) ?? '–'}`}
+                </span>
+              </div>
+              <XpLadderTooltip
+                id={`xp-ladder-modal-${fighterId}`}
+                currentXp={currentXp}
+                editionSlug={editionSlug}
+              />
+            </>
+          ) : (
+            <>
+              <span className="mr-2 text-sm text-muted-foreground">XP</span>
+              <span className="bg-green-500 text-white text-sm rounded-full px-2 py-1">
+                {currentXp}
+              </span>
+            </>
+          )}
         </div>
       }
       content={

--- a/components/ui/fighter-details-stats-table.tsx
+++ b/components/ui/fighter-details-stats-table.tsx
@@ -1,18 +1,197 @@
+'use client';
+
 import React from 'react';
+import { Tooltip } from 'react-tooltip';
 import { characteristicLimitsFor } from '@/utils/characteristicLimits';
+import { hasCumulativeXp } from '@/types/edition';
+import {
+  currentXpLadderRankFor,
+  xpLadderFor,
+  xpLadderRangeLabel,
+  type XpLadderRow,
+} from '@/utils/advancementRanks';
 
 const formatStatValue = (key: string, value: number | string) => {
   if (key === 'BS' && value === '0+') return '-';
   return value;
 };
 
+/** Rank progress like "124/133" is too wide for equal columns on phone/tablet — stack it. */
+const formatXpCell = (value: number | string) => {
+  const text = String(value);
+  const slashIndex = text.indexOf('/');
+  if (slashIndex === -1) return text;
+
+  const current = text.slice(0, slashIndex);
+  const next = text.slice(slashIndex); // includes leading '/'
+
+  return (
+    <>
+      <span className="flex flex-col items-center leading-none gap-0.5 text-[10px] md:text-[12px] lg:hidden">
+        <span>{current}</span>
+        <span>{next}</span>
+      </span>
+      <span className="hidden lg:inline">{text}</span>
+    </>
+  );
+};
+
+/** Numeric XP from a display cell that may be "124/133" or a bare number. */
+const parseXpFromDisplay = (value: number | string | undefined): number => {
+  if (value == null || value === 'N/A') return 0;
+  if (typeof value === 'number') return value;
+  const beforeSlash = String(value).split('/')[0];
+  const parsed = parseInt(beforeSlash, 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+type TitleGroup = {
+  title: string;
+  startIndex: number;
+  rowspan: number;
+};
+
+const COARSE_MQ = '(hover: none) and (pointer: coarse)';
+let _coarseMql: MediaQueryList | null = null;
+const getCoarseMql = () => {
+  if (typeof window === 'undefined') return null;
+  return (_coarseMql ??= window.matchMedia(COARSE_MQ));
+};
+
+const subscribeCoarsePointer = (onStoreChange: () => void) => {
+  const mql = getCoarseMql();
+  mql?.addEventListener('change', onStoreChange);
+  return () => mql?.removeEventListener('change', onStoreChange);
+};
+const getCoarsePointerSnapshot = () => getCoarseMql()?.matches ?? false;
+const getCoarsePointerServerSnapshot = () => false;
+
+function useCoarsePointer() {
+  return React.useSyncExternalStore(
+    subscribeCoarsePointer,
+    getCoarsePointerSnapshot,
+    getCoarsePointerServerSnapshot,
+  );
+}
+
+function titleGroups(ladder: readonly XpLadderRow[]): TitleGroup[] {
+  const groups: TitleGroup[] = [];
+  let i = 0;
+  while (i < ladder.length) {
+    const title = ladder[i].title;
+    let rowspan = 1;
+    while (i + rowspan < ladder.length && ladder[i + rowspan].title === title) {
+      rowspan++;
+    }
+    groups.push({ title, startIndex: i, rowspan });
+    i += rowspan;
+  }
+  return groups;
+}
+
+interface XpLadderTooltipProps {
+  id: string;
+  currentXp: number;
+  editionSlug?: string | null;
+}
+
+/** Shared by the XP modal header; lives here with the stats-table XP ladder. */
+export function XpLadderTooltip({ id, currentXp, editionSlug }: XpLadderTooltipProps) {
+  const isCoarsePointer = useCoarsePointer();
+  const ladder = xpLadderFor(editionSlug);
+  const currentRank = currentXpLadderRankFor(editionSlug, currentXp);
+  const groups = titleGroups(ladder);
+
+  if (ladder.length === 0) return null;
+
+  return (
+    <Tooltip
+      id={id}
+      place="top"
+      className="bg-neutral-900! text-white! text-xs! z-[2000]! print:hidden!"
+      delayShow={isCoarsePointer ? undefined : 200}
+      delayHide={isCoarsePointer ? 100 : 300}
+      offset={4}
+      noArrow={true}
+      clickable={true}
+      openOnClick={isCoarsePointer}
+      positionStrategy="fixed"
+      style={{
+        padding: '6px',
+        maxWidth: '22rem',
+      }}
+    >
+      <div>
+        <div className="mb-1.5 text-sm font-semibold">XP Ladder</div>
+        <div className="max-h-64 overflow-y-auto [scrollbar-width:thin] [scrollbar-color:#525252_#262626] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-neutral-800 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-neutral-600 hover:[&::-webkit-scrollbar-thumb]:bg-neutral-500">
+          <table className="w-full border-collapse text-left">
+            <thead>
+              <tr className="border-b border-neutral-700">
+                <th className="px-1.5 py-0.5 font-semibold">Rank</th>
+                <th className="px-1.5 py-0.5 font-semibold">XP</th>
+                <th className="px-1.5 py-0.5 font-semibold">Title</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ladder.map((row, index) => {
+                const isCurrent = currentRank === row.rank;
+                const titleGroup = groups.find((g) => g.startIndex === index);
+                const titleCoversCurrent =
+                  titleGroup != null &&
+                  currentRank != null &&
+                  currentRank >= ladder[titleGroup.startIndex].rank &&
+                  currentRank <= ladder[titleGroup.startIndex + titleGroup.rowspan - 1].rank;
+                const highlightCell = 'font-semibold text-white';
+                const mutedCell = 'text-neutral-400';
+                const isTitleGroupStart = titleGroup != null && index > 0;
+                const titleGroupBorder = isTitleGroupStart ? 'border-t border-neutral-600' : '';
+
+                return (
+                  <tr key={row.rank}>
+                    <td className={`px-1.5 py-0.5 tabular-nums ${titleGroupBorder} ${isCurrent ? highlightCell : mutedCell}`}>
+                      {row.rank}
+                    </td>
+                    <td className={`px-1.5 py-0.5 tabular-nums whitespace-nowrap ${titleGroupBorder} ${isCurrent ? highlightCell : mutedCell}`}>
+                      {xpLadderRangeLabel(row)}
+                    </td>
+                    {titleGroup && (
+                      <td
+                        rowSpan={titleGroup.rowspan}
+                        className={`px-1.5 py-0.5 align-middle ${titleGroupBorder} ${titleCoversCurrent ? highlightCell : mutedCell}`}
+                      >
+                        {titleGroup.title}
+                      </td>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </Tooltip>
+  );
+}
+
 interface FighterDetailsStatsTableProps {
   data?: Record<string, number | string>;
   isCrew?: boolean;
   editionSlug?: string | null;
+  /** Numeric XP for ladder highlight; display string stays in data.XP. */
+  currentXp?: number;
+  /** Scopes the XP ladder tooltip id when multiple surfaces share a page. */
+  fighterId?: string;
 }
 
-export function FighterDetailsStatsTable({ data, isCrew, editionSlug }: FighterDetailsStatsTableProps) {
+export function FighterDetailsStatsTable({
+  data,
+  isCrew,
+  editionSlug,
+  currentXp,
+  fighterId,
+}: FighterDetailsStatsTableProps) {
+  const generatedTooltipId = React.useId();
+
   if (!data || Object.keys(data).length === 0) {
     return <p>No characteristics available</p>;
   }
@@ -77,9 +256,16 @@ export function FighterDetailsStatsTable({ data, isCrew, editionSlug }: FighterD
   const columnCount = Object.keys(orderedStats).length;
   const columnWidth = `${100 / columnCount}%`;
 
+  const showXpLadder =
+    hasCumulativeXp(editionSlug) &&
+    orderedStats.XP !== undefined &&
+    orderedStats.XP !== 'N/A';
+  const resolvedCurrentXp = currentXp ?? parseXpFromDisplay(orderedStats.XP);
+  const xpLadderTooltipId = `xp-ladder-details-${fighterId ?? generatedTooltipId}`;
+
   return (
-    <div className="w-full">
-      <table className="w-full text-xs sm:text-sm border-collapse">
+    <div className="w-full min-w-0 overflow-hidden">
+      <table className="w-full table-fixed text-xs sm:text-sm border-collapse">
         <thead>
           {/* Conditionally Render Toughness Header Row */}
           {isCrew && (
@@ -95,12 +281,16 @@ export function FighterDetailsStatsTable({ data, isCrew, editionSlug }: FighterD
             {Object.keys(orderedStats).map((key) => (
               <th
                 key={key}
-                className={`font-semibold text-center p-1 border-b-[1px] border-[#a05236]
+                className={`font-semibold text-center p-0.5 sm:p-1 border-b-[1px] border-[#a05236]
                   ${specialBackgroundStats.includes(key) ? 'bg-[rgba(162,82,54,0.3)]' : ''}
                   ${key === 'Front' || key === 'Side' || key === 'Rear' ? 'bg-secondary/70' : ''}
                   ${key === 'XP' ? 'bg-[rgba(162,82,54,0.7)] text-white' : ''}
+                  ${key === 'XP' && showXpLadder ? 'cursor-help' : ''}
                   ${getColumnBorderClass(key)}`}
                 style={{ width: columnWidth }}
+                {...(key === 'XP' && showXpLadder
+                  ? { 'data-tooltip-id': xpLadderTooltipId }
+                  : {})}
               >
                 {/* Responsive Header Text */}
                 {columnRenameMap[key]
@@ -120,20 +310,31 @@ export function FighterDetailsStatsTable({ data, isCrew, editionSlug }: FighterD
             {Object.entries(orderedStats).map(([key, value]) => (
               <td
                 key={key}
-                className={`text-center p-1
+                className={`text-center p-0.5 sm:p-1
                   ${specialBackgroundStats.includes(key) ? 'bg-[rgba(162,82,54,0.3)]' : ''}
                   ${key === 'Front' || key === 'Side' || key === 'Rear' ? 'bg-secondary/70' : ''}
                   ${key === 'XP' ? 'bg-[rgba(162,82,54,0.7)] text-white' : ''}
+                  ${key === 'XP' && showXpLadder ? 'cursor-help' : ''}
                   ${getColumnBorderClass(key)}
                   ${isStatOutOfRange(key, value) ? 'text-red-500 font-semibold' : ''}`}
                 style={{ width: columnWidth }}
+                {...(key === 'XP' && showXpLadder
+                  ? { 'data-tooltip-id': xpLadderTooltipId }
+                  : {})}
               >
-                {formatStatValue(key, value)}
+                {key === 'XP' ? formatXpCell(formatStatValue(key, value)) : formatStatValue(key, value)}
               </td>
             ))}
           </tr>
         </tbody>
       </table>
+      {showXpLadder && (
+        <XpLadderTooltip
+          id={xpLadderTooltipId}
+          currentXp={resolvedCurrentXp}
+          editionSlug={editionSlug}
+        />
+      )}
     </div>
   );
 }

--- a/components/ui/fighter-details-stats-table.tsx
+++ b/components/ui/fighter-details-stats-table.tsx
@@ -1,15 +1,9 @@
 'use client';
 
 import React from 'react';
-import { Tooltip } from 'react-tooltip';
 import { characteristicLimitsFor } from '@/utils/characteristicLimits';
 import { hasCumulativeXp } from '@/types/edition';
-import {
-  currentXpLadderRankFor,
-  xpLadderFor,
-  xpLadderRangeLabel,
-  type XpLadderRow,
-} from '@/utils/advancementRanks';
+import { XpLadderTooltip } from '@/components/ui/xp-ladder-tooltip';
 
 const formatStatValue = (key: string, value: number | string) => {
   if (key === 'BS' && value === '0+') return '-';
@@ -44,134 +38,6 @@ const parseXpFromDisplay = (value: number | string | undefined): number => {
   const parsed = parseInt(beforeSlash, 10);
   return Number.isFinite(parsed) ? parsed : 0;
 };
-
-type TitleGroup = {
-  title: string;
-  startIndex: number;
-  rowspan: number;
-};
-
-const COARSE_MQ = '(hover: none) and (pointer: coarse)';
-let _coarseMql: MediaQueryList | null = null;
-const getCoarseMql = () => {
-  if (typeof window === 'undefined') return null;
-  return (_coarseMql ??= window.matchMedia(COARSE_MQ));
-};
-
-const subscribeCoarsePointer = (onStoreChange: () => void) => {
-  const mql = getCoarseMql();
-  mql?.addEventListener('change', onStoreChange);
-  return () => mql?.removeEventListener('change', onStoreChange);
-};
-const getCoarsePointerSnapshot = () => getCoarseMql()?.matches ?? false;
-const getCoarsePointerServerSnapshot = () => false;
-
-function useCoarsePointer() {
-  return React.useSyncExternalStore(
-    subscribeCoarsePointer,
-    getCoarsePointerSnapshot,
-    getCoarsePointerServerSnapshot,
-  );
-}
-
-function titleGroups(ladder: readonly XpLadderRow[]): TitleGroup[] {
-  const groups: TitleGroup[] = [];
-  let i = 0;
-  while (i < ladder.length) {
-    const title = ladder[i].title;
-    let rowspan = 1;
-    while (i + rowspan < ladder.length && ladder[i + rowspan].title === title) {
-      rowspan++;
-    }
-    groups.push({ title, startIndex: i, rowspan });
-    i += rowspan;
-  }
-  return groups;
-}
-
-interface XpLadderTooltipProps {
-  id: string;
-  currentXp: number;
-  editionSlug?: string | null;
-}
-
-/** Shared by the XP modal header; lives here with the stats-table XP ladder. */
-export function XpLadderTooltip({ id, currentXp, editionSlug }: XpLadderTooltipProps) {
-  const isCoarsePointer = useCoarsePointer();
-  const ladder = xpLadderFor(editionSlug);
-  const currentRank = currentXpLadderRankFor(editionSlug, currentXp);
-  const groups = titleGroups(ladder);
-
-  if (ladder.length === 0) return null;
-
-  return (
-    <Tooltip
-      id={id}
-      place="top"
-      className="bg-neutral-900! text-white! text-xs! z-[2000]! print:hidden!"
-      delayShow={isCoarsePointer ? undefined : 200}
-      delayHide={isCoarsePointer ? 100 : 300}
-      offset={4}
-      noArrow={true}
-      clickable={true}
-      openOnClick={isCoarsePointer}
-      positionStrategy="fixed"
-      style={{
-        padding: '6px',
-        maxWidth: '22rem',
-      }}
-    >
-      <div>
-        <div className="mb-1.5 text-sm font-semibold">XP Ladder</div>
-        <div className="max-h-64 overflow-y-auto [scrollbar-width:thin] [scrollbar-color:#525252_#262626] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-neutral-800 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-neutral-600 hover:[&::-webkit-scrollbar-thumb]:bg-neutral-500">
-          <table className="w-full border-collapse text-left">
-            <thead>
-              <tr className="border-b border-neutral-700">
-                <th className="px-1.5 py-0.5 font-semibold">Rank</th>
-                <th className="px-1.5 py-0.5 font-semibold">XP</th>
-                <th className="px-1.5 py-0.5 font-semibold">Title</th>
-              </tr>
-            </thead>
-            <tbody>
-              {ladder.map((row, index) => {
-                const isCurrent = currentRank === row.rank;
-                const titleGroup = groups.find((g) => g.startIndex === index);
-                const titleCoversCurrent =
-                  titleGroup != null &&
-                  currentRank != null &&
-                  currentRank >= ladder[titleGroup.startIndex].rank &&
-                  currentRank <= ladder[titleGroup.startIndex + titleGroup.rowspan - 1].rank;
-                const highlightCell = 'font-semibold text-white';
-                const mutedCell = 'text-neutral-400';
-                const isTitleGroupStart = titleGroup != null && index > 0;
-                const titleGroupBorder = isTitleGroupStart ? 'border-t border-neutral-600' : '';
-
-                return (
-                  <tr key={row.rank}>
-                    <td className={`px-1.5 py-0.5 tabular-nums ${titleGroupBorder} ${isCurrent ? highlightCell : mutedCell}`}>
-                      {row.rank}
-                    </td>
-                    <td className={`px-1.5 py-0.5 tabular-nums whitespace-nowrap ${titleGroupBorder} ${isCurrent ? highlightCell : mutedCell}`}>
-                      {xpLadderRangeLabel(row)}
-                    </td>
-                    {titleGroup && (
-                      <td
-                        rowSpan={titleGroup.rowspan}
-                        className={`px-1.5 py-0.5 align-middle ${titleGroupBorder} ${titleCoversCurrent ? highlightCell : mutedCell}`}
-                      >
-                        {titleGroup.title}
-                      </td>
-                    )}
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </Tooltip>
-  );
-}
 
 interface FighterDetailsStatsTableProps {
   data?: Record<string, number | string>;
@@ -264,7 +130,7 @@ export function FighterDetailsStatsTable({
   const xpLadderTooltipId = `xp-ladder-details-${fighterId ?? generatedTooltipId}`;
 
   return (
-    <div className="w-full min-w-0 overflow-hidden">
+    <div className="w-full min-w-0 overflow-x-auto">
       <table className="w-full table-fixed text-xs sm:text-sm border-collapse">
         <thead>
           {/* Conditionally Render Toughness Header Row */}

--- a/components/ui/list.tsx
+++ b/components/ui/list.tsx
@@ -26,6 +26,8 @@ export interface ListAction {
 
 export interface ListProps<T = any> {
   title: React.ReactNode;
+  /** Extra classes on the title heading (e.g. flex layout for a trailing badge). */
+  titleClassName?: string;
   description?: React.ReactNode;
   items: T[];
   columns: ListColumn[];
@@ -42,6 +44,7 @@ export interface ListProps<T = any> {
 
 export function List<T = any>({
   title,
+  titleClassName,
   description,
   items,
   columns,
@@ -84,7 +87,7 @@ export function List<T = any>({
   return (
     <div className={`mt-6 ${className}`}>
       <div className="flex flex-wrap justify-between items-center mb-2">
-        <h2 className="text-xl md:text-2xl font-bold">{title}</h2>
+        <h2 className={`text-xl md:text-2xl font-bold${titleClassName ? ` ${titleClassName}` : ''}`}>{title}</h2>
         {(headerActions || onAdd) && (
           <div className="flex flex-wrap items-center gap-2">
             {headerActions}

--- a/components/ui/xp-ladder-tooltip.tsx
+++ b/components/ui/xp-ladder-tooltip.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { Tooltip } from 'react-tooltip';
+import { useCoarsePointer } from '@/hooks/use-coarse-pointer';
+import {
+  currentXpLadderRankFor,
+  xpLadderFor,
+  xpLadderRangeLabel,
+  type XpLadderRow,
+} from '@/utils/advancementRanks';
+
+type TitleGroup = {
+  title: string;
+  startIndex: number;
+  rowspan: number;
+};
+
+function titleGroups(ladder: readonly XpLadderRow[]): TitleGroup[] {
+  const groups: TitleGroup[] = [];
+  let i = 0;
+  while (i < ladder.length) {
+    const title = ladder[i].title;
+    let rowspan = 1;
+    while (i + rowspan < ladder.length && ladder[i + rowspan].title === title) {
+      rowspan++;
+    }
+    groups.push({ title, startIndex: i, rowspan });
+    i += rowspan;
+  }
+  return groups;
+}
+
+interface XpLadderTooltipProps {
+  id: string;
+  currentXp: number;
+  editionSlug?: string | null;
+}
+
+export function XpLadderTooltip({ id, currentXp, editionSlug }: XpLadderTooltipProps) {
+  const isCoarsePointer = useCoarsePointer();
+  const ladder = xpLadderFor(editionSlug);
+  const currentRank = currentXpLadderRankFor(editionSlug, currentXp);
+  const groups = titleGroups(ladder);
+
+  if (ladder.length === 0) return null;
+
+  return (
+    <Tooltip
+      id={id}
+      place="top"
+      className="bg-neutral-900! text-white! text-xs! z-[2000]! print:hidden!"
+      delayShow={isCoarsePointer ? undefined : 200}
+      delayHide={isCoarsePointer ? 100 : 300}
+      offset={4}
+      noArrow={true}
+      clickable={true}
+      openOnClick={isCoarsePointer}
+      positionStrategy="fixed"
+      style={{
+        padding: '6px',
+        maxWidth: '22rem',
+      }}
+    >
+      <div>
+        <div className="mb-1.5 text-sm font-semibold">XP Ladder</div>
+        <div className="max-h-64 overflow-y-auto [scrollbar-width:thin] [scrollbar-color:#525252_#262626] [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-neutral-800 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-neutral-600 hover:[&::-webkit-scrollbar-thumb]:bg-neutral-500">
+          <table className="w-full border-collapse text-left">
+            <thead>
+              <tr className="border-b border-neutral-700">
+                <th className="px-1.5 py-0.5 font-semibold">Rank</th>
+                <th className="px-1.5 py-0.5 font-semibold">XP</th>
+                <th className="px-1.5 py-0.5 font-semibold">Title</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ladder.map((row, index) => {
+                const isCurrent = currentRank === row.rank;
+                const titleGroup = groups.find((g) => g.startIndex === index);
+                const titleCoversCurrent =
+                  titleGroup != null &&
+                  currentRank != null &&
+                  currentRank >= ladder[titleGroup.startIndex].rank &&
+                  currentRank <= ladder[titleGroup.startIndex + titleGroup.rowspan - 1].rank;
+                const highlightCell = 'font-semibold text-white';
+                const mutedCell = 'text-neutral-400';
+                const isTitleGroupStart = titleGroup != null && index > 0;
+                const titleGroupBorder = isTitleGroupStart ? 'border-t border-neutral-600' : '';
+
+                return (
+                  <tr key={row.rank}>
+                    <td className={`px-1.5 py-0.5 tabular-nums ${titleGroupBorder} ${isCurrent ? highlightCell : mutedCell}`}>
+                      {row.rank}
+                    </td>
+                    <td className={`px-1.5 py-0.5 tabular-nums whitespace-nowrap ${titleGroupBorder} ${isCurrent ? highlightCell : mutedCell}`}>
+                      {xpLadderRangeLabel(row)}
+                    </td>
+                    {titleGroup && (
+                      <td
+                        rowSpan={titleGroup.rowspan}
+                        className={`px-1.5 py-0.5 align-middle ${titleGroupBorder} ${titleCoversCurrent ? highlightCell : mutedCell}`}
+                      >
+                        {titleGroup.title}
+                      </td>
+                    )}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </Tooltip>
+  );
+}

--- a/hooks/use-coarse-pointer.ts
+++ b/hooks/use-coarse-pointer.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+const COARSE_MQ = '(hover: none) and (pointer: coarse)';
+let _coarseMql: MediaQueryList | null = null;
+
+const getCoarseMql = () => {
+  if (typeof window === 'undefined') return null;
+  return (_coarseMql ??= window.matchMedia(COARSE_MQ));
+};
+
+const subscribeCoarsePointer = (onStoreChange: () => void) => {
+  const mql = getCoarseMql();
+  mql?.addEventListener('change', onStoreChange);
+  return () => mql?.removeEventListener('change', onStoreChange);
+};
+
+const getCoarsePointerSnapshot = () => getCoarseMql()?.matches ?? false;
+const getCoarsePointerServerSnapshot = () => false;
+
+export function useCoarsePointer() {
+  return useSyncExternalStore(
+    subscribeCoarsePointer,
+    getCoarsePointerSnapshot,
+    getCoarsePointerServerSnapshot,
+  );
+}

--- a/utils/advancementRanks.ts
+++ b/utils/advancementRanks.ts
@@ -1,23 +1,54 @@
 import { EditionSlug } from '@/types/edition';
 
+export type XpLadderRow = {
+  rank: number;
+  xpMin: number;
+  /** null = open-ended (Legend of the Underhive). */
+  xpMax: number | null;
+  title: string;
+};
+
+/**
+ * Full N26 XP ladder for display. Rank 0 (1–3, Rookie) is recruitment only:
+ * every model starts on it, so it does not award an Advancement when entered.
+ */
+export const n26XpLadder: readonly XpLadderRow[] = [
+  { rank: 0, xpMin: 1, xpMax: 3, title: 'Rookie' },
+  { rank: 1, xpMin: 4, xpMax: 6, title: 'Rookie' },
+  { rank: 2, xpMin: 7, xpMax: 9, title: 'Rookie' },
+  { rank: 3, xpMin: 10, xpMax: 12, title: 'Rookie' },
+  { rank: 4, xpMin: 13, xpMax: 18, title: 'Gang Member' },
+  { rank: 5, xpMin: 19, xpMax: 24, title: 'Gang Member' },
+  { rank: 6, xpMin: 25, xpMax: 30, title: 'Gang Member' },
+  { rank: 7, xpMin: 31, xpMax: 36, title: 'Gang Member' },
+  { rank: 8, xpMin: 37, xpMax: 48, title: 'Gang Exemplar' },
+  { rank: 9, xpMin: 49, xpMax: 60, title: 'Gang Exemplar' },
+  { rank: 10, xpMin: 61, xpMax: 72, title: 'Gang Exemplar' },
+  { rank: 11, xpMin: 73, xpMax: 84, title: 'Gang Exemplar' },
+  { rank: 12, xpMin: 85, xpMax: 96, title: 'Gang Hero' },
+  { rank: 13, xpMin: 97, xpMax: 108, title: 'Gang Hero' },
+  { rank: 14, xpMin: 109, xpMax: 120, title: 'Gang Hero' },
+  { rank: 15, xpMin: 121, xpMax: 132, title: 'Gang Hero' },
+  { rank: 16, xpMin: 133, xpMax: 156, title: 'Gang Legend' },
+  { rank: 17, xpMin: 157, xpMax: 180, title: 'Gang Legend' },
+  { rank: 18, xpMin: 181, xpMax: 204, title: 'Gang Legend' },
+  { rank: 19, xpMin: 205, xpMax: 228, title: 'Gang Legend' },
+  { rank: 20, xpMin: 229, xpMax: null, title: 'Legend of the Underhive' },
+];
+
 /**
  * XP totals that move a model onto a new tier, and so award an Advancement.
  *
- * The Rookie band's own first tier (1-3) is absent: every model is recruited
- * onto it and nothing ever moves onto it, so a model starting on 1 XP first
- * advances at 4. Left out of the data rather than filtered by starting XP,
- * because starting_xp can be 0 and such a fighter would otherwise collect an
- * Advancement on reaching 1. Legend of the Underhive (229) is entered like any
- * other rank but has nothing above it, so Advancement stops there.
+ * Rank 0 (1–3) is absent: every model is recruited onto it and nothing ever
+ * moves onto it, so a model starting on 1 XP first advances at 4. Left out
+ * rather than filtered by starting XP, because starting_xp can be 0 and such a
+ * fighter would otherwise collect an Advancement on reaching 1. Legend of the
+ * Underhive (229) is entered like any other rank but has nothing above it, so
+ * Advancement stops there.
  */
-const N26_TIER_STARTS: readonly number[] = [
-  4, 7, 10,
-  13, 19, 25, 31,
-  37, 49, 61, 73,
-  85, 97, 109, 121,
-  133, 157, 181, 205,
-  229,
-];
+const N26_TIER_STARTS: readonly number[] = n26XpLadder
+  .filter((row) => row.rank > 0)
+  .map((row) => row.xpMin);
 
 /**
  * N23 spends XP on Advancements instead of earning them by rank, so it has no
@@ -32,13 +63,48 @@ const TIER_STARTS_BY_EDITION: Record<EditionSlug, readonly number[]> = {
   n26: N26_TIER_STARTS,
 };
 
+const LADDER_BY_EDITION: Record<EditionSlug, readonly XpLadderRow[]> = {
+  n23: [],
+  n26: n26XpLadder,
+};
+
 /** An unset or unrecognised slug means the edition failed to load: award nothing. */
 const NO_TIERS: readonly number[] = [];
+const NO_LADDER: readonly XpLadderRow[] = [];
 
 function tierStartsFor(editionSlug: string | null | undefined): readonly number[] {
   if (!editionSlug) return NO_TIERS;
 
   return TIER_STARTS_BY_EDITION[editionSlug as EditionSlug] ?? NO_TIERS;
+}
+
+export function xpLadderFor(editionSlug: string | null | undefined): readonly XpLadderRow[] {
+  if (!editionSlug) return NO_LADDER;
+
+  return LADDER_BY_EDITION[editionSlug as EditionSlug] ?? NO_LADDER;
+}
+
+export function xpLadderRangeLabel(row: XpLadderRow): string {
+  if (row.xpMax == null) return `${row.xpMin}+`;
+  return `${row.xpMin}-${row.xpMax}`;
+}
+
+/**
+ * Ladder rank for the given XP total, or null when below the Rookie band
+ * (XP &lt; 1) or the edition has no ladder.
+ */
+export function currentXpLadderRankFor(
+  editionSlug: string | null | undefined,
+  xp: number,
+): number | null {
+  const ladder = xpLadderFor(editionSlug);
+  if (ladder.length === 0 || xp < 1) return null;
+
+  for (let i = ladder.length - 1; i >= 0; i--) {
+    if (xp >= ladder[i].xpMin) return ladder[i].rank;
+  }
+
+  return null;
 }
 
 const tiersAtOrBelow = (tiers: readonly number[], xp: number): number =>


### PR DESCRIPTION
Surface rank progress and a touch-friendly ladder tooltip on XP cells, and replace the Advancements header XP progress with an Available count for cumulative-XP editions.