### PR TITLE
Add shared edition toggle to user profile Custom Assets and make counts edition-aware

### DIFF
--- a/app/user/[id]/page.tsx
+++ b/app/user/[id]/page.tsx
@@ -22,6 +22,7 @@ import { CustomTradingPost } from "@/app/actions/customise/custom-trading-posts"
 import { CustomCollectionWithItems } from "@/app/lib/customise/custom-collections";
 import { useClaims } from "@/hooks/use-claims";
 import { useHomeEdition } from "@/hooks/use-home-edition";
+import { EditionToggle } from "@/components/home/edition-toggle";
 import { sameEditionForDisplay } from "@/types/edition";
 import type { UserCampaign } from "@/types/campaign";
 import { toast } from 'sonner';
@@ -94,7 +95,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
   const { userId: currentUserId } = useClaims();
   // Same edition the home Custom Assets tab is on, so a profile never renders an
   // N26 asset under N23 rules.
-  const { editionSlug } = useHomeEdition();
+  const { editionSlug, setEditionSlug } = useHomeEdition();
 
   // Scroll to top when component mounts
   useEffect(() => {
@@ -136,6 +137,17 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
     skills: byEdition(customAssetsData.skills),
     collections: byEdition(customAssetsData.collections ?? []),
   };
+  const editionAssetCount = Object.values(editionAssets).reduce(
+    (total, assets) => total + assets.length,
+    0
+  );
+  const hasAnyCustomAssets =
+    customAssets.equipment > 0 ||
+    customAssets.fighters > 0 ||
+    customAssets.skills > 0 ||
+    customAssets.gangTypes > 0 ||
+    customAssets.tradingPosts > 0 ||
+    (customAssets.collections || 0) > 0;
 
   // Get arbitrator campaigns for sharing custom assets (only when viewing own profile)
   const userCampaigns = currentUserId === profile.id
@@ -205,7 +217,7 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
               <MdOutlineColorLens className="h-8 w-8 text-muted-foreground" />
               <div>
                 <p className="text-2xl font-bold">
-                  {customAssets.equipment + customAssets.fighters + customAssets.skills + customAssets.gangTypes + customAssets.tradingPosts + (customAssets.collections || 0)}
+                  {editionAssetCount}
                 </p>
                 <p className="text-sm text-muted-foreground">Custom Assets</p>
               </div>
@@ -292,19 +304,27 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
         )}
 
         {/* Custom Assets Section */}
-        {(customAssets.equipment > 0 || customAssets.fighters > 0 || customAssets.skills > 0 || customAssets.gangTypes > 0 || customAssets.tradingPosts > 0 || (customAssets.collections || 0) > 0) && (
+        {hasAnyCustomAssets && (
           <div className="bg-card shadow-md rounded-lg p-4">
             <div className="mb-4">
-              <h2 className="text-xl md:text-2xl font-bold flex items-center gap-2">
-                <MdOutlineColorLens className="h-5 w-5" />
-                Custom Assets
-              </h2>
+              <div className="flex items-center justify-between gap-2 mb-2">
+                <h2 className="text-xl md:text-2xl font-bold flex items-center gap-2">
+                  <MdOutlineColorLens className="h-5 w-5" />
+                  Custom Assets
+                </h2>
+                <EditionToggle value={editionSlug} onChange={setEditionSlug} />
+              </div>
               <p className="text-muted-foreground">
                 Custom content created by {profile.username}
               </p>
             </div>
             
             <div className="space-y-6">
+              {editionAssetCount === 0 && (
+                <p className="text-muted-foreground">
+                  No custom assets for {editionSlug.toUpperCase()}
+                </p>
+              )}
               {/* Custom Gang Types */}
               {editionAssets.gangTypes.length > 0 && (
                 <CustomiseGangTypes

--- a/app/user/[id]/page.tsx
+++ b/app/user/[id]/page.tsx
@@ -166,30 +166,30 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
       <div className="container ml-[10px] mr-[10px] max-w-4xl w-full space-y-6 mt-2">
         {/* User Profile Header */}
         <div className="bg-card shadow-md rounded-lg p-4">
-          <div className="flex items-center justify-between">
+          <div className="flex items-start justify-between gap-3">
             <div>
-              <div className="flex flex-wrap items-center gap-3">
-                <h1 className="text-2xl md:text-3xl font-bold flex items-center gap-3">
-                  {profile.username}
-                  {profile.user_role === 'admin' && (
-                    <Badge variant="destructive">Admin</Badge>
-                  )}
-                </h1>
-                <EditionToggle value={editionSlug} onChange={setEditionSlug} />
-              </div>
+              <h1 className="text-2xl md:text-3xl font-bold flex items-center gap-3">
+                {profile.username}
+                {profile.user_role === 'admin' && (
+                  <Badge variant="destructive">Admin</Badge>
+                )}
+              </h1>
               <p className="text-muted-foreground mt-2">
                 Member since: {new Date(profile.created_at).toISOString().split('T')[0]}
               </p>
             </div>
-            {profile.patreon_tier_id && profile.patron_status === 'active_patron' && (
-              <Badge variant="outline" className="flex items-center gap-1">
-                <PatreonSupporterIcon
-                  patreonTierId={profile.patreon_tier_id}
-                  patreonTierTitle={profile.patreon_tier_title}
-                />
-                {profile.patreon_tier_title || 'Patreon Supporter'}
-              </Badge>
-            )}
+            <div className="flex shrink-0 items-center gap-3">
+              {profile.patreon_tier_id && profile.patron_status === 'active_patron' && (
+                <Badge variant="outline" className="flex items-center gap-1">
+                  <PatreonSupporterIcon
+                    patreonTierId={profile.patreon_tier_id}
+                    patreonTierTitle={profile.patreon_tier_title}
+                  />
+                  {profile.patreon_tier_title || 'Patreon Supporter'}
+                </Badge>
+              )}
+              <EditionToggle value={editionSlug} onChange={setEditionSlug} />
+            </div>
           </div>
         </div>
 

--- a/app/user/[id]/page.tsx
+++ b/app/user/[id]/page.tsx
@@ -168,12 +168,15 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
         <div className="bg-card shadow-md rounded-lg p-4">
           <div className="flex items-center justify-between">
             <div>
-              <h1 className="text-2xl md:text-3xl font-bold flex items-center gap-3">
-                {profile.username}
-                {profile.user_role === 'admin' && (
-                  <Badge variant="destructive">Admin</Badge>
-                )}
-              </h1>
+              <div className="flex flex-wrap items-center gap-3">
+                <h1 className="text-2xl md:text-3xl font-bold flex items-center gap-3">
+                  {profile.username}
+                  {profile.user_role === 'admin' && (
+                    <Badge variant="destructive">Admin</Badge>
+                  )}
+                </h1>
+                <EditionToggle value={editionSlug} onChange={setEditionSlug} />
+              </div>
               <p className="text-muted-foreground mt-2">
                 Member since: {new Date(profile.created_at).toISOString().split('T')[0]}
               </p>
@@ -307,13 +310,10 @@ export default function UserPage({ params }: { params: Promise<{ id: string }> }
         {hasAnyCustomAssets && (
           <div className="bg-card shadow-md rounded-lg p-4">
             <div className="mb-4">
-              <div className="flex items-center justify-between gap-2 mb-2">
-                <h2 className="text-xl md:text-2xl font-bold flex items-center gap-2">
-                  <MdOutlineColorLens className="h-5 w-5" />
-                  Custom Assets
-                </h2>
-                <EditionToggle value={editionSlug} onChange={setEditionSlug} />
-              </div>
+              <h2 className="text-xl md:text-2xl font-bold flex items-center gap-2">
+                <MdOutlineColorLens className="h-5 w-5" />
+                Custom Assets
+              </h2>
               <p className="text-muted-foreground">
                 Custom content created by {profile.username}
               </p>


### PR DESCRIPTION
### Motivation
- Make the profile Custom Assets UI reflect the same edition selection as the home page so users see the active edition filter consistently.
- Ensure the displayed Custom Assets count and section content are consistent with the selected edition to avoid empty sections with non-zero counts.
- Preserve the shared `home_edition` localStorage-backed state so selection is synchronized between home and profile views.

### Description
- Import `EditionToggle` and use the existing `useHomeEdition` hook to destructure `{ editionSlug, setEditionSlug }` in `app/user/[id]/page.tsx` and wire the toggle to the shared store. 
- Compute `editionAssets` by filtering `customAssetsData` with the shared `editionSlug` and derive `editionAssetCount` as the sum of edition-filtered arrays. 
- Replace the displayed Custom Assets total with `editionAssetCount` and keep the Custom Assets section visible when the profile owns assets (regardless of edition), using a `hasAnyCustomAssets` predicate. 
- Render the `EditionToggle` beside the “Custom Assets” heading and add an edition-aware empty state message `No custom assets for N23/N26` when the profile has assets but none match the selected edition.