### PR TITLE
Use edition-based trading_post_type_id for custom gang types

### DIFF
--- a/app/actions/customise/custom-gang-type-editions.js
+++ b/app/actions/customise/custom-gang-type-editions.js
@@ -1,0 +1,15 @@
+export const N23_TRADING_POST_TYPE_ID = 'cada4005-66e3-4e3c-8a77-146329bd1eda';
+export const N26_TRADING_POST_TYPE_ID = '875c877f-ec67-444c-be04-99e9d09297df';
+
+/**
+ * @param {string | undefined} editionSlug
+ * @param {string | null} editionId
+ * @returns {{ edition_id: string | null; trading_post_type_id: string }}
+ */
+export function getCustomGangTypeEditionFields(editionSlug, editionId) {
+  return {
+    edition_id: editionId,
+    trading_post_type_id:
+      editionSlug === 'n26' ? N26_TRADING_POST_TYPE_ID : N23_TRADING_POST_TYPE_ID,
+  };
+}

--- a/app/actions/customise/custom-gang-types.ts
+++ b/app/actions/customise/custom-gang-types.ts
@@ -6,6 +6,7 @@ import { getEditionIdBySlug } from '@/app/lib/editions';
 import { getCustomDescriptionLengthError, normalizeCustomDescription } from './custom-constants';
 import { removeItemFromAllCollections } from './custom-collections';
 import { invalidateUserCustomGangTypes, invalidateUserCustomFighters, invalidateUserCustomCollections } from '@/utils/cache-tags';
+import { getCustomGangTypeEditionFields } from './custom-gang-type-editions';
 
 export interface CustomGangTypeData {
   gang_type: string;
@@ -13,8 +14,6 @@ export interface CustomGangTypeData {
   description?: string | null;
   edition_slug?: string;
 }
-
-const DEFAULT_TRADING_POST_TYPE_ID = 'cada4005-66e3-4e3c-8a77-146329bd1eda';
 
 export interface CustomGangType {
   id: string;
@@ -43,6 +42,10 @@ export async function createCustomGangType(
   try {
     const supabase = await createClient();
     const user = await getAuthenticatedUser(supabase);
+    const editionFields = getCustomGangTypeEditionFields(
+      data.edition_slug,
+      await getEditionIdBySlug(data.edition_slug)
+    );
 
     const { data: newGangType, error: insertError } = await supabase
       .from('custom_gang_types')
@@ -51,8 +54,7 @@ export async function createCustomGangType(
         gang_type: data.gang_type.trimEnd(),
         alignment: data.alignment || null,
         description,
-        trading_post_type_id: DEFAULT_TRADING_POST_TYPE_ID,
-        edition_id: await getEditionIdBySlug(data.edition_slug),
+        ...editionFields,
         created_at: new Date().toISOString(),
       })
       .select()
@@ -87,6 +89,10 @@ export async function updateCustomGangType(
   try {
     const supabase = await createClient();
     const user = await getAuthenticatedUser(supabase);
+    const editionFields = getCustomGangTypeEditionFields(
+      data.edition_slug,
+      await getEditionIdBySlug(data.edition_slug)
+    );
 
     // Verify ownership
     const { data: existing, error: fetchError } = await supabase
@@ -106,7 +112,7 @@ export async function updateCustomGangType(
         gang_type: data.gang_type.trimEnd(),
         alignment: data.alignment || null,
         description,
-        trading_post_type_id: DEFAULT_TRADING_POST_TYPE_ID,
+        ...editionFields,
         updated_at: new Date().toISOString(),
       })
       .eq('id', id)

--- a/components/customise/custom-gang-types.tsx
+++ b/components/customise/custom-gang-types.tsx
@@ -228,7 +228,11 @@ export function CustomiseGangTypes({
     if (!editModalData || !isFormValid()) return false;
     updateMutation.mutate({
       id: editModalData.id,
-      data: { ...formData, alignment: showAlignment ? formData.alignment : null },
+      data: {
+        ...formData,
+        alignment: showAlignment ? formData.alignment : null,
+        edition_slug: editionSlug,
+      },
     });
     return true;
   };


### PR DESCRIPTION
### Motivation

- Custom gang types previously used a single default `trading_post_type_id` and did not reliably set the `edition_id`, which could assign the wrong trading post type for different editions.
- Add logic to select the correct trading post type when creating or updating custom gang types based on the provided `edition_slug` (handling `n26` vs the default). 

### Description

- Added `app/actions/customise/custom-gang-type-editions.js` which exports `getCustomGangTypeEditionFields` and constants `N23_TRADING_POST_TYPE_ID` and `N26_TRADING_POST_TYPE_ID`.
- Updated `createCustomGangType` to call `getCustomGangTypeEditionFields` and spread the returned `edition_id` and `trading_post_type_id` into the insert payload.
- Updated `updateCustomGangType` to call `getCustomGangTypeEditionFields` and spread the returned fields into the update payload, replacing the previous hardcoded default.
- Removed the `DEFAULT_TRADING_POST_TYPE_ID` usage and imported the new helper in `custom-gang-types.ts`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a84055b596483328f7a04d82115e6dc)