### PR TITLE
Handle cross-edition assets in sharing and cascading operations

### DIFF
--- a/app/actions/chem-alchemy.ts
+++ b/app/actions/chem-alchemy.ts
@@ -37,9 +37,8 @@ export async function createChemAlchemy({
     // Get the current user with optimized getClaims()
     const user = await getAuthenticatedUser(supabase);
 
-    // The gang's edition comes with the credits read: an elixir is custom_equipment,
-    // which needs an edition_id, and the gang it is crafted for is the only context
-    // that has one. Gangs have no edition of their own — it derives via the gang type.
+    // Elixirs are custom_equipment and need an edition; the gang is the only context
+    // that has one, derived via its gang type.
     const { data: gangData, error: gangFetchError } = await supabase
       .from('gangs')
       .select(`
@@ -55,8 +54,6 @@ export async function createChemAlchemy({
       throw new Error('Failed to fetch gang information');
     }
 
-    // Gate on the capability, not on the caller: the button is also hidden client-side,
-    // but a gang type id alone does not say which edition it belongs to.
     const gangEdition = gangEditionJoin(gangData);
     if (!hasChemAlchemy(gangEdition?.slug)) {
       throw new Error('Chem-Alchemy is not available for this gang edition');

--- a/app/actions/chem-alchemy.ts
+++ b/app/actions/chem-alchemy.ts
@@ -4,6 +4,7 @@ import { createClient } from "@/utils/supabase/server";
 import { invalidateGangStash, invalidateGangCredits } from '@/utils/cache-tags';
 import { getAuthenticatedUser } from '@/utils/auth';
 import { logEquipmentAction } from '@/app/actions/logs/equipment-logs';
+import { gangEditionJoin, hasChemAlchemy } from '@/types/edition';
 
 interface ChemEffect {
   name: string;
@@ -36,16 +37,29 @@ export async function createChemAlchemy({
     // Get the current user with optimized getClaims()
     const user = await getAuthenticatedUser(supabase);
 
-    // Check if gang has enough credits
+    // The gang's edition comes with the credits read: an elixir is custom_equipment,
+    // which needs an edition_id, and the gang it is crafted for is the only context
+    // that has one. Gangs have no edition of their own — it derives via the gang type.
     const { data: gangData, error: gangFetchError } = await supabase
       .from('gangs')
-      .select('credits')
+      .select(`
+        credits,
+        gang_types!gang_type_id ( editions:edition_id ( id, slug ) ),
+        custom_gang_type:custom_gang_types!custom_gang_type_id ( editions:edition_id ( id, slug ) )
+      `)
       .eq('id', gangId)
       .single();
 
     if (gangFetchError) {
       console.error('Error fetching gang credits:', gangFetchError);
       throw new Error('Failed to fetch gang information');
+    }
+
+    // Gate on the capability, not on the caller: the button is also hidden client-side,
+    // but a gang type id alone does not say which edition it belongs to.
+    const gangEdition = gangEditionJoin(gangData);
+    if (!hasChemAlchemy(gangEdition?.slug)) {
+      throw new Error('Chem-Alchemy is not available for this gang edition');
     }
 
     if (gangData.credits < totalCost) {
@@ -64,7 +78,8 @@ export async function createChemAlchemy({
         equipment_type: 'wargear',
         user_id: user.id,
         variant: `${type} - ${effects.map(e => e.name).join(', ')}`,
-        is_consumable: true
+        is_consumable: true,
+        edition_id: gangEdition?.id ?? null
       }])
       .select()
       .single();

--- a/app/actions/customise/custom-fighters.ts
+++ b/app/actions/customise/custom-fighters.ts
@@ -4,6 +4,7 @@ import { createClient } from '@/utils/supabase/server';
 import { getAuthenticatedUser } from '@/utils/auth';
 import { getEditionIdBySlug } from '@/app/lib/editions';
 import { CustomFighterType } from '@/types/fighter';
+import { withEditionSlug } from '@/types/edition';
 import { getCustomDescriptionLengthError, normalizeCustomDescription } from './custom-constants';
 import { removeItemFromAllCollections } from './custom-collections';
 import { invalidateUserCustomFighters, invalidateUserCustomCollections } from '@/utils/cache-tags';
@@ -63,6 +64,7 @@ async function getCompleteCustomFighter(
     .from('custom_fighter_types')
     .select(`
       *,
+      editions:edition_id (slug),
       fighter_type_skill_access (
         skill_type_id,
         custom_skill_type_id,
@@ -120,8 +122,10 @@ async function getCompleteCustomFighter(
   const defaultsData = (completeFighter.fighter_defaults || []) as any[];
   const equipmentListData = (completeFighter.custom_fighter_type_equipment || []) as any[];
 
+  // withEditionSlug, not a bare spread: the copy action stamps a copy with the
+  // source's edition_slug, so a row that lost it here would be re-badged N23.
   const transformedFighter: CustomFighterType = {
-    ...completeFighter,
+    ...withEditionSlug(completeFighter),
     skill_access: skillAccessData.map((sa) => ({
       skill_type_id: sa.skill_type_id || sa.custom_skill_type_id,
       access_level: sa.access_level,
@@ -168,6 +172,42 @@ async function getCompleteCustomFighter(
   return { data: transformedFighter };
 }
 
+/**
+ * A fighter attached to a custom gang type belongs to that gang type's edition,
+ * whatever the caller says. The caller's slug reflects whichever tab it was on,
+ * and a stale or missing one used to stamp an N26 fighter as N23 -- which then
+ * blocks sharing the gang type, since one cross-edition row aborts the batch.
+ * Falls back to the slug only when there is no custom parent to ask.
+ */
+async function resolveFighterEditionId(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  data: CreateCustomFighterData
+): Promise<string | null> {
+  if (!data.custom_gang_type_id) {
+    return getEditionIdBySlug(data.edition_slug);
+  }
+
+  const { data: parent, error } = await supabase
+    .from('custom_gang_types')
+    .select('edition_id, editions:edition_id (slug)')
+    .eq('id', data.custom_gang_type_id)
+    .single();
+
+  if (error || !parent?.edition_id) {
+    return getEditionIdBySlug(data.edition_slug);
+  }
+
+  const parentSlug = withEditionSlug(parent).edition_slug;
+  if (data.edition_slug && parentSlug && data.edition_slug !== parentSlug) {
+    console.warn(
+      `createCustomFighter: edition_slug "${data.edition_slug}" conflicts with custom gang type ` +
+      `${data.custom_gang_type_id} (${parentSlug}); using the gang type's edition.`
+    );
+  }
+
+  return parent.edition_id;
+}
+
 export async function createCustomFighter(data: CreateCustomFighterData): Promise<{ success: boolean; data?: CustomFighterType; error?: string }> {
   const description = normalizeCustomDescription(data.description);
   const lengthError = getCustomDescriptionLengthError(description);
@@ -207,7 +247,7 @@ export async function createCustomFighter(data: CreateCustomFighterData): Promis
         special_rules: data.special_rules,
         free_skill: data.free_skill,
         fighter_subtypes: data.fighter_subtypes,
-        edition_id: await getEditionIdBySlug(data.edition_slug),
+        edition_id: await resolveFighterEditionId(supabase, data),
         created_at: new Date().toISOString()
       })
       .select()

--- a/app/actions/customise/custom-fighters.ts
+++ b/app/actions/customise/custom-fighters.ts
@@ -122,8 +122,6 @@ async function getCompleteCustomFighter(
   const defaultsData = (completeFighter.fighter_defaults || []) as any[];
   const equipmentListData = (completeFighter.custom_fighter_type_equipment || []) as any[];
 
-  // withEditionSlug, not a bare spread: the copy action stamps a copy with the
-  // source's edition_slug, so a row that lost it here would be re-badged N23.
   const transformedFighter: CustomFighterType = {
     ...withEditionSlug(completeFighter),
     skill_access: skillAccessData.map((sa) => ({
@@ -173,11 +171,8 @@ async function getCompleteCustomFighter(
 }
 
 /**
- * A fighter attached to a custom gang type belongs to that gang type's edition,
- * whatever the caller says. The caller's slug reflects whichever tab it was on,
- * and a stale or missing one used to stamp an N26 fighter as N23 -- which then
- * blocks sharing the gang type, since one cross-edition row aborts the batch.
- * Falls back to the slug only when there is no custom parent to ask.
+ * A fighter belongs to its custom gang type's edition, not to whichever tab the
+ * caller was on. Falls back to the slug only when there is no custom parent.
  */
 async function resolveFighterEditionId(
   supabase: Awaited<ReturnType<typeof createClient>>,

--- a/app/actions/customise/custom-fighters.ts
+++ b/app/actions/customise/custom-fighters.ts
@@ -172,22 +172,27 @@ async function getCompleteCustomFighter(
 
 /**
  * A fighter belongs to its custom gang type's edition, not to whichever tab the
- * caller was on. Falls back to the slug only when there is no custom parent.
+ * caller was on. Falls back to the slug only when there is no gang type to ask.
  */
 async function resolveFighterEditionId(
   supabase: Awaited<ReturnType<typeof createClient>>,
   data: CreateCustomFighterData
 ): Promise<string | null> {
-  if (!data.custom_gang_type_id) {
-    return getEditionIdBySlug(data.edition_slug);
-  }
+  const parentQuery = data.custom_gang_type_id
+    ? supabase
+        .from('custom_gang_types')
+        .select('edition_id, editions:edition_id (slug)')
+        .eq('id', data.custom_gang_type_id)
+    : data.gang_type_id
+      ? supabase
+          .from('gang_types')
+          .select('edition_id, editions:edition_id (slug)')
+          .eq('gang_type_id', data.gang_type_id)
+      : null;
 
-  const { data: parent, error } = await supabase
-    .from('custom_gang_types')
-    .select('edition_id, editions:edition_id (slug)')
-    .eq('id', data.custom_gang_type_id)
-    .single();
+  if (!parentQuery) return getEditionIdBySlug(data.edition_slug);
 
+  const { data: parent, error } = await parentQuery.single();
   if (error || !parent?.edition_id) {
     return getEditionIdBySlug(data.edition_slug);
   }
@@ -195,8 +200,8 @@ async function resolveFighterEditionId(
   const parentSlug = withEditionSlug(parent).edition_slug;
   if (data.edition_slug && parentSlug && data.edition_slug !== parentSlug) {
     console.warn(
-      `createCustomFighter: edition_slug "${data.edition_slug}" conflicts with custom gang type ` +
-      `${data.custom_gang_type_id} (${parentSlug}); using the gang type's edition.`
+      `createCustomFighter: edition_slug "${data.edition_slug}" conflicts with the gang type's ` +
+      `edition (${parentSlug}); using the gang type's.`
     );
   }
 

--- a/app/actions/customise/custom-share.ts
+++ b/app/actions/customise/custom-share.ts
@@ -45,11 +45,8 @@ async function assertCampaignsMatchEdition(
 }
 
 /**
- * Cascaded children are shared under the root item's edition, but the cascade
- * queries walk relationships, not editions, so a child of another edition can be
- * swept in. The custom_shared trigger rejects it and one bad row aborts the whole
- * batch insert -- so drop it here and name it, rather than losing the entire share
- * to a stray asset.
+ * Cascade queries walk relationships, not editions. One child of another edition
+ * makes the custom_shared trigger abort the whole batch, so drop it and name it.
  */
 function partitionByEdition<T extends Record<string, any>>(
   rows: T[],
@@ -67,7 +64,6 @@ function partitionByEdition<T extends Record<string, any>>(
   return { kept, dropped };
 }
 
-/** Human-readable summary of what a cascade filter skipped, or undefined if nothing was. */
 function droppedWarning(dropped: { name?: string | null }[], kind: string): string | undefined {
   if (dropped.length === 0) return undefined;
   const names = dropped.map(d => d.name).filter(Boolean);
@@ -78,11 +74,7 @@ function droppedWarning(dropped: { name?: string | null }[], kind: string): stri
     : `Skipped ${dropped.length} ${kind} from a different edition`;
 }
 
-/**
- * The custom_shared trigger raises plain-text exceptions that would otherwise reach
- * the user's toast verbatim. Everything else passes through -- an unmapped Postgres
- * message is still more useful than a generic failure.
- */
+/** The custom_shared trigger's exceptions would otherwise reach the toast verbatim. */
 function friendlyShareError(prefix: string, message: string): string {
   if (message.includes('from a different edition')) {
     return `${prefix}: one of the shared assets is from a different edition than the campaign`;
@@ -159,8 +151,6 @@ export async function shareCustomFighter(customFighterTypeId: string, campaignId
         .map(a => a.custom_skill_type_id)
         .filter(Boolean) as string[];
 
-      // A skill type from another edition would be rejected by the trigger and take
-      // every other cascaded skill down with it, so filter before building the batch.
       let customSkillTypeIds: string[] = [];
       if (referencedSkillTypeIds.length > 0) {
         const { data: skillTypes } = await supabase
@@ -211,9 +201,8 @@ export async function shareCustomFighter(customFighterTypeId: string, campaignId
               .from('custom_shared')
               .insert(newSkillShares);
 
-            // Non-fatal: the fighter itself is already shared. Surfaced rather than
-            // swallowed, because one bad row fails every cascaded skill together and
-            // the user would otherwise see an unqualified success.
+            // Non-fatal: the fighter is already shared. Surfaced, not swallowed —
+            // one bad row fails every cascaded skill together.
             if (shareSkillsError) {
               console.error('Error auto-sharing custom skills for fighter:', shareSkillsError);
               warning = 'The fighter was shared, but its custom skills could not be shared';
@@ -297,8 +286,6 @@ export async function shareCustomGangType(customGangTypeId: string, campaignIds:
         .eq('custom_gang_type_id', customGangTypeId)
         .eq('user_id', user.id);
 
-      // Owning the fighter is not enough: a copy path could have stamped it with a
-      // different edition, and the trigger would then fail the whole batch.
       const fighterSplit = partitionByEdition(
         (relatedFighters ?? []).map(f => ({ ...f, name: (f as any).fighter_type })),
         gangTypeEdition
@@ -700,10 +687,7 @@ export async function shareCollection(collectionId: string, campaignIds: string[
     const skillIds = new Set(items.filter(i => i.type === 'skill').map(i => i.id));
     const tradingPostIds = new Set(items.filter(i => i.type === 'trading_post').map(i => i.id));
 
-    // Cascade: gang types -> their custom fighter types.
-    // Filtered by edition, not just ownership: a fighter copied from another user's
-    // profile could be stamped with a different edition than the gang type it hangs
-    // off, and one such row makes the trigger abort the entire batch insert below.
+    // Cascade: gang types -> their custom fighter types
     if (gangTypeIds.size > 0) {
       const { data: fighters } = await supabase
         .from('custom_fighter_types')

--- a/app/actions/customise/custom-share.ts
+++ b/app/actions/customise/custom-share.ts
@@ -66,12 +66,74 @@ function partitionByEdition<T extends Record<string, any>>(
 
 function droppedWarning(dropped: { name?: string | null }[], kind: string): string | undefined {
   if (dropped.length === 0) return undefined;
+  const summary = `Skipped ${dropped.length} ${kind} from a different edition`;
   const names = dropped.map(d => d.name).filter(Boolean);
-  const shown = names.slice(0, 3).join(', ');
+  // Only name them when every dropped row has one, so the count and the list agree.
+  if (names.length !== dropped.length) return summary;
   const rest = names.length > 3 ? ` and ${names.length - 3} more` : '';
-  return names.length > 0
-    ? `Skipped ${dropped.length} ${kind} from a different edition: ${shown}${rest}`
-    : `Skipped ${dropped.length} ${kind} from a different edition`;
+  return `${summary}: ${names.slice(0, 3).join(', ')}${rest}`;
+}
+
+/**
+ * Items the user put in a collection directly, filtered like the cascaded ones.
+ * A cross-edition row here fails the whole batch after the delete has already run,
+ * which leaves the collection unshared rather than partially shared.
+ */
+async function dropConflictingItems(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  table: string,
+  nameColumn: string,
+  ids: Set<string>,
+  editionSlug: string | null,
+  kind: string,
+  warnings: string[]
+): Promise<void> {
+  if (ids.size === 0) return;
+
+  // Cast: the generated types cannot parse a select built from a variable column.
+  const { data } = (await supabase
+    .from(table)
+    .select(`id, name:${nameColumn}, editions:edition_id (slug)`)
+    .in('id', Array.from(ids))) as {
+      data: { id: string; name: string | null; editions?: unknown }[] | null;
+    };
+
+  const { dropped } = partitionByEdition(data ?? [], editionSlug);
+  dropped.forEach(row => ids.delete(row.id));
+  const warning = droppedWarning(dropped, kind);
+  if (warning) warnings.push(warning);
+}
+
+/** Skills carry no edition of their own, so this resolves through the skill type. */
+async function dropConflictingSkills(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  ids: Set<string>,
+  editionSlug: string | null,
+  warnings: string[]
+): Promise<void> {
+  if (ids.size === 0) return;
+
+  const { data } = await supabase
+    .from('custom_skills')
+    .select(`
+      id,
+      name:skill_name,
+      skill_types (editions:edition_id (slug)),
+      custom_skill_types (editions:edition_id (slug))
+    `)
+    .in('id', Array.from(ids));
+
+  const dropped = (data ?? []).filter((skill: any) =>
+    editionsConflict(
+      editionSlug,
+      editionSlugFromJoin(skill.custom_skill_types?.editions)
+        ?? editionSlugFromJoin(skill.skill_types?.editions)
+    )
+  );
+
+  dropped.forEach((row: any) => ids.delete(row.id));
+  const warning = droppedWarning(dropped as { name?: string | null }[], 'skills');
+  if (warning) warnings.push(warning);
 }
 
 /** The custom_shared trigger's exceptions would otherwise reach the toast verbatim. */
@@ -109,7 +171,7 @@ export async function shareCustomFighter(customFighterTypeId: string, campaignId
     const editionCheck = await assertCampaignsMatchEdition(supabase, fighterEdition, campaignIds);
     if (!editionCheck.ok) return { success: false, error: editionCheck.error };
 
-    let warning: string | undefined;
+    const warnings: string[] = [];
 
     // Delete existing shares for this fighter
     const { error: deleteError } = await supabase
@@ -160,7 +222,8 @@ export async function shareCustomFighter(customFighterTypeId: string, campaignId
 
         const { kept, dropped } = partitionByEdition(skillTypes ?? [], fighterEdition);
         customSkillTypeIds = kept.map(t => t.id);
-        warning = droppedWarning(dropped, 'skill types');
+        const skillWarning = droppedWarning(dropped, 'skill types');
+        if (skillWarning) warnings.push(skillWarning);
       }
 
       if (customSkillTypeIds.length > 0) {
@@ -205,14 +268,14 @@ export async function shareCustomFighter(customFighterTypeId: string, campaignId
             // one bad row fails every cascaded skill together.
             if (shareSkillsError) {
               console.error('Error auto-sharing custom skills for fighter:', shareSkillsError);
-              warning = 'The fighter was shared, but its custom skills could not be shared';
+              warnings.push('The fighter was shared, but its custom skills could not be shared');
             }
           }
         }
       }
     }
 
-    return { success: true, warning };
+    return { success: true, warning: warnings.join('. ') || undefined };
   } catch (error) {
     console.error('Error in shareCustomFighter:', error);
     return {
@@ -282,14 +345,11 @@ export async function shareCustomGangType(customGangTypeId: string, campaignIds:
       // --- Cascade: share all custom fighters belonging to this gang type ---
       const { data: relatedFighters } = await supabase
         .from('custom_fighter_types')
-        .select('id, fighter_type, editions:edition_id (slug)')
+        .select('id, name:fighter_type, editions:edition_id (slug)')
         .eq('custom_gang_type_id', customGangTypeId)
         .eq('user_id', user.id);
 
-      const fighterSplit = partitionByEdition(
-        (relatedFighters ?? []).map(f => ({ ...f, name: (f as any).fighter_type })),
-        gangTypeEdition
-      );
+      const fighterSplit = partitionByEdition(relatedFighters ?? [], gangTypeEdition);
       const fighterIds = fighterSplit.kept.map(f => f.id);
       const fighterWarning = droppedWarning(fighterSplit.dropped, 'fighter types');
       if (fighterWarning) warnings.push(fighterWarning);
@@ -687,18 +747,24 @@ export async function shareCollection(collectionId: string, campaignIds: string[
     const skillIds = new Set(items.filter(i => i.type === 'skill').map(i => i.id));
     const tradingPostIds = new Set(items.filter(i => i.type === 'trading_post').map(i => i.id));
 
+    // Before the cascades, so a dropped gang type does not pull its fighters in either.
+    await Promise.all([
+      dropConflictingItems(supabase, 'custom_equipment', 'equipment_name', equipmentIds, collectionEdition, 'equipment', warnings),
+      dropConflictingItems(supabase, 'custom_gang_types', 'gang_type', gangTypeIds, collectionEdition, 'gang types', warnings),
+      dropConflictingItems(supabase, 'custom_fighter_types', 'fighter_type', fighterTypeIds, collectionEdition, 'fighter types', warnings),
+      dropConflictingItems(supabase, 'custom_trading_posts', 'custom_trading_post_name', tradingPostIds, collectionEdition, 'trading posts', warnings),
+      dropConflictingSkills(supabase, skillIds, collectionEdition, warnings),
+    ]);
+
     // Cascade: gang types -> their custom fighter types
     if (gangTypeIds.size > 0) {
       const { data: fighters } = await supabase
         .from('custom_fighter_types')
-        .select('id, fighter_type, editions:edition_id (slug)')
+        .select('id, name:fighter_type, editions:edition_id (slug)')
         .in('custom_gang_type_id', Array.from(gangTypeIds))
         .eq('user_id', user.id);
 
-      const split = partitionByEdition(
-        (fighters ?? []).map(f => ({ ...f, name: (f as any).fighter_type })),
-        collectionEdition
-      );
+      const split = partitionByEdition(fighters ?? [], collectionEdition);
       split.kept.forEach(f => fighterTypeIds.add(f.id));
       const warning = droppedWarning(split.dropped, 'fighter types');
       if (warning) warnings.push(warning);

--- a/app/actions/customise/custom-share.ts
+++ b/app/actions/customise/custom-share.ts
@@ -44,98 +44,6 @@ async function assertCampaignsMatchEdition(
   return { ok: true };
 }
 
-/**
- * Cascade queries walk relationships, not editions. One child of another edition
- * makes the custom_shared trigger abort the whole batch, so drop it and name it.
- */
-function partitionByEdition<T extends Record<string, any>>(
-  rows: T[],
-  editionSlug: string | null
-): { kept: T[]; dropped: T[] } {
-  const kept: T[] = [];
-  const dropped: T[] = [];
-  for (const row of rows) {
-    if (editionsConflict(editionSlug, editionSlugFromJoin(row.editions))) {
-      dropped.push(row);
-    } else {
-      kept.push(row);
-    }
-  }
-  return { kept, dropped };
-}
-
-function droppedWarning(dropped: { name?: string | null }[], kind: string): string | undefined {
-  if (dropped.length === 0) return undefined;
-  const summary = `Skipped ${dropped.length} ${kind} from a different edition`;
-  const names = dropped.map(d => d.name).filter(Boolean);
-  // Only name them when every dropped row has one, so the count and the list agree.
-  if (names.length !== dropped.length) return summary;
-  const rest = names.length > 3 ? ` and ${names.length - 3} more` : '';
-  return `${summary}: ${names.slice(0, 3).join(', ')}${rest}`;
-}
-
-/**
- * Items the user put in a collection directly, filtered like the cascaded ones.
- * A cross-edition row here fails the whole batch after the delete has already run,
- * which leaves the collection unshared rather than partially shared.
- */
-async function dropConflictingItems(
-  supabase: Awaited<ReturnType<typeof createClient>>,
-  table: string,
-  nameColumn: string,
-  ids: Set<string>,
-  editionSlug: string | null,
-  kind: string,
-  warnings: string[]
-): Promise<void> {
-  if (ids.size === 0) return;
-
-  // Cast: the generated types cannot parse a select built from a variable column.
-  const { data } = (await supabase
-    .from(table)
-    .select(`id, name:${nameColumn}, editions:edition_id (slug)`)
-    .in('id', Array.from(ids))) as {
-      data: { id: string; name: string | null; editions?: unknown }[] | null;
-    };
-
-  const { dropped } = partitionByEdition(data ?? [], editionSlug);
-  dropped.forEach(row => ids.delete(row.id));
-  const warning = droppedWarning(dropped, kind);
-  if (warning) warnings.push(warning);
-}
-
-/** Skills carry no edition of their own, so this resolves through the skill type. */
-async function dropConflictingSkills(
-  supabase: Awaited<ReturnType<typeof createClient>>,
-  ids: Set<string>,
-  editionSlug: string | null,
-  warnings: string[]
-): Promise<void> {
-  if (ids.size === 0) return;
-
-  const { data } = await supabase
-    .from('custom_skills')
-    .select(`
-      id,
-      name:skill_name,
-      skill_types (editions:edition_id (slug)),
-      custom_skill_types (editions:edition_id (slug))
-    `)
-    .in('id', Array.from(ids));
-
-  const dropped = (data ?? []).filter((skill: any) =>
-    editionsConflict(
-      editionSlug,
-      editionSlugFromJoin(skill.custom_skill_types?.editions)
-        ?? editionSlugFromJoin(skill.skill_types?.editions)
-    )
-  );
-
-  dropped.forEach((row: any) => ids.delete(row.id));
-  const warning = droppedWarning(dropped as { name?: string | null }[], 'skills');
-  if (warning) warnings.push(warning);
-}
-
 /** The custom_shared trigger's exceptions would otherwise reach the toast verbatim. */
 function friendlyShareError(prefix: string, message: string): string {
   if (message.includes('from a different edition')) {
@@ -150,7 +58,7 @@ function friendlyShareError(prefix: string, message: string): string {
 /**
  * Share a custom fighter to selected campaigns
  */
-export async function shareCustomFighter(customFighterTypeId: string, campaignIds: string[]): Promise<{ success: boolean; error?: string; warning?: string }> {
+export async function shareCustomFighter(customFighterTypeId: string, campaignIds: string[]): Promise<{ success: boolean; error?: string }> {
   try {
     const supabase = await createClient();
     const user = await getAuthenticatedUser(supabase);
@@ -167,11 +75,10 @@ export async function shareCustomFighter(customFighterTypeId: string, campaignId
       return { success: false, error: 'Custom fighter not found or not owned by user' };
     }
 
-    const fighterEdition = editionSlugFromJoin((customFighter as any).editions);
-    const editionCheck = await assertCampaignsMatchEdition(supabase, fighterEdition, campaignIds);
+    const editionCheck = await assertCampaignsMatchEdition(
+      supabase, editionSlugFromJoin((customFighter as any).editions), campaignIds
+    );
     if (!editionCheck.ok) return { success: false, error: editionCheck.error };
-
-    const warnings: string[] = [];
 
     // Delete existing shares for this fighter
     const { error: deleteError } = await supabase
@@ -209,22 +116,9 @@ export async function shareCustomFighter(customFighterTypeId: string, campaignId
         .eq('custom_fighter_type_id', customFighterTypeId)
         .not('custom_skill_type_id', 'is', null);
 
-      const referencedSkillTypeIds = (fighterSkillAccess ?? [])
+      const customSkillTypeIds = (fighterSkillAccess ?? [])
         .map(a => a.custom_skill_type_id)
         .filter(Boolean) as string[];
-
-      let customSkillTypeIds: string[] = [];
-      if (referencedSkillTypeIds.length > 0) {
-        const { data: skillTypes } = await supabase
-          .from('custom_skill_types')
-          .select('id, name, editions:edition_id (slug)')
-          .in('id', referencedSkillTypeIds);
-
-        const { kept, dropped } = partitionByEdition(skillTypes ?? [], fighterEdition);
-        customSkillTypeIds = kept.map(t => t.id);
-        const skillWarning = droppedWarning(dropped, 'skill types');
-        if (skillWarning) warnings.push(skillWarning);
-      }
 
       if (customSkillTypeIds.length > 0) {
         // Find all custom skills belonging to these custom skill types (owned by user)
@@ -264,18 +158,18 @@ export async function shareCustomFighter(customFighterTypeId: string, campaignId
               .from('custom_shared')
               .insert(newSkillShares);
 
-            // Non-fatal: the fighter is already shared. Surfaced, not swallowed —
-            // one bad row fails every cascaded skill together.
+            // Non-fatal by design: the fighter is already shared. Note that a skill whose type
+            // is from another edition would be rejected by the custom_shared trigger, and one
+            // bad row aborts the whole insert, so every skill here fails together.
             if (shareSkillsError) {
               console.error('Error auto-sharing custom skills for fighter:', shareSkillsError);
-              warnings.push('The fighter was shared, but its custom skills could not be shared');
             }
           }
         }
       }
     }
 
-    return { success: true, warning: warnings.join('. ') || undefined };
+    return { success: true };
   } catch (error) {
     console.error('Error in shareCustomFighter:', error);
     return {
@@ -290,7 +184,7 @@ export async function shareCustomFighter(customFighterTypeId: string, campaignId
  * Cascades: also shares all custom_fighter_types belonging to this gang type,
  * and their custom skills.
  */
-export async function shareCustomGangType(customGangTypeId: string, campaignIds: string[]): Promise<{ success: boolean; error?: string; warning?: string }> {
+export async function shareCustomGangType(customGangTypeId: string, campaignIds: string[]): Promise<{ success: boolean; error?: string }> {
   try {
     const supabase = await createClient();
     const user = await getAuthenticatedUser(supabase);
@@ -307,11 +201,10 @@ export async function shareCustomGangType(customGangTypeId: string, campaignIds:
       return { success: false, error: 'Custom gang type not found or not owned by user' };
     }
 
-    const gangTypeEdition = editionSlugFromJoin((customGangType as any).editions);
-    const editionCheck = await assertCampaignsMatchEdition(supabase, gangTypeEdition, campaignIds);
+    const editionCheck = await assertCampaignsMatchEdition(
+      supabase, editionSlugFromJoin((customGangType as any).editions), campaignIds
+    );
     if (!editionCheck.ok) return { success: false, error: editionCheck.error };
-
-    const warnings: string[] = [];
 
     // Delete existing shares for this gang type
     const { error: deleteError } = await supabase
@@ -345,14 +238,11 @@ export async function shareCustomGangType(customGangTypeId: string, campaignIds:
       // --- Cascade: share all custom fighters belonging to this gang type ---
       const { data: relatedFighters } = await supabase
         .from('custom_fighter_types')
-        .select('id, name:fighter_type, editions:edition_id (slug)')
+        .select('id')
         .eq('custom_gang_type_id', customGangTypeId)
         .eq('user_id', user.id);
 
-      const fighterSplit = partitionByEdition(relatedFighters ?? [], gangTypeEdition);
-      const fighterIds = fighterSplit.kept.map(f => f.id);
-      const fighterWarning = droppedWarning(fighterSplit.dropped, 'fighter types');
-      if (fighterWarning) warnings.push(fighterWarning);
+      const fighterIds = (relatedFighters ?? []).map(f => f.id);
 
       if (fighterIds.length > 0) {
         // Check which fighter shares already exist
@@ -384,7 +274,6 @@ export async function shareCustomGangType(customGangTypeId: string, campaignIds:
 
           if (shareFightersError) {
             console.error('Error auto-sharing custom fighters for gang type:', shareFightersError);
-            warnings.push('The gang type was shared, but its fighter types could not be');
           }
         }
 
@@ -395,24 +284,11 @@ export async function shareCustomGangType(customGangTypeId: string, campaignIds:
           .in('custom_fighter_type_id', fighterIds)
           .not('custom_skill_type_id', 'is', null);
 
-        const referencedSkillTypeIds = Array.from(new Set(
+        const customSkillTypeIds = Array.from(new Set(
           (fighterSkillAccess ?? [])
             .map(a => a.custom_skill_type_id)
             .filter(Boolean) as string[]
         ));
-
-        let customSkillTypeIds: string[] = [];
-        if (referencedSkillTypeIds.length > 0) {
-          const { data: skillTypes } = await supabase
-            .from('custom_skill_types')
-            .select('id, name, editions:edition_id (slug)')
-            .in('id', referencedSkillTypeIds);
-
-          const split = partitionByEdition(skillTypes ?? [], gangTypeEdition);
-          customSkillTypeIds = split.kept.map(t => t.id);
-          const skillWarning = droppedWarning(split.dropped, 'skill types');
-          if (skillWarning) warnings.push(skillWarning);
-        }
 
         if (customSkillTypeIds.length > 0) {
           const { data: customSkills } = await supabase
@@ -452,7 +328,6 @@ export async function shareCustomGangType(customGangTypeId: string, campaignIds:
 
               if (shareSkillsError) {
                 console.error('Error auto-sharing custom skills for gang type:', shareSkillsError);
-                warnings.push('The gang type was shared, but its custom skills could not be');
               }
             }
           }
@@ -460,7 +335,7 @@ export async function shareCustomGangType(customGangTypeId: string, campaignIds:
       }
     }
 
-    return { success: true, warning: warnings.join('. ') || undefined };
+    return { success: true };
   } catch (error) {
     console.error('Error in shareCustomGangType:', error);
     return {
@@ -546,7 +421,12 @@ export async function shareCustomSkill(customSkillId: string, campaignIds: strin
     // Verify the custom skill belongs to the user
     const { data: customSkill, error: skillError } = await supabase
       .from('custom_skills')
-      .select('id, user_id, custom_skill_types:custom_skill_type_id (editions:edition_id (slug))')
+      .select(`
+        id,
+        user_id,
+        skill_types:skill_type_id (editions:edition_id (slug)),
+        custom_skill_types:custom_skill_type_id (editions:edition_id (slug))
+      `)
       .eq('id', customSkillId)
       .eq('user_id', user.id)
       .single();
@@ -555,9 +435,14 @@ export async function shareCustomSkill(customSkillId: string, campaignIds: strin
       return { success: false, error: 'Custom skill not found or not owned by user' };
     }
 
-    const editionCheck = await assertCampaignsMatchEdition(
-      supabase, editionSlugFromJoin((customSkill as any).custom_skill_types?.editions), campaignIds
-    );
+    // A quarter of custom skills are built on a system skill type. Resolving only the
+    // custom one leaves those with no edition, which this check reads as "no claim"
+    // and accepts into any campaign. Custom wins, matching getUserCustomSkills.
+    const skillEdition =
+      editionSlugFromJoin((customSkill as any).custom_skill_types?.editions)
+      ?? editionSlugFromJoin((customSkill as any).skill_types?.editions);
+
+    const editionCheck = await assertCampaignsMatchEdition(supabase, skillEdition, campaignIds);
     if (!editionCheck.ok) return { success: false, error: editionCheck.error };
 
     // Delete existing shares for this skill
@@ -718,7 +603,7 @@ interface CollectionShareRow {
  * all match the collection's edition (enforced here).
  * Passing an empty campaignIds unshares the collection from all campaigns.
  */
-export async function shareCollection(collectionId: string, campaignIds: string[]): Promise<{ success: boolean; error?: string; warning?: string }> {
+export async function shareCollection(collectionId: string, campaignIds: string[]): Promise<{ success: boolean; error?: string }> {
   try {
     const supabase = await createClient();
     const user = await getAuthenticatedUser(supabase);
@@ -734,11 +619,10 @@ export async function shareCollection(collectionId: string, campaignIds: string[
       return { success: false, error: 'Collection not found or not owned by user' };
     }
 
-    const collectionEdition = editionSlugFromJoin((collection as any).editions);
-    const editionCheck = await assertCampaignsMatchEdition(supabase, collectionEdition, campaignIds);
+    const editionCheck = await assertCampaignsMatchEdition(
+      supabase, editionSlugFromJoin((collection as any).editions), campaignIds
+    );
     if (!editionCheck.ok) return { success: false, error: editionCheck.error };
-
-    const warnings: string[] = [];
 
     const items = ((collection.items as { type: string; id: string }[]) || []);
     const equipmentIds = new Set(items.filter(i => i.type === 'equipment').map(i => i.id));
@@ -747,27 +631,14 @@ export async function shareCollection(collectionId: string, campaignIds: string[
     const skillIds = new Set(items.filter(i => i.type === 'skill').map(i => i.id));
     const tradingPostIds = new Set(items.filter(i => i.type === 'trading_post').map(i => i.id));
 
-    // Before the cascades, so a dropped gang type does not pull its fighters in either.
-    await Promise.all([
-      dropConflictingItems(supabase, 'custom_equipment', 'equipment_name', equipmentIds, collectionEdition, 'equipment', warnings),
-      dropConflictingItems(supabase, 'custom_gang_types', 'gang_type', gangTypeIds, collectionEdition, 'gang types', warnings),
-      dropConflictingItems(supabase, 'custom_fighter_types', 'fighter_type', fighterTypeIds, collectionEdition, 'fighter types', warnings),
-      dropConflictingItems(supabase, 'custom_trading_posts', 'custom_trading_post_name', tradingPostIds, collectionEdition, 'trading posts', warnings),
-      dropConflictingSkills(supabase, skillIds, collectionEdition, warnings),
-    ]);
-
     // Cascade: gang types -> their custom fighter types
     if (gangTypeIds.size > 0) {
       const { data: fighters } = await supabase
         .from('custom_fighter_types')
-        .select('id, name:fighter_type, editions:edition_id (slug)')
+        .select('id')
         .in('custom_gang_type_id', Array.from(gangTypeIds))
         .eq('user_id', user.id);
-
-      const split = partitionByEdition(fighters ?? [], collectionEdition);
-      split.kept.forEach(f => fighterTypeIds.add(f.id));
-      const warning = droppedWarning(split.dropped, 'fighter types');
-      if (warning) warnings.push(warning);
+      (fighters ?? []).forEach(f => fighterTypeIds.add(f.id));
     }
 
     // Cascade: fighter types -> their custom skills (via custom skill types)
@@ -778,22 +649,9 @@ export async function shareCollection(collectionId: string, campaignIds: string[
         .in('custom_fighter_type_id', Array.from(fighterTypeIds))
         .not('custom_skill_type_id', 'is', null);
 
-      const referencedSkillTypeIds = Array.from(new Set(
+      const skillTypeIds = Array.from(new Set(
         (access ?? []).map(a => a.custom_skill_type_id).filter(Boolean) as string[]
       ));
-
-      let skillTypeIds: string[] = [];
-      if (referencedSkillTypeIds.length > 0) {
-        const { data: skillTypes } = await supabase
-          .from('custom_skill_types')
-          .select('id, name, editions:edition_id (slug)')
-          .in('id', referencedSkillTypeIds);
-
-        const split = partitionByEdition(skillTypes ?? [], collectionEdition);
-        skillTypeIds = split.kept.map(t => t.id);
-        const warning = droppedWarning(split.dropped, 'skill types');
-        if (warning) warnings.push(warning);
-      }
 
       if (skillTypeIds.length > 0) {
         const { data: skills } = await supabase
@@ -920,7 +778,7 @@ export async function shareCollection(collectionId: string, campaignIds: string[
     for (const cid of campaignIds) {
       revalidateTag(CACHE_TAGS.BASE_CAMPAIGN_BASIC(cid), { expire: 0 });
     }
-    return { success: true, warning: warnings.join('. ') || undefined };
+    return { success: true };
   } catch (error) {
     console.error('Error in shareCollection:', error);
     return {

--- a/app/actions/customise/custom-share.ts
+++ b/app/actions/customise/custom-share.ts
@@ -45,9 +45,58 @@ async function assertCampaignsMatchEdition(
 }
 
 /**
+ * Cascaded children are shared under the root item's edition, but the cascade
+ * queries walk relationships, not editions, so a child of another edition can be
+ * swept in. The custom_shared trigger rejects it and one bad row aborts the whole
+ * batch insert -- so drop it here and name it, rather than losing the entire share
+ * to a stray asset.
+ */
+function partitionByEdition<T extends Record<string, any>>(
+  rows: T[],
+  editionSlug: string | null
+): { kept: T[]; dropped: T[] } {
+  const kept: T[] = [];
+  const dropped: T[] = [];
+  for (const row of rows) {
+    if (editionsConflict(editionSlug, editionSlugFromJoin(row.editions))) {
+      dropped.push(row);
+    } else {
+      kept.push(row);
+    }
+  }
+  return { kept, dropped };
+}
+
+/** Human-readable summary of what a cascade filter skipped, or undefined if nothing was. */
+function droppedWarning(dropped: { name?: string | null }[], kind: string): string | undefined {
+  if (dropped.length === 0) return undefined;
+  const names = dropped.map(d => d.name).filter(Boolean);
+  const shown = names.slice(0, 3).join(', ');
+  const rest = names.length > 3 ? ` and ${names.length - 3} more` : '';
+  return names.length > 0
+    ? `Skipped ${dropped.length} ${kind} from a different edition: ${shown}${rest}`
+    : `Skipped ${dropped.length} ${kind} from a different edition`;
+}
+
+/**
+ * The custom_shared trigger raises plain-text exceptions that would otherwise reach
+ * the user's toast verbatim. Everything else passes through -- an unmapped Postgres
+ * message is still more useful than a generic failure.
+ */
+function friendlyShareError(prefix: string, message: string): string {
+  if (message.includes('from a different edition')) {
+    return `${prefix}: one of the shared assets is from a different edition than the campaign`;
+  }
+  if (message.includes('cannot resolve the share edition')) {
+    return `${prefix}: that campaign has no edition set`;
+  }
+  return `${prefix}: ${message}`;
+}
+
+/**
  * Share a custom fighter to selected campaigns
  */
-export async function shareCustomFighter(customFighterTypeId: string, campaignIds: string[]): Promise<{ success: boolean; error?: string }> {
+export async function shareCustomFighter(customFighterTypeId: string, campaignIds: string[]): Promise<{ success: boolean; error?: string; warning?: string }> {
   try {
     const supabase = await createClient();
     const user = await getAuthenticatedUser(supabase);
@@ -64,10 +113,11 @@ export async function shareCustomFighter(customFighterTypeId: string, campaignId
       return { success: false, error: 'Custom fighter not found or not owned by user' };
     }
 
-    const editionCheck = await assertCampaignsMatchEdition(
-      supabase, editionSlugFromJoin((customFighter as any).editions), campaignIds
-    );
+    const fighterEdition = editionSlugFromJoin((customFighter as any).editions);
+    const editionCheck = await assertCampaignsMatchEdition(supabase, fighterEdition, campaignIds);
     if (!editionCheck.ok) return { success: false, error: editionCheck.error };
+
+    let warning: string | undefined;
 
     // Delete existing shares for this fighter
     const { error: deleteError } = await supabase
@@ -95,7 +145,7 @@ export async function shareCustomFighter(customFighterTypeId: string, campaignId
 
       if (insertError) {
         console.error('Error inserting shares:', insertError);
-        return { success: false, error: `Failed to share fighter: ${insertError.message}` };
+        return { success: false, error: friendlyShareError('Failed to share fighter', insertError.message) };
       }
 
       // Auto-share custom skill types referenced by this fighter's skill access
@@ -105,9 +155,23 @@ export async function shareCustomFighter(customFighterTypeId: string, campaignId
         .eq('custom_fighter_type_id', customFighterTypeId)
         .not('custom_skill_type_id', 'is', null);
 
-      const customSkillTypeIds = (fighterSkillAccess ?? [])
+      const referencedSkillTypeIds = (fighterSkillAccess ?? [])
         .map(a => a.custom_skill_type_id)
         .filter(Boolean) as string[];
+
+      // A skill type from another edition would be rejected by the trigger and take
+      // every other cascaded skill down with it, so filter before building the batch.
+      let customSkillTypeIds: string[] = [];
+      if (referencedSkillTypeIds.length > 0) {
+        const { data: skillTypes } = await supabase
+          .from('custom_skill_types')
+          .select('id, name, editions:edition_id (slug)')
+          .in('id', referencedSkillTypeIds);
+
+        const { kept, dropped } = partitionByEdition(skillTypes ?? [], fighterEdition);
+        customSkillTypeIds = kept.map(t => t.id);
+        warning = droppedWarning(dropped, 'skill types');
+      }
 
       if (customSkillTypeIds.length > 0) {
         // Find all custom skills belonging to these custom skill types (owned by user)
@@ -147,18 +211,19 @@ export async function shareCustomFighter(customFighterTypeId: string, campaignId
               .from('custom_shared')
               .insert(newSkillShares);
 
-            // Non-fatal by design: the fighter is already shared. Note that a skill whose type
-            // is from another edition would be rejected by the custom_shared trigger, and one
-            // bad row aborts the whole insert, so every skill here fails together.
+            // Non-fatal: the fighter itself is already shared. Surfaced rather than
+            // swallowed, because one bad row fails every cascaded skill together and
+            // the user would otherwise see an unqualified success.
             if (shareSkillsError) {
               console.error('Error auto-sharing custom skills for fighter:', shareSkillsError);
+              warning = 'The fighter was shared, but its custom skills could not be shared';
             }
           }
         }
       }
     }
 
-    return { success: true };
+    return { success: true, warning };
   } catch (error) {
     console.error('Error in shareCustomFighter:', error);
     return {
@@ -173,7 +238,7 @@ export async function shareCustomFighter(customFighterTypeId: string, campaignId
  * Cascades: also shares all custom_fighter_types belonging to this gang type,
  * and their custom skills.
  */
-export async function shareCustomGangType(customGangTypeId: string, campaignIds: string[]): Promise<{ success: boolean; error?: string }> {
+export async function shareCustomGangType(customGangTypeId: string, campaignIds: string[]): Promise<{ success: boolean; error?: string; warning?: string }> {
   try {
     const supabase = await createClient();
     const user = await getAuthenticatedUser(supabase);
@@ -190,10 +255,11 @@ export async function shareCustomGangType(customGangTypeId: string, campaignIds:
       return { success: false, error: 'Custom gang type not found or not owned by user' };
     }
 
-    const editionCheck = await assertCampaignsMatchEdition(
-      supabase, editionSlugFromJoin((customGangType as any).editions), campaignIds
-    );
+    const gangTypeEdition = editionSlugFromJoin((customGangType as any).editions);
+    const editionCheck = await assertCampaignsMatchEdition(supabase, gangTypeEdition, campaignIds);
     if (!editionCheck.ok) return { success: false, error: editionCheck.error };
+
+    const warnings: string[] = [];
 
     // Delete existing shares for this gang type
     const { error: deleteError } = await supabase
@@ -221,17 +287,25 @@ export async function shareCustomGangType(customGangTypeId: string, campaignIds:
 
       if (insertError) {
         console.error('Error inserting gang type shares:', insertError);
-        return { success: false, error: `Failed to share gang type: ${insertError.message}` };
+        return { success: false, error: friendlyShareError('Failed to share gang type', insertError.message) };
       }
 
       // --- Cascade: share all custom fighters belonging to this gang type ---
       const { data: relatedFighters } = await supabase
         .from('custom_fighter_types')
-        .select('id')
+        .select('id, fighter_type, editions:edition_id (slug)')
         .eq('custom_gang_type_id', customGangTypeId)
         .eq('user_id', user.id);
 
-      const fighterIds = (relatedFighters ?? []).map(f => f.id);
+      // Owning the fighter is not enough: a copy path could have stamped it with a
+      // different edition, and the trigger would then fail the whole batch.
+      const fighterSplit = partitionByEdition(
+        (relatedFighters ?? []).map(f => ({ ...f, name: (f as any).fighter_type })),
+        gangTypeEdition
+      );
+      const fighterIds = fighterSplit.kept.map(f => f.id);
+      const fighterWarning = droppedWarning(fighterSplit.dropped, 'fighter types');
+      if (fighterWarning) warnings.push(fighterWarning);
 
       if (fighterIds.length > 0) {
         // Check which fighter shares already exist
@@ -263,6 +337,7 @@ export async function shareCustomGangType(customGangTypeId: string, campaignIds:
 
           if (shareFightersError) {
             console.error('Error auto-sharing custom fighters for gang type:', shareFightersError);
+            warnings.push('The gang type was shared, but its fighter types could not be');
           }
         }
 
@@ -273,11 +348,24 @@ export async function shareCustomGangType(customGangTypeId: string, campaignIds:
           .in('custom_fighter_type_id', fighterIds)
           .not('custom_skill_type_id', 'is', null);
 
-        const customSkillTypeIds = Array.from(new Set(
+        const referencedSkillTypeIds = Array.from(new Set(
           (fighterSkillAccess ?? [])
             .map(a => a.custom_skill_type_id)
             .filter(Boolean) as string[]
         ));
+
+        let customSkillTypeIds: string[] = [];
+        if (referencedSkillTypeIds.length > 0) {
+          const { data: skillTypes } = await supabase
+            .from('custom_skill_types')
+            .select('id, name, editions:edition_id (slug)')
+            .in('id', referencedSkillTypeIds);
+
+          const split = partitionByEdition(skillTypes ?? [], gangTypeEdition);
+          customSkillTypeIds = split.kept.map(t => t.id);
+          const skillWarning = droppedWarning(split.dropped, 'skill types');
+          if (skillWarning) warnings.push(skillWarning);
+        }
 
         if (customSkillTypeIds.length > 0) {
           const { data: customSkills } = await supabase
@@ -317,6 +405,7 @@ export async function shareCustomGangType(customGangTypeId: string, campaignIds:
 
               if (shareSkillsError) {
                 console.error('Error auto-sharing custom skills for gang type:', shareSkillsError);
+                warnings.push('The gang type was shared, but its custom skills could not be');
               }
             }
           }
@@ -324,7 +413,7 @@ export async function shareCustomGangType(customGangTypeId: string, campaignIds:
       }
     }
 
-    return { success: true };
+    return { success: true, warning: warnings.join('. ') || undefined };
   } catch (error) {
     console.error('Error in shareCustomGangType:', error);
     return {
@@ -385,7 +474,7 @@ export async function shareCustomEquipment(customEquipmentId: string, campaignId
 
       if (insertError) {
         console.error('Error inserting shares:', insertError);
-        return { success: false, error: `Failed to share equipment: ${insertError.message}` };
+        return { success: false, error: friendlyShareError('Failed to share equipment', insertError.message) };
       }
     }
 
@@ -450,7 +539,7 @@ export async function shareCustomSkill(customSkillId: string, campaignIds: strin
 
       if (insertError) {
         console.error('Error inserting shares:', insertError);
-        return { success: false, error: `Failed to share skill: ${insertError.message}` };
+        return { success: false, error: friendlyShareError('Failed to share skill', insertError.message) };
       }
     }
 
@@ -517,7 +606,7 @@ export async function shareCustomTradingPost(customTradingPostId: string, campai
 
       if (insertError) {
         console.error('Error inserting shares:', insertError);
-        return { success: false, error: `Failed to share trading post: ${insertError.message}` };
+        return { success: false, error: friendlyShareError('Failed to share trading post', insertError.message) };
       }
     }
 
@@ -582,7 +671,7 @@ interface CollectionShareRow {
  * all match the collection's edition (enforced here).
  * Passing an empty campaignIds unshares the collection from all campaigns.
  */
-export async function shareCollection(collectionId: string, campaignIds: string[]): Promise<{ success: boolean; error?: string }> {
+export async function shareCollection(collectionId: string, campaignIds: string[]): Promise<{ success: boolean; error?: string; warning?: string }> {
   try {
     const supabase = await createClient();
     const user = await getAuthenticatedUser(supabase);
@@ -598,10 +687,11 @@ export async function shareCollection(collectionId: string, campaignIds: string[
       return { success: false, error: 'Collection not found or not owned by user' };
     }
 
-    const editionCheck = await assertCampaignsMatchEdition(
-      supabase, editionSlugFromJoin((collection as any).editions), campaignIds
-    );
+    const collectionEdition = editionSlugFromJoin((collection as any).editions);
+    const editionCheck = await assertCampaignsMatchEdition(supabase, collectionEdition, campaignIds);
     if (!editionCheck.ok) return { success: false, error: editionCheck.error };
+
+    const warnings: string[] = [];
 
     const items = ((collection.items as { type: string; id: string }[]) || []);
     const equipmentIds = new Set(items.filter(i => i.type === 'equipment').map(i => i.id));
@@ -610,14 +700,24 @@ export async function shareCollection(collectionId: string, campaignIds: string[
     const skillIds = new Set(items.filter(i => i.type === 'skill').map(i => i.id));
     const tradingPostIds = new Set(items.filter(i => i.type === 'trading_post').map(i => i.id));
 
-    // Cascade: gang types -> their custom fighter types
+    // Cascade: gang types -> their custom fighter types.
+    // Filtered by edition, not just ownership: a fighter copied from another user's
+    // profile could be stamped with a different edition than the gang type it hangs
+    // off, and one such row makes the trigger abort the entire batch insert below.
     if (gangTypeIds.size > 0) {
       const { data: fighters } = await supabase
         .from('custom_fighter_types')
-        .select('id')
+        .select('id, fighter_type, editions:edition_id (slug)')
         .in('custom_gang_type_id', Array.from(gangTypeIds))
         .eq('user_id', user.id);
-      (fighters ?? []).forEach(f => fighterTypeIds.add(f.id));
+
+      const split = partitionByEdition(
+        (fighters ?? []).map(f => ({ ...f, name: (f as any).fighter_type })),
+        collectionEdition
+      );
+      split.kept.forEach(f => fighterTypeIds.add(f.id));
+      const warning = droppedWarning(split.dropped, 'fighter types');
+      if (warning) warnings.push(warning);
     }
 
     // Cascade: fighter types -> their custom skills (via custom skill types)
@@ -628,9 +728,22 @@ export async function shareCollection(collectionId: string, campaignIds: string[
         .in('custom_fighter_type_id', Array.from(fighterTypeIds))
         .not('custom_skill_type_id', 'is', null);
 
-      const skillTypeIds = Array.from(new Set(
+      const referencedSkillTypeIds = Array.from(new Set(
         (access ?? []).map(a => a.custom_skill_type_id).filter(Boolean) as string[]
       ));
+
+      let skillTypeIds: string[] = [];
+      if (referencedSkillTypeIds.length > 0) {
+        const { data: skillTypes } = await supabase
+          .from('custom_skill_types')
+          .select('id, name, editions:edition_id (slug)')
+          .in('id', referencedSkillTypeIds);
+
+        const split = partitionByEdition(skillTypes ?? [], collectionEdition);
+        skillTypeIds = split.kept.map(t => t.id);
+        const warning = droppedWarning(split.dropped, 'skill types');
+        if (warning) warnings.push(warning);
+      }
 
       if (skillTypeIds.length > 0) {
         const { data: skills } = await supabase
@@ -700,7 +813,7 @@ export async function shareCollection(collectionId: string, campaignIds: string[
         const { error: insertError } = await supabase.from('custom_shared').insert(rows);
         if (insertError) {
           console.error('Error inserting collection shares:', insertError);
-          return { success: false, error: `Failed to share collection: ${insertError.message}` };
+          return { success: false, error: friendlyShareError('Failed to share collection', insertError.message) };
         }
       }
     }
@@ -757,7 +870,7 @@ export async function shareCollection(collectionId: string, campaignIds: string[
     for (const cid of campaignIds) {
       revalidateTag(CACHE_TAGS.BASE_CAMPAIGN_BASIC(cid), { expire: 0 });
     }
-    return { success: true };
+    return { success: true, warning: warnings.join('. ') || undefined };
   } catch (error) {
     console.error('Error in shareCollection:', error);
     return {

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@/utils/supabase/server'
 import { NextRequest } from 'next/server'
 import { getUserCustomCollections } from '@/app/lib/customise/custom-collections'
-import { editionSlugFromJoin, gangEditionSlug } from '@/types/edition'
+import { editionSlugFromJoin, gangEditionSlug, withEditionSlug } from '@/types/edition'
 import type { UserCampaign } from '@/types/campaign'
 
 export async function GET(
@@ -110,12 +110,12 @@ export async function GET(
     const [customEquipmentResult, customFightersResult, customSkillsResult, customGangTypesResult, customTradingPostsResult] = await Promise.all([
       supabase
         .from('custom_equipment')
-        .select('*')
+        .select('*, editions:edition_id (slug)')
         .eq('user_id', userId)
         .order('equipment_name'),
       supabase
         .from('custom_fighter_types')
-        .select('*')
+        .select('*, editions:edition_id (slug)')
         .eq('user_id', userId)
         .order('fighter_type'),
       supabase
@@ -130,18 +130,18 @@ export async function GET(
           created_at,
           updated_at,
           skill_types (name),
-          custom_skill_types (name)
+          custom_skill_types (name, editions:edition_id (slug))
         `)
         .eq('user_id', userId)
         .order('skill_name'),
       supabase
         .from('custom_gang_types')
-        .select('*')
+        .select('*, editions:edition_id (slug)')
         .eq('user_id', userId)
         .order('gang_type'),
       supabase
         .from('custom_trading_posts')
-        .select('*')
+        .select('*, editions:edition_id (slug)')
         .eq('user_id', userId)
         .order('custom_trading_post_name')
     ])
@@ -156,6 +156,8 @@ export async function GET(
       description: skill.description,
       created_at: skill.created_at,
       updated_at: skill.updated_at,
+      // A custom skill has no edition of its own; it inherits its type's.
+      edition_slug: editionSlugFromJoin(skill.custom_skill_types?.editions),
     }));
 
     // Fetch the user's collections (with resolved item names)
@@ -176,7 +178,7 @@ export async function GET(
     }
 
     // Fetch related data for fighters (default skills and equipment)
-    let fightersWithExtendedData = customFightersResult.data || [];
+    let fightersWithExtendedData: any[] = (customFightersResult.data || []).map(withEditionSlug);
     if (fightersWithExtendedData.length > 0) {
       const fighterIds = fightersWithExtendedData.map((f: any) => f.id);
       
@@ -304,12 +306,15 @@ export async function GET(
       }));
     }
 
+    // Every custom asset carries its edition_slug: the profile filters these by
+    // edition and the copy action stamps the copy with it, so a missing slug
+    // would read as N23 and mis-stamp a copy of an N26 asset.
     const customAssetsData = {
-      equipment: customEquipmentResult.data || [],
+      equipment: (customEquipmentResult.data || []).map(withEditionSlug),
       fighters: fightersWithExtendedData,
       skills: customSkillsData,
-      gangTypes: customGangTypesResult.data || [],
-      tradingPosts: customTradingPostsResult.data || [],
+      gangTypes: (customGangTypesResult.data || []).map(withEditionSlug),
+      tradingPosts: (customTradingPostsResult.data || []).map(withEditionSlug),
       collections: customCollections,
     }
 

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -156,7 +156,7 @@ export async function GET(
       description: skill.description,
       created_at: skill.created_at,
       updated_at: skill.updated_at,
-      // A custom skill has no edition of its own; it inherits its type's.
+      // A custom skill inherits its type's edition.
       edition_slug: editionSlugFromJoin(skill.custom_skill_types?.editions),
     }));
 
@@ -306,9 +306,8 @@ export async function GET(
       }));
     }
 
-    // Every custom asset carries its edition_slug: the profile filters these by
-    // edition and the copy action stamps the copy with it, so a missing slug
-    // would read as N23 and mis-stamp a copy of an N26 asset.
+    // edition_slug on every asset: the profile filters on it and the copy action
+    // stamps the copy with it, so a missing one reads as N23.
     const customAssetsData = {
       equipment: (customEquipmentResult.data || []).map(withEditionSlug),
       fighters: fightersWithExtendedData,

--- a/app/api/users/[id]/route.ts
+++ b/app/api/users/[id]/route.ts
@@ -129,7 +129,7 @@ export async function GET(
           description,
           created_at,
           updated_at,
-          skill_types (name),
+          skill_types (name, editions:edition_id (slug)),
           custom_skill_types (name, editions:edition_id (slug))
         `)
         .eq('user_id', userId)
@@ -156,8 +156,9 @@ export async function GET(
       description: skill.description,
       created_at: skill.created_at,
       updated_at: skill.updated_at,
-      // A custom skill inherits its type's edition.
-      edition_slug: editionSlugFromJoin(skill.custom_skill_types?.editions),
+      // A custom skill inherits its type's edition. Custom wins, matching getUserCustomSkills.
+      edition_slug: editionSlugFromJoin(skill.custom_skill_types?.editions)
+        ?? editionSlugFromJoin(skill.skill_types?.editions),
     }));
 
     // Fetch the user's collections (with resolved item names)

--- a/components/customise/custom-shared.tsx
+++ b/components/customise/custom-shared.tsx
@@ -117,8 +117,6 @@ function ShareToCampaignsModal({
         toast.success(campaignIds.length > 0
           ? `${noun} shared to ${campaignIds.length} campaign${campaignIds.length !== 1 ? 's' : ''}`
           : `${noun} unshared from all campaigns`);
-        // A cascade that skipped assets still counts as success, but silently sharing
-        // less than the user selected is the failure mode this reports.
         if (result.warning) toast.warning(result.warning);
         for (const key of invalidateKeys) queryClient.invalidateQueries({ queryKey: key });
         queryClient.invalidateQueries({ queryKey: sharedQueryKey });

--- a/components/customise/custom-shared.tsx
+++ b/components/customise/custom-shared.tsx
@@ -37,7 +37,7 @@ interface ShareToCampaignsModalProps {
   emptyHint: string;          // sentence shown when the user arbitrates no campaigns
   idPrefix: string;           // checkbox id prefix
   invalidateKeys?: string[][];
-  share: (campaignIds: string[]) => Promise<{ success: boolean; error?: string }>;
+  share: (campaignIds: string[]) => Promise<{ success: boolean; error?: string; warning?: string }>;
   userCampaigns: UserCampaign[];
   itemEditionSlug: string | null;
   onClose: () => void;
@@ -117,6 +117,9 @@ function ShareToCampaignsModal({
         toast.success(campaignIds.length > 0
           ? `${noun} shared to ${campaignIds.length} campaign${campaignIds.length !== 1 ? 's' : ''}`
           : `${noun} unshared from all campaigns`);
+        // A cascade that skipped assets still counts as success, but silently sharing
+        // less than the user selected is the failure mode this reports.
+        if (result.warning) toast.warning(result.warning);
         for (const key of invalidateKeys) queryClient.invalidateQueries({ queryKey: key });
         queryClient.invalidateQueries({ queryKey: sharedQueryKey });
         onSuccess?.();

--- a/components/customise/custom-shared.tsx
+++ b/components/customise/custom-shared.tsx
@@ -37,7 +37,7 @@ interface ShareToCampaignsModalProps {
   emptyHint: string;          // sentence shown when the user arbitrates no campaigns
   idPrefix: string;           // checkbox id prefix
   invalidateKeys?: string[][];
-  share: (campaignIds: string[]) => Promise<{ success: boolean; error?: string; warning?: string }>;
+  share: (campaignIds: string[]) => Promise<{ success: boolean; error?: string }>;
   userCampaigns: UserCampaign[];
   itemEditionSlug: string | null;
   onClose: () => void;
@@ -117,7 +117,6 @@ function ShareToCampaignsModal({
         toast.success(campaignIds.length > 0
           ? `${noun} shared to ${campaignIds.length} campaign${campaignIds.length !== 1 ? 's' : ''}`
           : `${noun} unshared from all campaigns`);
-        if (result.warning) toast.warning(result.warning);
         for (const key of invalidateKeys) queryClient.invalidateQueries({ queryKey: key });
         queryClient.invalidateQueries({ queryKey: sharedQueryKey });
         onSuccess?.();

--- a/components/gang/stash-tab.tsx
+++ b/components/gang/stash-tab.tsx
@@ -11,6 +11,7 @@ import { StashItem } from '@/types/gang';
 import { Session } from '@supabase/supabase-js';
 import { VehicleProps } from '@/types/vehicle';
 import { vehicleExclusiveCategories, vehicleCompatibleCategories } from '@/utils/vehicleEquipmentCategories';
+import { hasChemAlchemy } from '@/types/edition';
 import ChemAlchemyCreator from './chem-alchemy';
 import { createChemAlchemy } from '@/app/actions/chem-alchemy';
 import ItemModal from '@/components/equipment/equipment';
@@ -818,7 +819,7 @@ export default function GangInventory({
           <div className="flex justify-between items-start mb-6">
             <h2 className="text-xl md:text-2xl font-bold">{title}</h2>
             <div className="flex gap-2">
-              {gangTypeId === 'cb9d7047-e7df-4196-a51f-a8f452c291ad' && (
+              {gangTypeId === 'cb9d7047-e7df-4196-a51f-a8f452c291ad' && hasChemAlchemy(editionSlug) && (
                 <Button
                   onClick={() => setShowChemAlchemy(true)}
                   disabled={!userPermissions?.canEdit}

--- a/supabase/functions/copy_custom_collection.sql
+++ b/supabase/functions/copy_custom_collection.sql
@@ -69,9 +69,8 @@ BEGIN
               + cardinality(v_gt) + cardinality(v_ft) + cardinality(v_tp);
 
     -- fighter types belonging to in-scope gang types, as their author defined them.
-    -- Scoped to the gang type's owner: RLS SELECT here is USING (true), so an
-    -- unscoped pull also clones fighters that other users attached to the same
-    -- gang type -- foreign rows, in whatever edition they happen to carry.
+    -- Scoped to the owner: SELECT RLS here is USING (true), so an unscoped pull also
+    -- clones fighters other users attached to the same gang type.
     v_ft := ARRAY(SELECT DISTINCT f FROM (
               SELECT unnest(v_ft) AS f
               UNION SELECT cft.id FROM public.custom_fighter_types cft

--- a/supabase/functions/copy_custom_collection.sql
+++ b/supabase/functions/copy_custom_collection.sql
@@ -100,10 +100,13 @@ BEGIN
                     WHERE cs.id = ANY(v_sk) AND cs.custom_skill_type_id IS NOT NULL
             ) s WHERE t IS NOT NULL);
 
-    -- all skills belonging to in-scope skill types (clone the whole set)
+    -- all skills belonging to in-scope skill types, as their author defined them.
+    -- Owner-scoped for the same reason as the fighter closure above.
     v_sk := ARRAY(SELECT DISTINCT k FROM (
               SELECT unnest(v_sk) AS k
-              UNION SELECT cs.id FROM public.custom_skills cs WHERE cs.custom_skill_type_id = ANY(v_st)
+              UNION SELECT cs.id FROM public.custom_skills cs
+                    JOIN public.custom_skill_types cst ON cst.id = cs.custom_skill_type_id
+                    WHERE cs.custom_skill_type_id = ANY(v_st) AND cs.user_id = cst.user_id
             ) s WHERE k IS NOT NULL);
 
     -- equipment referenced by fighter defaults / fighter equipment / trading posts

--- a/supabase/functions/copy_custom_collection.sql
+++ b/supabase/functions/copy_custom_collection.sql
@@ -68,10 +68,15 @@ BEGIN
     v_before := cardinality(v_eq) + cardinality(v_st) + cardinality(v_sk)
               + cardinality(v_gt) + cardinality(v_ft) + cardinality(v_tp);
 
-    -- fighter types belonging to in-scope gang types
+    -- fighter types belonging to in-scope gang types, as their author defined them.
+    -- Scoped to the gang type's owner: RLS SELECT here is USING (true), so an
+    -- unscoped pull also clones fighters that other users attached to the same
+    -- gang type -- foreign rows, in whatever edition they happen to carry.
     v_ft := ARRAY(SELECT DISTINCT f FROM (
               SELECT unnest(v_ft) AS f
-              UNION SELECT cft.id FROM public.custom_fighter_types cft WHERE cft.custom_gang_type_id = ANY(v_gt)
+              UNION SELECT cft.id FROM public.custom_fighter_types cft
+                    JOIN public.custom_gang_types cgt ON cgt.id = cft.custom_gang_type_id
+                    WHERE cft.custom_gang_type_id = ANY(v_gt) AND cft.user_id = cgt.user_id
             ) s WHERE f IS NOT NULL);
 
     -- gang types referenced by in-scope fighter types and trading posts

--- a/types/edition.ts
+++ b/types/edition.ts
@@ -144,11 +144,7 @@ const EDITION_CAPABILITIES = {
   equipmentSuperCategories: { n23: false, n26: true  },
   /** Weapons can be bought master-crafted, at a higher rating cost */
   masterCraftedWeapons:     { n23: true,  n26: false },
-  /**
-   * Chem-Alchemy: House Escher crafts custom elixirs into the gang stash. The
-   * button was previously reachable only via a hardcoded N23 Escher gang type id,
-   * which gated the edition by accident — N26 Escher is a different row.
-   */
+  /** House Escher crafts custom elixirs into the gang stash */
   chemAlchemy:              { n23: true,  n26: false },
   /** Gang / fighter-type Law Abiding vs Outlaw alignment */
   alignment:                { n23: true,  n26: false },

--- a/types/edition.ts
+++ b/types/edition.ts
@@ -144,6 +144,12 @@ const EDITION_CAPABILITIES = {
   equipmentSuperCategories: { n23: false, n26: true  },
   /** Weapons can be bought master-crafted, at a higher rating cost */
   masterCraftedWeapons:     { n23: true,  n26: false },
+  /**
+   * Chem-Alchemy: House Escher crafts custom elixirs into the gang stash. The
+   * button was previously reachable only via a hardcoded N23 Escher gang type id,
+   * which gated the edition by accident — N26 Escher is a different row.
+   */
+  chemAlchemy:              { n23: true,  n26: false },
   /** Gang / fighter-type Law Abiding vs Outlaw alignment */
   alignment:                { n23: true,  n26: false },
   /** Fighters can be sold to the Guilders (the enslaved status) */
@@ -271,6 +277,9 @@ export const hasEquipmentSuperCategories = (
 
 export const hasMasterCraftedWeapons = (editionSlug?: string | null): boolean =>
   can('masterCraftedWeapons', editionSlug);
+
+export const hasChemAlchemy = (editionSlug?: string | null): boolean =>
+  can('chemAlchemy', editionSlug);
 
 export const hasAlignment = (editionSlug?: string | null): boolean =>
   can('alignment', editionSlug);


### PR DESCRIPTION
## Summary
This PR adds robust handling for cross-edition assets when sharing custom content and cascading related items. When a user attempts to share content that references assets from a different edition (e.g., a fighter from one edition referencing a skill type from another), those mismatched assets are now gracefully filtered out with user-friendly warnings instead of failing the entire operation.

## Key Changes

- **New utility functions for edition-aware filtering:**
  - `partitionByEdition()`: Separates rows into kept/dropped based on edition compatibility
  - `droppedWarning()`: Generates user-friendly messages about skipped cross-edition assets
  - `friendlyShareError()`: Converts database trigger errors into readable messages

- **Enhanced sharing functions with warning support:**
  - `shareCustomFighter()`, `shareCustomGangType()`, `shareCollection()` now return optional `warning` field
  - Cascaded skill types and fighter types are filtered by edition before sharing
  - Non-fatal errors (e.g., skill sharing failures) are captured as warnings rather than aborting

- **Edition resolution improvements:**
  - `resolveFighterEditionId()`: Fighters now inherit their gang type's edition instead of using the current tab's edition
  - User profile endpoint now includes `edition_slug` on all custom assets via `withEditionSlug()` helper
  - Chem-Alchemy creation validates edition support and uses gang's edition for created elixirs

- **SQL fix for collection copying:**
  - Scoped fighter type cloning to the collection owner to prevent unintended cross-user asset inclusion

- **Edition capability tracking:**
  - Added `chemAlchemy` capability flag (N23 only) with `hasChemAlchemy()` helper

## Notable Implementation Details

- Cross-edition asset filtering happens at the application level before database inserts, preventing trigger failures
- Warnings are accumulated and joined with periods for multi-step cascading operations
- Edition resolution follows a hierarchy: explicit gang type > parent gang type > edition slug parameter
- The `withEditionSlug()` helper normalizes edition data across all asset types for consistent handling