### PR TITLE
Stop scaling strict weapon replacements by the default count

### DIFF
--- a/components/gang/fighter-add/EquipmentSelection.tsx
+++ b/components/gang/fighter-add/EquipmentSelection.tsx
@@ -24,7 +24,7 @@ interface EquipmentSelectionProps {
  * Shared starting-equipment picker for the fighter-add flows. Renders four
  * selection patterns driven by each category's `select_type` / `replacement_mode`:
  *  - optional + flexible → checkboxes with per-slot accounting
- *  - optional + strict   → radios that replace all slots
+ *  - optional + strict   → radios that replace the whole default group with one item
  *  - single / optional_single → radios (with a "Keep Default" option)
  *  - multiple → checkboxes
  */
@@ -253,7 +253,7 @@ export function EquipmentSelection({
                             const prevOption = (categoryData.options || []).find((o: any) => `${categoryId}-${o.id}` === strictSelectedId);
                             if (prevOption) {
                               setFighterCost((prevCost) =>
-                                String(parseInt(prevCost || '0') - (prevOption.cost || 0) * totalSlots)
+                                String(parseInt(prevCost || '0') - (prevOption.cost || 0))
                               );
                             }
                           }
@@ -367,7 +367,7 @@ export function EquipmentSelection({
                               const prevOption = strictSelectedId
                                 ? (categoryData.options || []).find((o: any) => `${categoryId}-${o.id}` === strictSelectedId)
                                 : undefined;
-                              const prevCostPerUnit = prevOption?.cost || 0;
+                              const prevOptionCost = prevOption?.cost || 0;
 
                               setSelectedEquipmentIds((prev) => {
                                 const currentCategoryOptions = categoryData.options || [];
@@ -390,19 +390,19 @@ export function EquipmentSelection({
                                 return [...filtered, {
                                   equipment_id: option.id,
                                   cost: optionCost,
-                                  quantity: totalSlots,
+                                  quantity: 1,
                                   is_editable: option.is_editable || false,
                                 }];
                               });
 
                               setFighterCost((prevCost) =>
-                                String(parseInt(prevCost || '0') - (prevCostPerUnit * totalSlots) + (optionCost * totalSlots))
+                                String(parseInt(prevCost || '0') - prevOptionCost + optionCost)
                               );
                             }}
                           />
                           <label htmlFor={uniqueOptionId} className="text-sm">
-                            {totalSlots}x {option.equipment_name || 'Loading...'}
-                            {` ${option.cost * totalSlots >= 0 ? '+' : ''}${option.cost * totalSlots} credits`}
+                            1x {option.equipment_name || 'Loading...'}
+                            {` ${option.cost >= 0 ? '+' : ''}${option.cost} credits`}
                           </label>
                         </div>
                       );


### PR DESCRIPTION
## Problem

In the fighter-add / Gang Additions picker, an optional weapon group with `replacement_mode: 'strict'` multiplied every replacement option by the number of default weapon slots in the group.

The **Bailiff** (Justicar Courts: Palanite Justicar Delegation) has `1x Heavy club` + `1x Shock pistol`, so `totalSlots === 2` and the modal offered:

```
Optional Weapons 1 (replace all 2)
  ( ) 2x Fulman pattern man-catcher +0 credits
  ( ) 2x Shotgun +0 credits
```

Not just a label: the radio submitted `quantity: 2`, and `app/actions/add-fighter.ts` inserts one `fighter_equipment` row per unit — so the fighter really got two shotguns and was charged twice the option cost.

## Cause

`totalSlots` (`EquipmentSelection.tsx:88`) correctly answers *"how many default slots does this group have?"*, and is right for the group label and for flexible-mode accounting. The strict branch reused it as *"how many copies of the chosen option to grant"*, which does not follow — strict replaces the **whole default group** with **one** copy of the selected option.

The SQL (`get_fighter_types_with_cost`) and `normalizeEquipmentSelection` were both ruled out: no join between defaults and replacements, and the option pool is deduplicated by id, never summed.

## Change

One file, strict branch only:

- Label renders `1x <name>` and the unscaled `option.cost`.
- Submitted selection uses `quantity: 1`.
- Cost delta on select is `-prevOptionCost + optionCost` (local renamed from `prevCostPerUnit`, which no longer describes anything).
- **Keep Default** refunds exactly what selecting charged.

Both cost paths had to move together: `fighterCost` is a running total maintained by these deltas, while `selectedEquipment` (`cost * quantity`) feeds the rating and the "Equipment cost" line.

Untouched: `totalSlots` itself, the `(replace all N)` label (still accurate), and the flexible / single / optional_single / multiple branches.

## Reviewer note

This changes live behaviour beyond the Bailiff: an existing strict group modelling a homogeneous stack (default `2x Autopistol`, option `Lasgun`, previously shown as "2x Lasgun") now grants a single lasgun. That is the intended semantics — flagging it so it isn't a surprise. No data migration.

## Verification

Typecheck and lint clean. Not yet exercised in a running app — worth checking that adding a Bailiff with Shotgun selected yields **one** shotgun and moves the rating by base cost + one option cost, and that a flexible group is unchanged.
