### PR TITLE
Add Gang Tactics section to the gang page Battles tab

### DIFF
--- a/app/actions/gang-tactics-cards.ts
+++ b/app/actions/gang-tactics-cards.ts
@@ -1,0 +1,218 @@
+'use server'
+
+import { createClient } from '@/utils/supabase/server';
+import { getAuthenticatedUser } from '@/utils/auth';
+import { checkPermissionCached } from '@/utils/user-permissions';
+import { invalidateGangTacticsCards } from '@/utils/cache-tags';
+import { gangEditionJoin, gangEditionSlug, hasGangTacticsCards } from '@/types/edition';
+import {
+  normaliseTacticsDescription,
+  TACTICS_DESCRIPTION_CHAR_LIMIT,
+  type GangTacticsCard
+} from '@/types/tactics-card';
+
+interface GangTacticsResult {
+  success: boolean;
+  error?: string;
+}
+
+interface AddGangTacticsCardsResult extends GangTacticsResult {
+  /** The rows just added, so the client can append without a refetch. */
+  data?: GangTacticsCard[];
+}
+
+/** What every action here needs once the caller has been cleared. */
+interface GangTacticsContext {
+  /** The gang's edition uuid, for scoping which catalogue cards it may hold. */
+  editionId: string | null;
+}
+
+/**
+ * Authenticate, confirm the caller may edit this gang, and confirm the gang's
+ * edition actually has Gang Tactics. RLS enforces the first two again at the
+ * database, but failing here returns a usable message instead of a raw error.
+ */
+async function authoriseGangTactics(
+  supabase: any,
+  gangId: string
+): Promise<{ error: string } | { context: GangTacticsContext }> {
+  const user = await getAuthenticatedUser(supabase);
+
+  const { data: gang, error } = await supabase
+    .from('gangs')
+    .select(`
+      id,
+      user_id,
+      gang_types!gang_type_id ( editions:edition_id ( id, slug ) ),
+      custom_gang_types!custom_gang_type_id ( editions:edition_id ( id, slug ) )
+    `)
+    .eq('id', gangId)
+    .maybeSingle();
+
+  if (error || !gang) {
+    return { error: 'Gang not found' };
+  }
+
+  const permissions = await checkPermissionCached(user.id, gangId, gang.user_id ?? null);
+  if (!permissions.canEdit) {
+    return { error: 'Access denied' };
+  }
+
+  if (!hasGangTacticsCards(gangEditionSlug(gang))) {
+    return { error: 'Gang Tactics are not available for this edition' };
+  }
+
+  return { context: { editionId: gangEditionJoin(gang)?.id ?? null } };
+}
+
+/** Re-reads gang rows joined to the catalogue, flattened for the client. */
+async function selectGangTacticsCards(
+  supabase: any,
+  gangId: string,
+  tacticsCardIds: string[]
+): Promise<GangTacticsCard[]> {
+  if (tacticsCardIds.length === 0) return [];
+
+  const { data, error } = await supabase
+    .from('gang_tactics_cards')
+    .select(`
+      id,
+      description,
+      tactics_cards_id,
+      tactics_cards:tactics_cards_id ( name, d66_min, d66_max )
+    `)
+    .eq('gang_id', gangId)
+    .in('tactics_cards_id', tacticsCardIds);
+
+  if (error) throw error;
+
+  return (data ?? []).map((row: any) => {
+    const card = Array.isArray(row.tactics_cards) ? row.tactics_cards[0] : row.tactics_cards;
+    return {
+      id: row.id,
+      tactics_cards_id: row.tactics_cards_id,
+      name: card?.name ?? 'Unknown Tactic',
+      d66_min: card?.d66_min ?? null,
+      d66_max: card?.d66_max ?? null,
+      description: row.description ?? null
+    };
+  });
+}
+
+export async function addGangTacticsCards(params: {
+  gangId: string;
+  tacticsCardIds: string[];
+}): Promise<AddGangTacticsCardsResult> {
+  try {
+    const supabase = await createClient();
+
+    const auth = await authoriseGangTactics(supabase, params.gangId);
+    if ('error' in auth) return { success: false, error: auth.error };
+
+    const tacticsCardIds = Array.from(new Set(params.tacticsCardIds));
+    if (tacticsCardIds.length === 0) {
+      return { success: false, error: 'No tactics cards selected' };
+    }
+
+    // The browser can post any uuid, so confirm every id is a real card in this
+    // gang's edition rather than trusting what the picker sent.
+    let catalogueQuery = supabase
+      .from('tactics_cards')
+      .select('id')
+      .in('id', tacticsCardIds);
+
+    if (auth.context.editionId) {
+      catalogueQuery = catalogueQuery.eq('edition_id', auth.context.editionId);
+    }
+
+    const { data: catalogue, error: catalogueError } = await catalogueQuery;
+    if (catalogueError) throw catalogueError;
+
+    if ((catalogue?.length ?? 0) !== tacticsCardIds.length) {
+      return { success: false, error: 'One or more tactics cards are not available for this gang' };
+    }
+
+    // ignoreDuplicates so a stale picker can't 23505 on the
+    // (gang_id, tactics_cards_id) unique constraint.
+    const { error: insertError } = await supabase
+      .from('gang_tactics_cards')
+      .upsert(
+        tacticsCardIds.map(id => ({ gang_id: params.gangId, tactics_cards_id: id })),
+        { onConflict: 'gang_id,tactics_cards_id', ignoreDuplicates: true }
+      );
+
+    if (insertError) throw insertError;
+
+    const added = await selectGangTacticsCards(supabase, params.gangId, tacticsCardIds);
+
+    invalidateGangTacticsCards(params.gangId);
+
+    return { success: true, data: added };
+  } catch (error) {
+    console.error('Error adding gang tactics cards:', error);
+    return { success: false, error: 'An unexpected error occurred' };
+  }
+}
+
+export async function updateGangTacticsCardDescription(params: {
+  gangId: string;
+  gangTacticsCardId: string;
+  description: string | null;
+}): Promise<GangTacticsResult> {
+  try {
+    const supabase = await createClient();
+
+    const auth = await authoriseGangTactics(supabase, params.gangId);
+    if ('error' in auth) return { success: false, error: auth.error };
+
+    const description = normaliseTacticsDescription(params.description);
+    if (description && description.length > TACTICS_DESCRIPTION_CHAR_LIMIT) {
+      return {
+        success: false,
+        error: `Description must be ${TACTICS_DESCRIPTION_CHAR_LIMIT} characters or fewer.`
+      };
+    }
+
+    const { error } = await supabase
+      .from('gang_tactics_cards')
+      .update({ description, updated_at: new Date().toISOString() })
+      .eq('id', params.gangTacticsCardId)
+      .eq('gang_id', params.gangId);
+
+    if (error) throw error;
+
+    invalidateGangTacticsCards(params.gangId);
+
+    return { success: true };
+  } catch (error) {
+    console.error('Error updating gang tactics card description:', error);
+    return { success: false, error: 'An unexpected error occurred' };
+  }
+}
+
+export async function deleteGangTacticsCard(params: {
+  gangId: string;
+  gangTacticsCardId: string;
+}): Promise<GangTacticsResult> {
+  try {
+    const supabase = await createClient();
+
+    const auth = await authoriseGangTactics(supabase, params.gangId);
+    if ('error' in auth) return { success: false, error: auth.error };
+
+    const { error } = await supabase
+      .from('gang_tactics_cards')
+      .delete()
+      .eq('id', params.gangTacticsCardId)
+      .eq('gang_id', params.gangId);
+
+    if (error) throw error;
+
+    invalidateGangTacticsCards(params.gangId);
+
+    return { success: true };
+  } catch (error) {
+    console.error('Error deleting gang tactics card:', error);
+    return { success: false, error: 'An unexpected error occurred' };
+  }
+}

--- a/app/api/tactics-cards/route.ts
+++ b/app/api/tactics-cards/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/utils/supabase/server';
+import { getUserIdFromClaims } from '@/utils/auth';
+import { getEditionIdBySlug } from '@/app/lib/editions';
+import { getTacticsCards } from '@/app/lib/tactics-cards';
+import { hasGangTacticsCards } from '@/types/edition';
+
+/**
+ * The Gang Tactics catalogue for one edition, for the "Add Gang Tactics" picker.
+ * The caller passes the slug it already holds (a gang page knows its own
+ * edition), so this never has to resolve a gang.
+ */
+export async function GET(request: Request) {
+  const supabase = await createClient();
+
+  try {
+    const userId = await getUserIdFromClaims(supabase);
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const editionSlug = new URL(request.url).searchParams.get('edition_slug');
+    if (!editionSlug) {
+      return NextResponse.json(
+        { error: 'Missing edition', details: 'edition_slug is required' },
+        { status: 400 }
+      );
+    }
+
+    // An edition without a catalogue would otherwise return an empty list,
+    // which reads as "none seeded yet" rather than "not a thing here".
+    if (!hasGangTacticsCards(editionSlug)) {
+      return NextResponse.json(
+        { error: 'Unsupported edition', details: `Gang Tactics are not available for '${editionSlug}'` },
+        { status: 400 }
+      );
+    }
+
+    const editionId = await getEditionIdBySlug(editionSlug);
+    if (!editionId) {
+      return NextResponse.json(
+        { error: 'Unknown edition', details: `No edition with slug '${editionSlug}'` },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json(await getTacticsCards(editionId));
+  } catch (error) {
+    console.error('Error in GET /api/tactics-cards:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch tactics cards' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/gang/[id]/page.tsx
+++ b/app/gang/[id]/page.tsx
@@ -17,9 +17,11 @@ import {
   getGangVariants,
   getGangRatingAndWealth,
   getGangResources,
+  getGangTacticsCards,
   getUserProfile
 } from '@/app/lib/shared/gang-data';
 import { getGangBattleSessionsCached } from '@/app/lib/battle-sessions/get-battle-session-data';
+import { hasGangTacticsCards } from '@/types/edition';
 
 export default async function GangPage(props: { params: Promise<{ id: string }> }) {
   const params = await props.params;
@@ -66,7 +68,8 @@ export default async function GangPage(props: { params: Promise<{ id: string }> 
       gangRatingAndWealth,
       userProfile,
       userPermissions,
-      battleSessions
+      battleSessions,
+      tacticsCards
     ] = await Promise.all([
       getGangPositioning(params.id, supabase),
       getGangType(gangBasic, supabase),
@@ -80,7 +83,12 @@ export default async function GangPage(props: { params: Promise<{ id: string }> 
       getGangRatingAndWealth(params.id, supabase),
       getUserProfile(gangBasic.user_id, supabase),
       checkPermissionCached(user.id, params.id, gangBasic.user_id),
-      getGangBattleSessionsCached(params.id, supabase)
+      getGangBattleSessionsCached(params.id, supabase),
+      // Editions without a tactics catalogue never render the section, so skip
+      // the query entirely rather than caching an always-empty list.
+      hasGangTacticsCards(gangBasic.edition_slug)
+        ? getGangTacticsCards(params.id, supabase)
+        : Promise.resolve([])
     ]);
 
     // Initialize positioning if needed (lazy initialization only)
@@ -143,7 +151,8 @@ export default async function GangPage(props: { params: Promise<{ id: string }> 
       patreon_tier_title: userProfile?.patreon_tier_title,
       patron_status: userProfile?.patron_status,
       hidden: gangBasic.hidden,
-      battleSessions: battleSessions
+      battleSessions: battleSessions,
+      tacticsCards: tacticsCards
     };
 
     return (

--- a/app/lib/shared/gang-data.ts
+++ b/app/lib/shared/gang-data.ts
@@ -6,6 +6,7 @@ import { WeaponProfile } from '@/types/equipment';
 import { applyWeaponModifiers } from '@/utils/effect-modifiers';
 import { DefaultImageEntry, normaliseDefaultImageUrls } from '@/types/gang';
 import { gangEditionSlug } from '@/types/edition';
+import { GangTacticsCard } from '@/types/tactics-card';
 
 // =============================================================================
 // TYPES - Shared interfaces for gang data
@@ -318,6 +319,49 @@ export const getGangPositioning = async (gangId: string, supabase: any): Promise
     [`gang-positioning-${gangId}`],
     {
       tags: [CACHE_TAGS.BASE_GANG_POSITIONING(gangId)],
+      revalidate: false
+    }
+  )();
+};
+
+/**
+ * Get the Gang Tactics cards a gang holds, flattened with their catalogue name
+ * and D66 range. Callers gate on hasGangTacticsCards() — this does not, so it
+ * stays usable for any edition whose catalogue is seeded later.
+ * Cache: BASE_GANG_TACTICS_CARDS
+ */
+export const getGangTacticsCards = async (gangId: string, supabase: any): Promise<GangTacticsCard[]> => {
+  return unstable_cache(
+    async () => {
+      const { data, error } = await supabase
+        .from('gang_tactics_cards')
+        .select(`
+          id,
+          description,
+          tactics_cards_id,
+          tactics_cards:tactics_cards_id ( name, d66_min, d66_max )
+        `)
+        .eq('gang_id', gangId);
+
+      if (error) throw error;
+
+      return (data ?? []).map((row: any) => {
+        // PostgREST returns a to-one embed as an object, but generated types
+        // sometimes widen it to an array.
+        const card = Array.isArray(row.tactics_cards) ? row.tactics_cards[0] : row.tactics_cards;
+        return {
+          id: row.id,
+          tactics_cards_id: row.tactics_cards_id,
+          name: card?.name ?? 'Unknown Tactic',
+          d66_min: card?.d66_min ?? null,
+          d66_max: card?.d66_max ?? null,
+          description: row.description ?? null
+        };
+      });
+    },
+    [`gang-tactics-cards-${gangId}`],
+    {
+      tags: [CACHE_TAGS.BASE_GANG_TACTICS_CARDS(gangId)],
       revalidate: false
     }
   )();

--- a/app/lib/tactics-cards.ts
+++ b/app/lib/tactics-cards.ts
@@ -1,0 +1,42 @@
+import { unstable_cache } from 'next/cache';
+import { CACHE_TAGS } from '@/utils/cache-tags';
+import { createServiceRoleClient } from '@/utils/supabase/server';
+import { withEditionSlug } from '@/types/edition';
+import { compareTacticsCards, type TacticsCard } from '@/types/tactics-card';
+
+/**
+ * The tactics_cards catalogue for one edition. Service role because every user
+ * of that edition reads the same rows.
+ *
+ * Like editions, revalidation has to be time-based: the catalogue is seeded by
+ * migration and RLS restricts writes to admins, so no app code path can call
+ * revalidateTag on it.
+ */
+const getCachedTacticsCards = unstable_cache(
+  async (editionId: string): Promise<TacticsCard[]> => {
+    const supabase = createServiceRoleClient();
+
+    const { data, error } = await supabase
+      .from('tactics_cards')
+      .select('id, name, d66_min, d66_max, editions:edition_id ( slug )')
+      .eq('edition_id', editionId);
+
+    if (error) {
+      console.error('Error fetching tactics cards:', error);
+      throw new Error(`Failed to fetch tactics cards: ${error.message}`);
+    }
+
+    return (data ?? [])
+      .map(withEditionSlug)
+      .sort(compareTacticsCards) as TacticsCard[];
+  },
+  ['global-tactics-cards'],
+  {
+    tags: [CACHE_TAGS.GLOBAL_TACTICS_CARDS()],
+    revalidate: 3600, // 1 hour — the catalogue only ever changes via migration
+  }
+);
+
+export async function getTacticsCards(editionId: string): Promise<TacticsCard[]> {
+  return getCachedTacticsCards(editionId);
+}

--- a/components/gang/gang-page-content.tsx
+++ b/components/gang/gang-page-content.tsx
@@ -16,7 +16,9 @@ import { FaUsers, FaBox, FaTruckMoving } from 'react-icons/fa';
 import { PiFlagBannerFoldBold } from 'react-icons/pi';
 import { LuClipboard, LuSwords } from 'react-icons/lu';
 import GangBattleSessions from "@/components/gang/battle-sessions-tab";
+import GangTacticsCards from "@/components/gang/gang-tactics-cards";
 import type { BattleSession } from "@/types/battle-session";
+import type { GangTacticsCard } from "@/types/tactics-card";
 import { FighterCardModalsProvider } from "@/components/gang/fighter-card-modals-context";
 import { FighterXpModal } from "@/components/fighter/fighter-xp-modal";
 import { InjuriesList } from "@/components/fighter/fighter-injury-list";
@@ -26,7 +28,7 @@ import { editFighterStatus } from "@/app/actions/edit-fighter";
 import { toast } from 'sonner';
 import type { FighterEffect } from '@/types/fighter';
 import { hasKilledStatusFlag, countsTowardRating } from '@/utils/fighter-status';
-import { hasVehicles } from '@/types/edition';
+import { hasVehicles, hasGangTacticsCards } from '@/types/edition';
 
 interface GangPageContentProps {
   initialGangData: any; // We'll type this properly based on the processed data structure
@@ -79,6 +81,7 @@ interface GangDataState {
     patron_status?: string;
     hidden: boolean;
     battleSessions?: BattleSession[];
+    tacticsCards?: GangTacticsCard[];
   };
   stash: StashItem[];
 }
@@ -380,6 +383,16 @@ export default function GangPageContent({
       processedData: {
         ...prev.processedData,
         note: updatedNote
+      }
+    }));
+  }, []);
+
+  const handleTacticsCardsUpdate = useCallback((updatedTacticsCards: GangTacticsCard[]) => {
+    setGangData((prev: GangDataState) => ({
+      ...prev,
+      processedData: {
+        ...prev.processedData,
+        tacticsCards: updatedTacticsCards
       }
     }));
   }, []);
@@ -721,15 +734,27 @@ export default function GangPageContent({
       title: 'Battles',
       icon: <LuSwords key="swords" />,
       content: (
-        <GangBattleSessions
-          key="battles"
-          sessions={gangData.processedData.battleSessions || []}
-          gangId={gangId}
-          gangName={gangData.processedData.name}
-          editionSlug={gangData.processedData.edition_slug}
-          campaignId={(gangData.processedData.campaigns || [])[0]?.campaign_id}
-          sessionUrl={(id) => `/gang/${gangId}/battle-session/${id}`}
-        />
+        <div key="battles" className="space-y-4">
+          <GangBattleSessions
+            sessions={gangData.processedData.battleSessions || []}
+            gangId={gangId}
+            gangName={gangData.processedData.name}
+            editionSlug={gangData.processedData.edition_slug}
+            campaignId={(gangData.processedData.campaigns || [])[0]?.campaign_id}
+            sessionUrl={(id) => `/gang/${gangId}/battle-session/${id}`}
+          />
+          {hasGangTacticsCards(gangData.processedData.edition_slug) && (
+            <div className="bg-card shadow-md rounded-lg p-4">
+              <GangTacticsCards
+                gangId={gangId}
+                editionSlug={gangData.processedData.edition_slug}
+                tacticsCards={gangData.processedData.tacticsCards || []}
+                onTacticsCardsUpdate={handleTacticsCardsUpdate}
+                userPermissions={userPermissions}
+              />
+            </div>
+          )}
+        </div>
       ),
     },
   ];

--- a/components/gang/gang-tactics-cards.tsx
+++ b/components/gang/gang-tactics-cards.tsx
@@ -1,0 +1,363 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { Tooltip } from 'react-tooltip';
+import { BiSolidNotepad } from 'react-icons/bi';
+import { LuSquarePen, LuTrash2 } from 'react-icons/lu';
+import Modal from '@/components/ui/modal';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Textarea } from '@/components/ui/textarea';
+import { List, ListAction, ListColumn } from '@/components/ui/list';
+import { renderDescriptionTooltip } from '@/components/ui/tooltip-renderers';
+import { UserPermissions } from '@/types/user-permissions';
+import {
+  compareTacticsCards,
+  formatD66Range,
+  normaliseTacticsDescription,
+  TACTICS_DESCRIPTION_CHAR_LIMIT,
+  type GangTacticsCard,
+  type TacticsCard
+} from '@/types/tactics-card';
+import {
+  addGangTacticsCards,
+  deleteGangTacticsCard,
+  updateGangTacticsCardDescription
+} from '@/app/actions/gang-tactics-cards';
+
+interface GangTacticsCardsProps {
+  gangId: string;
+  editionSlug?: string | null;
+  tacticsCards: GangTacticsCard[];
+  /** Tab bodies unmount on switch, so the list itself lives in the page. */
+  onTacticsCardsUpdate: (cards: GangTacticsCard[]) => void;
+  userPermissions: UserPermissions;
+}
+
+const TOOLTIP_ID = 'gang-tactics-description-tooltip';
+
+export default function GangTacticsCards({
+  gangId,
+  editionSlug,
+  tacticsCards,
+  onTacticsCardsUpdate,
+  userPermissions
+}: GangTacticsCardsProps) {
+  const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+  const [selectedCardIds, setSelectedCardIds] = useState<Set<string>>(new Set());
+  const [editCard, setEditCard] = useState<GangTacticsCard | null>(null);
+  const [editDescription, setEditDescription] = useState('');
+  const [deleteCard, setDeleteCard] = useState<GangTacticsCard | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const canEdit = userPermissions.canEdit;
+
+  const ownedCardIds = useMemo(
+    () => new Set(tacticsCards.map(card => card.tactics_cards_id)),
+    [tacticsCards]
+  );
+
+  // Only the picker needs the catalogue, so it stays unfetched until opened.
+  const { data: catalogue = [], isLoading: isLoadingCatalogue, error: catalogueError } = useQuery<TacticsCard[]>({
+    queryKey: ['tactics-cards', editionSlug],
+    queryFn: async () => {
+      const response = await fetch(`/api/tactics-cards?edition_slug=${editionSlug}`);
+      if (!response.ok) throw new Error('Failed to fetch tactics cards');
+      return response.json();
+    },
+    staleTime: 5 * 60 * 1000,
+    enabled: isAddModalOpen && !!editionSlug
+  });
+
+  const handleOpenAddModal = () => {
+    setSelectedCardIds(new Set());
+    setIsAddModalOpen(true);
+  };
+
+  const toggleCard = (cardId: string) => {
+    setSelectedCardIds(prev => {
+      const next = new Set(prev);
+      if (next.has(cardId)) {
+        next.delete(cardId);
+      } else {
+        next.add(cardId);
+      }
+      return next;
+    });
+  };
+
+  const handleAdd = async () => {
+    if (selectedCardIds.size === 0) return false;
+
+    setIsSubmitting(true);
+    try {
+      const result = await addGangTacticsCards({
+        gangId,
+        tacticsCardIds: Array.from(selectedCardIds)
+      });
+
+      if (!result.success) throw new Error(result.error);
+
+      const added = result.data ?? [];
+      // Re-adding an existing card is a no-op server-side, so merge on id
+      // rather than appending blindly.
+      const byId = new Map(tacticsCards.map(card => [card.id, card]));
+      added.forEach(card => byId.set(card.id, card));
+      onTacticsCardsUpdate(Array.from(byId.values()));
+
+      toast.success(added.length === 1 ? 'Tactics card added' : `${added.length} tactics cards added`);
+      return true;
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to add tactics cards');
+      return false;
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleOpenEditModal = (card: GangTacticsCard) => {
+    setEditCard(card);
+    setEditDescription(card.description ?? '');
+  };
+
+  const isEditOverLimit = editDescription.length > TACTICS_DESCRIPTION_CHAR_LIMIT;
+  const hasEditChanged =
+    !!editCard &&
+    normaliseTacticsDescription(editDescription) !== normaliseTacticsDescription(editCard.description);
+
+  const handleSaveDescription = async () => {
+    if (!editCard) return false;
+
+    if (isEditOverLimit) {
+      toast.error(`Description cannot exceed ${TACTICS_DESCRIPTION_CHAR_LIMIT} characters`);
+      return false;
+    }
+
+    const description = normaliseTacticsDescription(editDescription);
+
+    setIsSubmitting(true);
+    try {
+      const result = await updateGangTacticsCardDescription({
+        gangId,
+        gangTacticsCardId: editCard.id,
+        description
+      });
+
+      if (!result.success) throw new Error(result.error);
+
+      onTacticsCardsUpdate(
+        tacticsCards.map(card => (card.id === editCard.id ? { ...card, description } : card))
+      );
+      toast.success('Description updated');
+      return true;
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to update description');
+      return false;
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteCard) return false;
+
+    setIsSubmitting(true);
+    try {
+      const result = await deleteGangTacticsCard({
+        gangId,
+        gangTacticsCardId: deleteCard.id
+      });
+
+      if (!result.success) throw new Error(result.error);
+
+      onTacticsCardsUpdate(tacticsCards.filter(card => card.id !== deleteCard.id));
+      toast.success(`${deleteCard.name} removed`);
+      return true;
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to remove tactics card');
+      return false;
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const columns: ListColumn[] = [
+    {
+      key: 'd66',
+      label: 'D66',
+      align: 'center',
+      width: '4rem',
+      cellClassName: 'tabular-nums text-muted-foreground',
+      render: (_value, item: GangTacticsCard) => formatD66Range(item.d66_min, item.d66_max)
+    },
+    { key: 'name', label: 'Name', align: 'left' },
+    {
+      key: 'description',
+      label: 'Desc.',
+      align: 'left',
+      width: '5%',
+      render: (_value, item: GangTacticsCard) =>
+        item.description?.trim() ? (
+          <span
+            className="inline-flex text-muted-foreground hover:text-foreground cursor-help"
+            data-tooltip-id={TOOLTIP_ID}
+            data-tooltip-title={item.name}
+            data-tooltip-description={item.description}
+          >
+            <BiSolidNotepad className="h-4 w-4 inline" aria-label="View tactics card description" />
+          </span>
+        ) : null
+    }
+  ];
+
+  const actions: ListAction[] = [
+    {
+      icon: <LuSquarePen className="h-4 w-4" />,
+      title: 'Edit',
+      variant: 'outline',
+      size: 'sm',
+      onClick: (item: GangTacticsCard) => handleOpenEditModal(item),
+      disabled: () => !canEdit || isSubmitting
+    },
+    {
+      icon: <LuTrash2 className="h-4 w-4" />,
+      title: 'Delete',
+      variant: 'outline_remove',
+      size: 'sm',
+      onClick: (item: GangTacticsCard) => setDeleteCard(item),
+      disabled: () => !canEdit || isSubmitting
+    }
+  ];
+
+  return (
+    <>
+      <List<GangTacticsCard>
+        title="Gang Tactics"
+        className="mt-0"
+        items={tacticsCards}
+        columns={columns}
+        actions={actions}
+        onAdd={handleOpenAddModal}
+        addButtonText="Add"
+        addButtonDisabled={!canEdit}
+        emptyMessage="No gang tactics yet."
+        sortBy={compareTacticsCards}
+      />
+
+      {isAddModalOpen && (
+        <Modal
+          title="Add Gang Tactics"
+          helper="Pick the tactics cards this gang holds."
+          content={
+            <div>
+              {isLoadingCatalogue ? (
+                <p className="text-muted-foreground italic text-center py-4">Loading tactics cards...</p>
+              ) : catalogueError ? (
+                <p className="text-muted-foreground italic text-center py-4">Failed to load tactics cards.</p>
+              ) : catalogue.length === 0 ? (
+                <p className="text-muted-foreground italic text-center py-4">No tactics cards available.</p>
+              ) : (
+                <div className="max-h-96 overflow-y-auto border border-border rounded-lg">
+                  {catalogue.map((card, index) => {
+                    const isOwned = ownedCardIds.has(card.id);
+                    return (
+                      <label
+                        key={card.id}
+                        htmlFor={`tactics-card-${card.id}`}
+                        className={`flex items-center gap-3 px-3 py-[6px] ${
+                          index !== catalogue.length - 1 ? 'border-b border-border' : ''
+                        } ${isOwned ? 'opacity-50' : 'hover:bg-muted cursor-pointer'} transition-colors`}
+                      >
+                        <Checkbox
+                          id={`tactics-card-${card.id}`}
+                          checked={isOwned || selectedCardIds.has(card.id)}
+                          disabled={isOwned}
+                          onCheckedChange={() => toggleCard(card.id)}
+                        />
+                        <span className="tabular-nums text-sm text-muted-foreground w-12 shrink-0">
+                          {formatD66Range(card.d66_min, card.d66_max)}
+                        </span>
+                        <span className="text-sm font-medium text-foreground">{card.name}</span>
+                        {isOwned && (
+                          <span className="ml-auto text-xs text-muted-foreground">Already added</span>
+                        )}
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          }
+          onClose={() => setIsAddModalOpen(false)}
+          onConfirm={handleAdd}
+          confirmText="Add"
+          confirmDisabled={selectedCardIds.size === 0 || isSubmitting}
+          width="lg"
+        />
+      )}
+
+      {editCard && (
+        <Modal
+          title="Edit Tactics Card"
+          helper={`Description for ${editCard.name}`}
+          content={
+            <div>
+              <label
+                htmlFor="gang-tactics-description"
+                className="flex justify-between items-center text-sm font-medium text-muted-foreground mb-1"
+              >
+                <span>Description</span>
+                <span className={`text-sm ${isEditOverLimit ? 'text-red-500' : 'text-muted-foreground'}`}>
+                  {editDescription.length}/{TACTICS_DESCRIPTION_CHAR_LIMIT} characters
+                </span>
+              </label>
+              <Textarea
+                id="gang-tactics-description"
+                className="min-h-[200px] resize-y"
+                value={editDescription}
+                onChange={(e) => setEditDescription(e.target.value)}
+                placeholder="Enter the card's rules text or your own notes..."
+              />
+            </div>
+          }
+          onClose={() => setEditCard(null)}
+          onConfirm={handleSaveDescription}
+          confirmText="Save"
+          confirmDisabled={!hasEditChanged || isEditOverLimit || isSubmitting}
+          width="2xl"
+        />
+      )}
+
+      {deleteCard && (
+        <Modal
+          title="Remove Tactics Card"
+          content={
+            <p>
+              Remove <strong>{deleteCard.name}</strong> from this gang&apos;s tactics?
+            </p>
+          }
+          onClose={() => setDeleteCard(null)}
+          onConfirm={handleDelete}
+          confirmText="Remove"
+          confirmDisabled={isSubmitting}
+        />
+      )}
+
+      <Tooltip
+        id={TOOLTIP_ID}
+        place="top"
+        className="bg-neutral-900! text-white! text-xs! z-[2000]!"
+        delayHide={100}
+        clickable={true}
+        render={renderDescriptionTooltip}
+        style={{
+          padding: '6px',
+          width: '24rem',
+          maxWidth: '90vw',
+          maxHeight: '60vh'
+        }}
+      />
+    </>
+  );
+}

--- a/components/ui/list.tsx
+++ b/components/ui/list.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { cn } from '@/app/lib/utils';
 import { Button } from './button';
 
 export interface ListColumn {
@@ -84,8 +85,9 @@ export function List<T = any>({
     return String(value);
   };
 
+  // cn so a caller's own spacing overrides mt-6 instead of losing to it
   return (
-    <div className={`mt-6 ${className}`}>
+    <div className={cn('mt-6', className)}>
       <div className="flex flex-wrap justify-between items-center mb-2">
         <h2 className={`text-xl md:text-2xl font-bold${titleClassName ? ` ${titleClassName}` : ''}`}>{title}</h2>
         {(headerActions || onAdd) && (

--- a/types/edition.ts
+++ b/types/edition.ts
@@ -148,6 +148,12 @@ const EDITION_CAPABILITIES = {
   chemAlchemy:              { n23: true,  n26: false },
   /** Gang / fighter-type Law Abiding vs Outlaw alignment */
   alignment:                { n23: true,  n26: false },
+  /**
+   * Gangs hold Gang Tactics cards drawn from an edition's `tactics_cards`
+   * catalogue. Only N26's catalogue is seeded, so the section is hidden rather
+   * than shown empty for N23.
+   */
+  gangTacticsCards:         { n23: false, n26: true  },
   /** Fighters can be sold to the Guilders (the enslaved status) */
   sellToGuilders:           { n23: true,  n26: false },
   /**
@@ -279,6 +285,9 @@ export const hasChemAlchemy = (editionSlug?: string | null): boolean =>
 
 export const hasAlignment = (editionSlug?: string | null): boolean =>
   can('alignment', editionSlug);
+
+export const hasGangTacticsCards = (editionSlug?: string | null): boolean =>
+  can('gangTacticsCards', editionSlug);
 
 export const hasGuilderSales = (editionSlug?: string | null): boolean =>
   can('sellToGuilders', editionSlug);

--- a/types/tactics-card.ts
+++ b/types/tactics-card.ts
@@ -1,0 +1,63 @@
+// Gang Tactics cards. Two tables meet here: `tactics_cards` is the global,
+// edition-scoped catalogue (admin-written, no rules text), and
+// `gang_tactics_cards` is the per-gang row carrying the user's own description.
+// They live together because the gang row denormalises the catalogue's name and
+// D66 range, and both helpers below sort or format across the pair.
+//
+// Kept dependency-free so client components can import it.
+
+/** A row from the global `tactics_cards` catalogue. */
+export interface TacticsCard {
+  id: string;
+  name: string;
+  d66_min: number | null;
+  d66_max: number | null;
+  edition_slug: string | null;
+}
+
+/** A tactics card held by a gang, flattened with its catalogue fields. */
+export interface GangTacticsCard {
+  /** `gang_tactics_cards.id`, not the catalogue id. */
+  id: string;
+  tactics_cards_id: string;
+  name: string;
+  d66_min: number | null;
+  d66_max: number | null;
+  description: string | null;
+}
+
+/** Matches the territory description limit used elsewhere in the app. */
+export const TACTICS_DESCRIPTION_CHAR_LIMIT = 1500;
+
+/** A card's D66 range as printed ("11-12"), or a dash when it has none. */
+export function formatD66Range(
+  min: number | null | undefined,
+  max: number | null | undefined
+): string {
+  if (min == null || max == null) return '-';
+  return min === max ? String(min) : `${min}-${max}`;
+}
+
+/**
+ * Printed card order: D66 ascending, then name. Cards without a range sort
+ * last, since they are supplements to a numbered deck rather than part of it.
+ */
+export function compareTacticsCards(
+  a: Pick<TacticsCard, 'name' | 'd66_min'>,
+  b: Pick<TacticsCard, 'name' | 'd66_min'>
+): number {
+  if (a.d66_min !== b.d66_min) {
+    if (a.d66_min == null) return 1;
+    if (b.d66_min == null) return -1;
+    return a.d66_min - b.d66_min;
+  }
+  return a.name.localeCompare(b.name);
+}
+
+/** Trims a user-entered description, treating blank as absent. */
+export function normaliseTacticsDescription(
+  value: string | null | undefined
+): string | null {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/utils/cache-tags.ts
+++ b/utils/cache-tags.ts
@@ -24,6 +24,7 @@ export const CACHE_TAGS = {
   BASE_GANG_STASH: (id: string) => `base-gang-stash-${id}`,           // gang stash equipment
   BASE_GANG_VEHICLES: (id: string) => `base-gang-vehicles-${id}`,     // gang-owned vehicles
   BASE_GANG_POSITIONING: (id: string) => `base-gang-positioning-${id}`, // gang positioning data
+  BASE_GANG_TACTICS_CARDS: (id: string) => `base-gang-tactics-cards-${id}`, // gang tactics cards + descriptions
   
   // Fighter base data
   BASE_FIGHTER_BASIC: (id: string) => `base-fighter-basic-${id}`,     // name, stats, basic info
@@ -116,6 +117,7 @@ export const CACHE_TAGS = {
   GLOBAL_GANG_TYPES: () => `global-gang-types`,                       // gang type options
   GLOBAL_FIGHTER_TYPES: () => `global-fighter-types`,                 // fighter type options
   GLOBAL_TERRITORIES_LIST: () => `global-territories-list`,           // territory options
+  GLOBAL_TACTICS_CARDS: () => `global-tactics-cards`,                 // tactics card catalogue (migration-only)
   GLOBAL_CAMPAIGN_TYPES: () => `campaign-types`,                      // campaign type options
   GLOBAL_PATREON_SUPPORTERS: () => `global-patreon-supporters`,       // patreon supporters list
   GLOBAL_USER_COUNT: () => `global-user-count`,                       // total user count for homepage
@@ -143,6 +145,16 @@ export const CACHE_TAGS = {
  */
 export const invalidateUserGangsList = (userId: string) => {
   revalidateTag(CACHE_TAGS.USER_GANGS(userId), { expire: 0 });
+};
+
+/**
+ * Gang Tactics invalidation.
+ * Triggered when: a gang's tactics cards are added, described or removed.
+ * Data changed: the gang's tactics card list only — nothing feeds rating,
+ * credits or the fighters list, so this stays a single tag.
+ */
+export const invalidateGangTacticsCards = (gangId: string) => {
+  revalidateTag(CACHE_TAGS.BASE_GANG_TACTICS_CARDS(gangId), { expire: 0 });
 };
 
 /**


### PR DESCRIPTION
Wires up the tactics_cards / gang_tactics_cards tables, which until now existed only in the database.

The Battles tab gains a "Gang Tactics" card listing the cards a gang holds — D66 range, name, and a notepad tooltip for the user's own description — with the standard edit/delete row actions and an Add button opening a checkbox picker over the edition's catalogue. Cards the gang already holds show as checked and disabled rather than being hidden, so the full deck stays visible.

N26-only: the catalogue is edition-scoped and only N26 is seeded, so this adds a gangTacticsCards capability row rather than rendering an empty section for N23. N23 gangs skip the query entirely.

The gang's own cards are server-loaded alongside stash and battle sessions under a new BASE_GANG_TACTICS_CARDS tag, so the section renders on first paint. Only the catalogue goes through an API route, fetched lazily when the picker opens. Mutations are server actions guarded by checkPermissionCached plus an edition check, and the add path verifies every posted card id belongs to the gang's edition.

List now merges its className with cn() so a caller's spacing overrides mt-6 instead of losing to it in the generated CSS.


Claude-Session: https://claude.ai/code/session_01Bgty9QD32KvwTXcRGGjNtV