### PR TITLE
Require category selection when adding/editing fighter effects

### DIFF
--- a/components/admin/admin-fighter-effects.tsx
+++ b/components/admin/admin-fighter-effects.tsx
@@ -770,7 +770,7 @@ export function AdminFighterEffects({
           }}
           onConfirm={editingEffect ? handleUpdateEffect : handleAddEffect}
           confirmText={editingEffect ? "Update Effect" : "Add Effect"}
-          confirmDisabled={isLoading || !newEffect.effect_name}
+          confirmDisabled={isLoading || !newEffect.effect_name || !newEffect.fighter_effect_category_id}
         >
           <div className="space-y-4">
             <div>
@@ -801,7 +801,7 @@ export function AdminFighterEffects({
             </div>
 
             <div>
-              <label className="block text-sm font-medium mb-1">Category</label>
+              <label className="block text-sm font-medium mb-1">Category *</label>
               <select
                 value={newEffect.fighter_effect_category_id}
                 onChange={(e) => setNewEffect(prev => ({ ...prev, fighter_effect_category_id: e.target.value }))}
@@ -1169,4 +1169,4 @@ export function AdminFighterEffects({
       </Tooltip>
     </>
   );
-} 
+}


### PR DESCRIPTION
### Motivation
- Prevent creating or updating fighter effects without an associated category to avoid incomplete records.
- Make it explicit in the UI that the Category field is required.

### Description
- Updated the modal confirm disabled condition to include `!newEffect.fighter_effect_category_id` so the confirm button is disabled if no category is selected.
- Changed the Category label to `Category *` to indicate the field is required in the form.
- Minor EOF/whitespace cleanup in `components/admin/admin-fighter-effects.tsx`.

### Testing
- Ran TypeScript compilation and local frontend build with `yarn build` and observed no build/type errors.
- Ran unit tests with `yarn test` and all tests passed.