### PR TITLE
Make EDITION_N26 the default home edition

### DIFF
--- a/hooks/use-home-edition.ts
+++ b/hooks/use-home-edition.ts
@@ -10,14 +10,14 @@ function isEditionSlug(value: string | null | undefined): value is EditionSlug {
 }
 
 function readStoredEdition(): EditionSlug {
-  if (typeof window === 'undefined') return EDITION_N23
+  if (typeof window === 'undefined') return EDITION_N26
   const saved = localStorage.getItem(HOME_EDITION_STORAGE_KEY)
-  return isEditionSlug(saved) ? saved : EDITION_N23
+  return isEditionSlug(saved) ? saved : EDITION_N26
 }
 
 type Listener = () => void
 
-let currentEdition: EditionSlug = EDITION_N23
+let currentEdition: EditionSlug = EDITION_N26
 let hydrated = false
 const listeners = new Set<Listener>()
 
@@ -40,7 +40,7 @@ function getSnapshot(): EditionSlug {
 }
 
 function getServerSnapshot(): EditionSlug {
-  return EDITION_N23
+  return EDITION_N26
 }
 
 function setStoredEdition(slug: EditionSlug) {


### PR DESCRIPTION
### Motivation

- Update the default home edition to the newer edition so the UI and server-rendered fallback use `EDITION_N26` instead of `EDITION_N23`.

### Description

- Change the fallback returned by `readStoredEdition` from `EDITION_N23` to `EDITION_N26` when no stored value is present or on the server.
- Initialize `currentEdition` to `EDITION_N26` so the synchronous home edition value matches the new default.
- Update `getServerSnapshot` to return `EDITION_N26` for server-side rendering consistency.

### Testing

- Ran the project test suite and all tests passed. 
- Ran TypeScript type-checking with `tsc --noEmit` and there were no type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a87158be9fc8332bf5bef833101ec65)