### PR TITLE
Add a D66 roll button to the Gang Tactics picker

### DIFF
--- a/components/gang/gang-tactics-cards.tsx
+++ b/components/gang/gang-tactics-cards.tsx
@@ -7,11 +7,13 @@ import { Tooltip } from 'react-tooltip';
 import { BiSolidNotepad } from 'react-icons/bi';
 import { LuSquarePen, LuTrash2 } from 'react-icons/lu';
 import Modal from '@/components/ui/modal';
+import DiceRoller from '@/components/dice-roller';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Textarea } from '@/components/ui/textarea';
 import { List, ListAction, ListColumn } from '@/components/ui/list';
 import { renderDescriptionTooltip } from '@/components/ui/tooltip-renderers';
 import { UserPermissions } from '@/types/user-permissions';
+import { rollD66Outcome, type RollOutcome } from '@/utils/dice';
 import {
   compareTacticsCards,
   formatD66Range,
@@ -69,6 +71,26 @@ export default function GangTacticsCards({
     staleTime: 5 * 60 * 1000,
     enabled: isAddModalOpen && !!editionSlug
   });
+
+  const isTaken = (cardId: string) => ownedCardIds.has(cardId) || selectedCardIds.has(cardId);
+
+  const hasRollableCard = catalogue.some(card => card.d66_min != null && !isTaken(card.id));
+
+  const cardForRoll = (total: number) =>
+    catalogue.find(
+      card => card.d66_min != null && card.d66_max != null && total >= card.d66_min && total <= card.d66_max
+    );
+
+  const rollUnownedD66 = (): RollOutcome => {
+    let outcome = rollD66Outcome();
+    for (let attempt = 0; attempt < 50; attempt++) {
+      const card = cardForRoll(outcome.total);
+      // No match is a gap in the catalogue's ranges — report it rather than loop past it.
+      if (!card || !isTaken(card.id)) return outcome;
+      outcome = rollD66Outcome();
+    }
+    return outcome;
+  };
 
   const handleOpenAddModal = () => {
     setSelectedCardIds(new Set());
@@ -242,6 +264,29 @@ export default function GangTacticsCards({
           helper="Pick the tactics cards this gang holds."
           content={
             <div>
+              <div className="mb-3">
+                <DiceRoller<TacticsCard>
+                  items={catalogue}
+                  getRange={(card) =>
+                    card.d66_min != null && card.d66_max != null
+                      ? { min: card.d66_min, max: card.d66_max }
+                      : null
+                  }
+                  getName={(card) => card.name}
+                  inline
+                  rollFn={rollUnownedD66}
+                  buttonText="Roll D66"
+                  disabled={isLoadingCatalogue || !hasRollableCard}
+                  onRolled={(rolled) => {
+                    const card = rolled[0]?.item;
+                    if (!card) return;
+                    setSelectedCardIds(prev => new Set(prev).add(card.id));
+                    document
+                      .getElementById(`tactics-card-${card.id}`)
+                      ?.scrollIntoView({ block: 'nearest' });
+                  }}
+                />
+              </div>
               {isLoadingCatalogue ? (
                 <p className="text-muted-foreground italic text-center py-4">Loading tactics cards...</p>
               ) : catalogueError ? (

--- a/components/gang/gang-tactics-cards.tsx
+++ b/components/gang/gang-tactics-cards.tsx
@@ -72,9 +72,7 @@ export default function GangTacticsCards({
     enabled: isAddModalOpen && !!editionSlug
   });
 
-  const isTaken = (cardId: string) => ownedCardIds.has(cardId) || selectedCardIds.has(cardId);
-
-  const hasRollableCard = catalogue.some(card => card.d66_min != null && !isTaken(card.id));
+  const hasRollableCard = catalogue.some(card => card.d66_min != null && !ownedCardIds.has(card.id));
 
   const cardForRoll = (total: number) =>
     catalogue.find(
@@ -86,7 +84,7 @@ export default function GangTacticsCards({
     for (let attempt = 0; attempt < 50; attempt++) {
       const card = cardForRoll(outcome.total);
       // No match is a gap in the catalogue's ranges — report it rather than loop past it.
-      if (!card || !isTaken(card.id)) return outcome;
+      if (!card || !ownedCardIds.has(card.id)) return outcome;
       outcome = rollD66Outcome();
     }
     return outcome;
@@ -280,7 +278,7 @@ export default function GangTacticsCards({
                   onRolled={(rolled) => {
                     const card = rolled[0]?.item;
                     if (!card) return;
-                    setSelectedCardIds(prev => new Set(prev).add(card.id));
+                    setSelectedCardIds(new Set([card.id]));
                     document
                       .getElementById(`tactics-card-${card.id}`)
                       ?.scrollIntoView({ block: 'nearest' });


### PR DESCRIPTION
Reuses DiceRoller in inline mode with rollD66Outcome, so the result reads
"Roll 23 (2, 3): Adrenaline Surge" next to the button and the matching
card is ticked. Rolls add to the selection rather than replacing it.

Cards the gang already holds, and ones already ticked, are rolled past —
a bounded rejection loop in rollFn, which gives the same distribution as
re-rolling duplicates by hand. The button disables when nothing is left
to roll. The rolled row is scrolled into view, since the list scrolls and
the tick would otherwise land off-screen.