### PR TITLE
Log tactics card rolls, adds and removals to the gang log

### DIFF
--- a/app/actions/gang-tactics-cards.ts
+++ b/app/actions/gang-tactics-cards.ts
@@ -4,6 +4,12 @@ import { createClient } from '@/utils/supabase/server';
 import { getAuthenticatedUser } from '@/utils/auth';
 import { checkPermissionCached } from '@/utils/user-permissions';
 import { invalidateGangTacticsCards } from '@/utils/cache-tags';
+import type { GangLogActionResult } from './logs/gang-logs';
+import {
+  logRolledTacticsCard,
+  logTacticsCardAdded,
+  logTacticsCardRemoved
+} from './logs/gang-tactics-logs';
 import { gangEditionJoin, gangEditionSlug, hasGangTacticsCards } from '@/types/edition';
 import {
   GANG_TACTICS_CARD_SELECT,
@@ -101,7 +107,7 @@ export async function addGangTacticsCards(params: {
     // The browser can post any uuid, so don't trust what the picker sent.
     let catalogueQuery = supabase
       .from('tactics_cards')
-      .select('id')
+      .select('id, name')
       .in('id', tacticsCardIds);
 
     if (auth.context.editionId) {
@@ -116,22 +122,73 @@ export async function addGangTacticsCards(params: {
     }
 
     // ignoreDuplicates so a stale picker can't 23505 on (gang_id, tactics_cards_id).
-    const { error: insertError } = await supabase
+    // The returned rows are only the ones actually inserted, which is what gets logged.
+    const { data: inserted, error: insertError } = await supabase
       .from('gang_tactics_cards')
       .upsert(
         tacticsCardIds.map(id => ({ gang_id: params.gangId, tactics_cards_id: id })),
         { onConflict: 'gang_id,tactics_cards_id', ignoreDuplicates: true }
-      );
+      )
+      .select('tactics_cards_id');
 
     if (insertError) throw insertError;
 
     const added = await selectGangTacticsCards(supabase, params.gangId, tacticsCardIds);
+
+    const nameById = new Map((catalogue ?? []).map((card: any) => [card.id, card.name]));
+    await Promise.all(
+      (inserted ?? []).map((row: any) =>
+        logTacticsCardAdded({
+          gang_id: params.gangId,
+          card_name: nameById.get(row.tactics_cards_id) ?? 'Unknown Tactic'
+        })
+      )
+    );
 
     invalidateGangTacticsCards(params.gangId);
 
     return { success: true, data: added };
   } catch (error) {
     console.error('Error adding gang tactics cards:', error);
+    return { success: false, error: 'An unexpected error occurred' };
+  }
+}
+
+export async function verifyAndLogRolledTacticsCard(params: {
+  gangId: string;
+  total: number;
+  dice: number[];
+}): Promise<GangLogActionResult> {
+  try {
+    const supabase = await createClient();
+
+    const auth = await authoriseGangTactics(supabase, params.gangId);
+    if ('error' in auth) return { success: false, error: auth.error };
+
+    // Resolved from the dice rather than a posted id, so a roll can't be
+    // credited to a card it didn't produce.
+    let query = supabase
+      .from('tactics_cards')
+      .select('name')
+      .lte('d66_min', params.total)
+      .gte('d66_max', params.total);
+
+    if (auth.context.editionId) {
+      query = query.eq('edition_id', auth.context.editionId);
+    }
+
+    const { data: card, error } = await query.maybeSingle();
+    if (error) throw error;
+    if (!card) return { success: false, error: 'No tactics card matches that roll' };
+
+    return await logRolledTacticsCard({
+      gang_id: params.gangId,
+      card_name: card.name,
+      total: params.total,
+      dice: params.dice
+    });
+  } catch (error) {
+    console.error('Error logging tactics card roll:', error);
     return { success: false, error: 'An unexpected error occurred' };
   }
 }
@@ -182,6 +239,13 @@ export async function deleteGangTacticsCard(params: {
     const auth = await authoriseGangTactics(supabase, params.gangId);
     if ('error' in auth) return { success: false, error: auth.error };
 
+    const { data: existing } = await supabase
+      .from('gang_tactics_cards')
+      .select('tactics_cards:tactics_cards_id ( name )')
+      .eq('id', params.gangTacticsCardId)
+      .eq('gang_id', params.gangId)
+      .maybeSingle();
+
     const { error } = await supabase
       .from('gang_tactics_cards')
       .delete()
@@ -189,6 +253,11 @@ export async function deleteGangTacticsCard(params: {
       .eq('gang_id', params.gangId);
 
     if (error) throw error;
+
+    const card = Array.isArray(existing?.tactics_cards) ? existing?.tactics_cards[0] : existing?.tactics_cards;
+    if (card?.name) {
+      await logTacticsCardRemoved({ gang_id: params.gangId, card_name: card.name });
+    }
 
     invalidateGangTacticsCards(params.gangId);
 

--- a/app/actions/gang-tactics-cards.ts
+++ b/app/actions/gang-tactics-cards.ts
@@ -71,24 +71,6 @@ async function authoriseGangTactics(
   return { context: { editionId: gangEditionJoin(gang)?.id ?? null } };
 }
 
-async function selectGangTacticsCards(
-  supabase: any,
-  gangId: string,
-  tacticsCardIds: string[]
-): Promise<GangTacticsCard[]> {
-  if (tacticsCardIds.length === 0) return [];
-
-  const { data, error } = await supabase
-    .from('gang_tactics_cards')
-    .select(GANG_TACTICS_CARD_SELECT)
-    .eq('gang_id', gangId)
-    .in('tactics_cards_id', tacticsCardIds);
-
-  if (error) throw error;
-
-  return (data ?? []).map(toGangTacticsCard);
-}
-
 export async function addGangTacticsCards(params: {
   gangId: string;
   tacticsCardIds: string[];
@@ -107,7 +89,7 @@ export async function addGangTacticsCards(params: {
     // The browser can post any uuid, so don't trust what the picker sent.
     let catalogueQuery = supabase
       .from('tactics_cards')
-      .select('id, name')
+      .select('id')
       .in('id', tacticsCardIds);
 
     if (auth.context.editionId) {
@@ -122,27 +104,22 @@ export async function addGangTacticsCards(params: {
     }
 
     // ignoreDuplicates so a stale picker can't 23505 on (gang_id, tactics_cards_id).
-    // The returned rows are only the ones actually inserted, which is what gets logged.
+    // Returns only the rows actually inserted, which is what the client appends
+    // and what gets logged.
     const { data: inserted, error: insertError } = await supabase
       .from('gang_tactics_cards')
       .upsert(
         tacticsCardIds.map(id => ({ gang_id: params.gangId, tactics_cards_id: id })),
         { onConflict: 'gang_id,tactics_cards_id', ignoreDuplicates: true }
       )
-      .select('tactics_cards_id');
+      .select(GANG_TACTICS_CARD_SELECT);
 
     if (insertError) throw insertError;
 
-    const added = await selectGangTacticsCards(supabase, params.gangId, tacticsCardIds);
+    const added = (inserted ?? []).map(toGangTacticsCard);
 
-    const nameById = new Map((catalogue ?? []).map((card: any) => [card.id, card.name]));
     await Promise.all(
-      (inserted ?? []).map((row: any) =>
-        logTacticsCardAdded({
-          gang_id: params.gangId,
-          card_name: nameById.get(row.tactics_cards_id) ?? 'Unknown Tactic'
-        })
-      )
+      added.map(card => logTacticsCardAdded({ gang_id: params.gangId, card_name: card.name }))
     );
 
     invalidateGangTacticsCards(params.gangId);

--- a/app/actions/logs/gang-tactics-logs.ts
+++ b/app/actions/logs/gang-tactics-logs.ts
@@ -16,52 +16,27 @@ interface TacticsCardLogParams {
 }
 
 export async function logRolledTacticsCard(params: TacticsCardRollLogParams): Promise<GangLogActionResult> {
-  try {
-    const firstLine = `Gang rolled ${params.total} on the Gang Tactics table, resulting in: "${params.card_name}"`;
-    const description = `${firstLine}\n${formatRollOutcomeLine(params.total, params.dice)}`;
+  const firstLine = `Gang rolled ${params.total} on the Gang Tactics table, resulting in: "${params.card_name}"`;
 
-    return await createGangLog({
-      gang_id: params.gang_id,
-      action_type: 'tactics_card_roll',
-      description
-    });
-  } catch (error) {
-    console.error('Error logging the Gang Tactics roll:', error);
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'Failed to log the Gang Tactics roll'
-    };
-  }
+  return createGangLog({
+    gang_id: params.gang_id,
+    action_type: 'tactics_card_roll',
+    description: `${firstLine}\n${formatRollOutcomeLine(params.total, params.dice)}`
+  });
 }
 
 export async function logTacticsCardAdded(params: TacticsCardLogParams): Promise<GangLogActionResult> {
-  try {
-    return await createGangLog({
-      gang_id: params.gang_id,
-      action_type: 'tactics_card_added',
-      description: `Added Gang Tactic "${params.card_name}".`
-    });
-  } catch (error) {
-    console.error('Error logging the added Gang Tactic:', error);
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'Failed to log the added Gang Tactic'
-    };
-  }
+  return createGangLog({
+    gang_id: params.gang_id,
+    action_type: 'tactics_card_added',
+    description: `Added Gang Tactic "${params.card_name}".`
+  });
 }
 
 export async function logTacticsCardRemoved(params: TacticsCardLogParams): Promise<GangLogActionResult> {
-  try {
-    return await createGangLog({
-      gang_id: params.gang_id,
-      action_type: 'tactics_card_removed',
-      description: `Removed Gang Tactic "${params.card_name}".`
-    });
-  } catch (error) {
-    console.error('Error logging the removed Gang Tactic:', error);
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'Failed to log the removed Gang Tactic'
-    };
-  }
+  return createGangLog({
+    gang_id: params.gang_id,
+    action_type: 'tactics_card_removed',
+    description: `Removed Gang Tactic "${params.card_name}".`
+  });
 }

--- a/app/actions/logs/gang-tactics-logs.ts
+++ b/app/actions/logs/gang-tactics-logs.ts
@@ -3,37 +3,65 @@
 import { createGangLog, GangLogActionResult } from "./gang-logs";
 import { formatRollOutcomeLine } from "@/utils/dice";
 
-export async function logRolledTacticsCard(params: {
+interface TacticsCardRollLogParams {
   gang_id: string;
   card_name: string;
   total: number;
   dice: number[];
-}): Promise<GangLogActionResult> {
-  return createGangLog({
-    gang_id: params.gang_id,
-    action_type: 'tactics_card_roll',
-    description: formatRollOutcomeLine(params.total, params.dice, params.card_name)
-  });
 }
 
-export async function logTacticsCardAdded(params: {
+interface TacticsCardLogParams {
   gang_id: string;
   card_name: string;
-}): Promise<GangLogActionResult> {
-  return createGangLog({
-    gang_id: params.gang_id,
-    action_type: 'tactics_card_added',
-    description: `Added Gang Tactic "${params.card_name}"`
-  });
 }
 
-export async function logTacticsCardRemoved(params: {
-  gang_id: string;
-  card_name: string;
-}): Promise<GangLogActionResult> {
-  return createGangLog({
-    gang_id: params.gang_id,
-    action_type: 'tactics_card_removed',
-    description: `Removed Gang Tactic "${params.card_name}"`
-  });
+export async function logRolledTacticsCard(params: TacticsCardRollLogParams): Promise<GangLogActionResult> {
+  try {
+    const firstLine = `Gang rolled ${params.total} on the Gang Tactics table, resulting in: "${params.card_name}"`;
+    const description = `${firstLine}\n${formatRollOutcomeLine(params.total, params.dice)}`;
+
+    return await createGangLog({
+      gang_id: params.gang_id,
+      action_type: 'tactics_card_roll',
+      description
+    });
+  } catch (error) {
+    console.error('Error logging the Gang Tactics roll:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to log the Gang Tactics roll'
+    };
+  }
+}
+
+export async function logTacticsCardAdded(params: TacticsCardLogParams): Promise<GangLogActionResult> {
+  try {
+    return await createGangLog({
+      gang_id: params.gang_id,
+      action_type: 'tactics_card_added',
+      description: `Added Gang Tactic "${params.card_name}".`
+    });
+  } catch (error) {
+    console.error('Error logging the added Gang Tactic:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to log the added Gang Tactic'
+    };
+  }
+}
+
+export async function logTacticsCardRemoved(params: TacticsCardLogParams): Promise<GangLogActionResult> {
+  try {
+    return await createGangLog({
+      gang_id: params.gang_id,
+      action_type: 'tactics_card_removed',
+      description: `Removed Gang Tactic "${params.card_name}".`
+    });
+  } catch (error) {
+    console.error('Error logging the removed Gang Tactic:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Failed to log the removed Gang Tactic'
+    };
+  }
 }

--- a/app/actions/logs/gang-tactics-logs.ts
+++ b/app/actions/logs/gang-tactics-logs.ts
@@ -1,0 +1,39 @@
+'use server'
+
+import { createGangLog, GangLogActionResult } from "./gang-logs";
+import { formatRollOutcomeLine } from "@/utils/dice";
+
+export async function logRolledTacticsCard(params: {
+  gang_id: string;
+  card_name: string;
+  total: number;
+  dice: number[];
+}): Promise<GangLogActionResult> {
+  return createGangLog({
+    gang_id: params.gang_id,
+    action_type: 'tactics_card_roll',
+    description: formatRollOutcomeLine(params.total, params.dice, params.card_name)
+  });
+}
+
+export async function logTacticsCardAdded(params: {
+  gang_id: string;
+  card_name: string;
+}): Promise<GangLogActionResult> {
+  return createGangLog({
+    gang_id: params.gang_id,
+    action_type: 'tactics_card_added',
+    description: `Added Gang Tactic "${params.card_name}"`
+  });
+}
+
+export async function logTacticsCardRemoved(params: {
+  gang_id: string;
+  card_name: string;
+}): Promise<GangLogActionResult> {
+  return createGangLog({
+    gang_id: params.gang_id,
+    action_type: 'tactics_card_removed',
+    description: `Removed Gang Tactic "${params.card_name}"`
+  });
+}

--- a/components/gang/gang-tactics-cards.tsx
+++ b/components/gang/gang-tactics-cards.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { Tooltip } from 'react-tooltip';
 import { BiSolidNotepad } from 'react-icons/bi';
@@ -25,7 +25,8 @@ import {
 import {
   addGangTacticsCards,
   deleteGangTacticsCard,
-  updateGangTacticsCardDescription
+  updateGangTacticsCardDescription,
+  verifyAndLogRolledTacticsCard
 } from '@/app/actions/gang-tactics-cards';
 
 interface GangTacticsCardsProps {
@@ -52,6 +53,7 @@ export default function GangTacticsCards({
   const [editDescription, setEditDescription] = useState('');
   const [deleteCard, setDeleteCard] = useState<GangTacticsCard | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [rollLogCooldown, setRollLogCooldown] = useState(false);
 
   const canEdit = userPermissions.canEdit;
 
@@ -73,6 +75,21 @@ export default function GangTacticsCards({
   });
 
   const hasRollableCard = catalogue.some(card => card.d66_min != null && !ownedCardIds.has(card.id));
+
+  const logRollMutation = useMutation({
+    mutationFn: (outcome: RollOutcome) =>
+      verifyAndLogRolledTacticsCard({ gangId, total: outcome.total, dice: outcome.dice })
+  });
+
+  const logRollWithCooldown = (outcome: RollOutcome) => {
+    if (rollLogCooldown || logRollMutation.isPending) return;
+    setRollLogCooldown(true);
+    try {
+      logRollMutation.mutate(outcome);
+    } finally {
+      setTimeout(() => setRollLogCooldown(false), 2000);
+    }
+  };
 
   const cardForRoll = (total: number) =>
     catalogue.find(
@@ -276,8 +293,10 @@ export default function GangTacticsCards({
                   buttonText="Roll D66"
                   disabled={isLoadingCatalogue || !hasRollableCard}
                   onRolled={(rolled) => {
-                    const card = rolled[0]?.item;
+                    const result = rolled[0];
+                    const card = result?.item;
                     if (!card) return;
+                    logRollWithCooldown({ total: result.roll, dice: result.dice });
                     setSelectedCardIds(new Set([card.id]));
                     document
                       .getElementById(`tactics-card-${card.id}`)

--- a/utils/log-types.ts
+++ b/utils/log-types.ts
@@ -102,6 +102,11 @@ export const LOG_TYPE_LABELS: Record<string, string> = {
   'name_changed': 'Name changed',
   'gang_type_changed': 'Gang type changed',
 
+  // Gang Tactics
+  'tactics_card_roll': 'Gang Tactics roll',
+  'tactics_card_added': 'Gang Tactic added',
+  'tactics_card_removed': 'Gang Tactic removed',
+
   // Campaign
   'campaign_joined': 'Campaign joined',
   'campaign_left': 'Campaign left',


### PR DESCRIPTION
Three new action types go through the existing createGangLog, so the log
modal picks them up without any enum to extend: tactics_card_roll,
tactics_card_added and tactics_card_removed.

The roll happens in the browser, so it needs a server hop to record it.
That action takes only the dice and resolves the card itself, rather than
trusting a posted card id. Repeated Roll clicks are held behind the same
2s cooldown the injury roll uses.

Adds log one row per card actually inserted, read back from the upsert so
re-adding an existing card logs nothing. Delete reads the card name before
removing the row, since the client's copy isn't trusted.