### PR TITLE
Cut ~100k wasted Supabase round trips per day

### DIFF
--- a/app/actions/add-fighter.ts
+++ b/app/actions/add-fighter.ts
@@ -425,7 +425,7 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
         .select('adjusted_cost')
         .eq('fighter_type_id', params.fighter_type_id)
         .eq('gang_type_id', gangData.gang_type_id)
-        .single();
+        .maybeSingle();
 
       // Use adjusted cost if available, otherwise use the original cost
       adjustedBaseCost = adjustedCostData?.adjusted_cost ?? fighterTypeData.cost;

--- a/app/actions/logs/fighter-logs.ts
+++ b/app/actions/logs/fighter-logs.ts
@@ -182,16 +182,17 @@ export async function calculateFighterCredits(fighter_id: string): Promise<numbe
     
     const { data: fighter, error } = await supabase
       .from('fighters')
+      // Left joins: !inner dropped the row unless the fighter had all four relations
       .select(`
         credits,
         cost_adjustment,
-        fighter_equipment!inner(purchase_cost),
-        fighter_skills!inner(credits_increase),
-        fighter_effects!inner(type_specific_data),
-        vehicles!inner(cost, fighter_equipment!inner(purchase_cost))
+        fighter_equipment(purchase_cost),
+        fighter_skills(credits_increase),
+        fighter_effects(type_specific_data),
+        vehicles(cost, fighter_equipment(purchase_cost))
       `)
       .eq('id', fighter_id)
-      .single();
+      .maybeSingle();
 
     if (error || !fighter) {
       console.error('Error fetching fighter data for credit calculation:', error);

--- a/app/actions/logs/gang-logs.ts
+++ b/app/actions/logs/gang-logs.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { createClient } from "@/utils/supabase/server";
+import { getUserIdFromClaims } from "@/utils/auth";
 
 export interface CreateGangLogParams {
   gang_id: string;
@@ -20,16 +21,13 @@ export interface GangLogActionResult {
 export async function createGangLog(params: CreateGangLogParams): Promise<GangLogActionResult> {
   try {
     const supabase = await createClient();
-    
-    // Get the current user
-    const { data: { user } } = await supabase.auth.getUser();
-    
-    if (!user) {
+
+    // Claims are verified locally; getUser() would be a network round trip per log write
+    const userId = params.user_id || await getUserIdFromClaims(supabase);
+
+    if (!userId) {
       throw new Error('User not authenticated');
     }
-
-    // Use user_id from params or fallback to current user
-    const userId = params.user_id || user.id;
 
     // Insert gang log
     const { data, error } = await supabase

--- a/app/lib/shared/fighter-data.ts
+++ b/app/lib/shared/fighter-data.ts
@@ -1279,7 +1279,7 @@ export const getFighterOwnershipInfo = async (fighterPetId: string, supabase: an
           )
         `)
         .eq('id', fighterPetId)
-        .single();
+        .maybeSingle();
 
       if (error || !data) return null;
 


### PR DESCRIPTION
Three fixes on the server-side hot paths, none of which change behaviour except where the current behaviour is wrong.

createGangLog called supabase.auth.getUser() on every gang log insert. That is a network round trip to Supabase Auth, and it showed up as an exact 1:1 match in 24h of edge logs: 49,710 POSTs to /rest/v1/gang_logs against 50,147 GETs to /auth/v1/user, all from the Vercel runtime. Every other helper in app/actions/logs/ funnels through createGangLog, so this was on every logged action. It now uses getUserIdFromClaims (local JWT verification, the app-wide idiom) and only resolves the caller at all when params.user_id is absent, which most callers already supply.

Two .single() calls accounted for ~90% of the 54,264 daily 406/PGRST116 responses:

  - add-fighter.ts looked up an optional per-gang-type cost override. The row almost never exists, so 10,378 of 10,379 requests returned 406. Zero rows is the normal case and the null path was already handled.
  - getFighterOwnershipInfo runs per fighter to test whether that fighter is an exotic beast. Most are not, giving 38,424 406s a day.

Both become .maybeSingle().

calculateFighterCredits joined fighter_equipment, fighter_skills, fighter_effects and vehicles with !inner, then called .single(). An inner join drops the fighter row unless it has all four, so for most fighters the query matched nothing and the function returned 0 credits into the log message. Those are now left joins with .maybeSingle(); the reducers below already guarded each relation.

---

**On the Vercel cost investigation this came out of:** this is efficiency work, not a fix for the cost step-up. There is no per-request regression — requests per active user fell ~15% (1,444 to 1,226) and cost per active user fell ~27% across the boundary.

The cost curve is two separate events on the same morning, both starting 09:00 UTC on 14 Aug:

  - **The one-day spike** was a Supabase saturation incident. N26 launched and server-side traffic stepped ~10x within the hour (20k to 210k requests/hour). Average query latency went from ~20ms to 1,500-7,500ms and stayed there for eight hours, so that day accumulated 660 origin-hours of blocked function time against a normal ~13. Fluid Compute bills provisioned memory on wall-clock instance lifetime, so blocked functions are billed functions. The database recovered at 17:00 and latency has been normal since (17-21ms).
  - **The permanent plateau** is the launch traffic itself, which never came back down: 725k to ~2.5M Supabase requests/day, ~500 to ~2,080 daily active users.

The billing chart's "13 Aug" is the 14 Aug UTC incident crossing a billing-day boundary.

Remaining efficiency work not in this PR: ~235k daily reads of near-static reference tables (weapon_profiles, equipment, fighter_effect_types and friends), caused by those reads living inside the ~1,130-line getGangFightersList unstable_cache block, which every gang mutation invalidates.