### PR TITLE
Add edition-scoped scenarios and D6 scenario rolling for N26

### DIFF
--- a/app/api/admin/scenarios/route.ts
+++ b/app/api/admin/scenarios/route.ts
@@ -66,16 +66,20 @@ async function _POST(request: Request) {
       );
     }
 
-    // Check for duplicate scenario number
-    const { data: existing } = await supabase
+    // Scenario numbers restart per edition, so the check is scoped to one.
+    let duplicateQuery = supabase
       .from('scenarios')
       .select('id')
-      .eq('scenario_number', numericScenarioNumber)
-      .single();
+      .eq('scenario_number', numericScenarioNumber);
+    duplicateQuery = edition_id
+      ? duplicateQuery.eq('edition_id', edition_id)
+      : duplicateQuery.is('edition_id', null);
+
+    const { data: existing } = await duplicateQuery.maybeSingle();
 
     if (existing) {
       return NextResponse.json(
-        { error: 'A scenario with this number already exists' },
+        { error: 'A scenario with this number already exists for this edition' },
         { status: 409 }
       );
     }
@@ -140,17 +144,21 @@ async function _PATCH(request: Request) {
       );
     }
 
-    // Check for duplicate scenario number (excluding current scenario)
-    const { data: existing } = await supabase
+    // Duplicate check, excluding the current scenario.
+    let duplicateQuery = supabase
       .from('scenarios')
       .select('id')
       .eq('scenario_number', numericScenarioNumber)
-      .neq('id', id)
-      .single();
+      .neq('id', id);
+    duplicateQuery = edition_id
+      ? duplicateQuery.eq('edition_id', edition_id)
+      : duplicateQuery.is('edition_id', null);
+
+    const { data: existing } = await duplicateQuery.maybeSingle();
 
     if (existing) {
       return NextResponse.json(
-        { error: 'A scenario with this number already exists' },
+        { error: 'A scenario with this number already exists for this edition' },
         { status: 409 }
       );
     }

--- a/app/api/campaigns/battles/route.ts
+++ b/app/api/campaigns/battles/route.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 import { normaliseParticipants, territoryClaimerFor } from "@/utils/battle-participants";
+import { withEditionSlug } from "@/types/edition";
 
 export async function GET(
   request: Request
@@ -9,11 +10,13 @@ export async function GET(
   const campaignId = request.headers.get('X-Campaign-Id');
 
   try {
-    const { data: scenarios, error: scenariosError } = await supabase
+    const { data: scenarioRows, error: scenariosError } = await supabase
       .from('scenarios')
-      .select('id, scenario_name, scenario_number');
+      .select('id, scenario_name, scenario_number, editions:edition_id (slug)');
 
     if (scenariosError) throw scenariosError;
+
+    const scenarios = (scenarioRows || []).map(withEditionSlug);
 
     if (!campaignId) {
       return NextResponse.json({ scenarios });

--- a/app/lib/reference-data.ts
+++ b/app/lib/reference-data.ts
@@ -2,6 +2,7 @@ import { TAGS } from '@/utils/cache-tags';
 import { unstable_cache } from 'next/cache';
 import { createClient } from '@/utils/supabase/server';
 import { withEditionSlug } from '@/types/edition';
+import type { Scenario } from '@/types/campaign';
 
 /**
  * Cached global reference data (admin-owned tables, not scoped to any
@@ -9,24 +10,20 @@ import { withEditionSlug } from '@/types/edition';
  * tables (plus a time-based fallback where noted).
  */
 
-export interface Scenario {
-  id: string;
-  scenario_name: string;
-  scenario_number: number | null;
-}
+export type { Scenario };
 
 export const getScenariosCached = async (supabase: any): Promise<Scenario[]> => {
   return unstable_cache(
     async () => {
       const { data, error } = await supabase
         .from('scenarios')
-        .select('id, scenario_name, scenario_number')
+        .select('id, scenario_name, scenario_number, editions:edition_id (slug)')
         .order('scenario_number');
 
       if (error) throw error;
-      return data || [];
+      return (data || []).map(withEditionSlug);
     },
-    ['global-scenarios'],
+    ['global-scenarios-with-edition'],
     {
       tags: [TAGS.globalScenarios()],
       revalidate: 3600

--- a/components/battle-session/active-session.tsx
+++ b/components/battle-session/active-session.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useRouter } from 'next/navigation';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -22,6 +22,7 @@ import { Button } from '@/components/ui/button';
 import { Combobox } from '@/components/ui/combobox';
 import type { BattleSessionFull } from '@/types/battle-session';
 import type { Scenario } from '@/types/campaign';
+import { sameEditionForDisplay } from '@/types/edition';
 import type { GangFighter } from '@/app/lib/shared/gang-data';
 
 interface ActiveSessionProps {
@@ -57,6 +58,11 @@ export default function ActiveSession({
     refetchOnWindowFocus: false,
   });
   const { broadcast, suppressRefetch } = useBattleSessionRealtime(session.id);
+
+  const editionScenarios = useMemo(
+    () => scenarios.filter((s) => sameEditionForDisplay(s.edition_slug, session.edition_slug)),
+    [scenarios, session.edition_slug]
+  );
 
   const [showCancelModal, setShowCancelModal] = useState(false);
   const [showAddPlayerModal, setShowAddPlayerModal] = useState(false);
@@ -221,13 +227,13 @@ export default function ActiveSession({
               Scenario
             </label>
             <Combobox
-              options={scenarios.map((s) => ({
+              options={editionScenarios.map((s) => ({
                 value: s.id,
                 label: s.scenario_number ? `${s.scenario_number}. ${s.scenario_name}` : s.scenario_name,
               }))}
-              value={scenarios.find((s) => s.scenario_name === session.scenario)?.id ?? ''}
+              value={editionScenarios.find((s) => s.scenario_name === session.scenario)?.id ?? ''}
               onValueChange={(id) => {
-                const name = scenarios.find((s) => s.id === id)?.scenario_name ?? id;
+                const name = editionScenarios.find((s) => s.id === id)?.scenario_name ?? id;
                 scenarioMutation.mutate(name);
               }}
               placeholder="Select scenario..."

--- a/components/battle-session/create-battle-modal.tsx
+++ b/components/battle-session/create-battle-modal.tsx
@@ -142,6 +142,8 @@ export default function CreateBattleModal({
     return a.scenario_number - b.scenario_number;
   });
 
+  const showScenarioRoll = hasScenarioD6Roll(editionSlug);
+
   const opponentCampaignGangs = (campaignGangs ?? []).filter(
     (g) =>
       g.id !== effectiveGangId &&
@@ -443,74 +445,74 @@ export default function CreateBattleModal({
 
         {/* Scenario picker (create mode only) */}
         {!isAddMode && (
-          <div>
-            <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
-              Scenario
-            </label>
-            {hasScenarioD6Roll(editionSlug) && (
-              <div className="mb-2">
-                <DiceRoller<Scenario>
-                  items={sortedScenarios}
-                  // scenario_number is numeric in Postgres, so it arrives as a string.
-                  getRange={(s) =>
-                    s.scenario_number != null
-                      ? { min: Number(s.scenario_number), max: Number(s.scenario_number) }
-                      : null
-                  }
-                  getName={(s) => s.scenario_name}
-                  inline
-                  rollFn={() => rollNd6Outcome(1)}
-                  buttonText="Roll D6"
-                  disabled={isLoadingBattleData || sortedScenarios.length === 0}
-                  onRolled={(rolled) => {
-                    const result = rolled[0];
-                    if (!result) return;
-                    setSelectedScenario(result.item.id);
-                    setCustomScenario('');
-                  }}
-                />
-              </div>
-            )}
-            <Combobox
-              options={[
-                { value: 'custom', label: 'Custom' },
-                ...sortedScenarios.map((s) => ({
-                  value: s.id,
-                  label: s.scenario_number ? `${s.scenario_number}. ${s.scenario_name}` : s.scenario_name,
-                })),
-              ]}
-              value={selectedScenario === 'custom' ? 'custom' : selectedScenario}
-              onValueChange={(value) => {
-                if (value === 'custom') {
-                  setSelectedScenario('custom');
-                  setCustomScenario('');
-                } else {
-                  const isCustomValue = !sortedScenarios.some((s) => s.id === value);
-                  if (isCustomValue) {
-                    setSelectedScenario('custom');
-                    setCustomScenario(value);
-                  } else {
-                    setSelectedScenario(value);
-                    setCustomScenario('');
-                  }
+          <div className="space-y-4">
+            {showScenarioRoll && (
+              <DiceRoller<Scenario>
+                items={sortedScenarios}
+                // scenario_number is numeric in Postgres, so it arrives as a string.
+                getRange={(s) =>
+                  s.scenario_number != null
+                    ? { min: Number(s.scenario_number), max: Number(s.scenario_number) }
+                    : null
                 }
-              }}
-              placeholder="Select or search for a Scenario..."
-              disabled={isLoadingBattleData}
-              dropdownPlacement="down"
-              allowCustom={true}
-            />
-            {selectedScenario === 'custom' && (
-              <div className="mt-2">
-                <input
-                  type="text"
-                  className="w-full px-3 py-2 rounded-md border border-border bg-muted"
-                  placeholder="Enter custom Scenario name"
-                  value={customScenario}
-                  onChange={(e) => setCustomScenario(e.target.value)}
-                />
-              </div>
+                getName={(s) => s.scenario_name}
+                inline
+                rollFn={() => rollNd6Outcome(1)}
+                buttonText="Roll D6"
+                disabled={isLoadingBattleData || sortedScenarios.length === 0}
+                onRolled={(rolled) => {
+                  const result = rolled[0];
+                  if (!result) return;
+                  setSelectedScenario(result.item.id);
+                  setCustomScenario('');
+                }}
+              />
             )}
+            <div className={showScenarioRoll ? 'border-t pt-3' : undefined}>
+              <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                Scenario
+              </label>
+              <Combobox
+                options={[
+                  { value: 'custom', label: 'Custom' },
+                  ...sortedScenarios.map((s) => ({
+                    value: s.id,
+                    label: s.scenario_number ? `${s.scenario_number}. ${s.scenario_name}` : s.scenario_name,
+                  })),
+                ]}
+                value={selectedScenario === 'custom' ? 'custom' : selectedScenario}
+                onValueChange={(value) => {
+                  if (value === 'custom') {
+                    setSelectedScenario('custom');
+                    setCustomScenario('');
+                  } else {
+                    const isCustomValue = !sortedScenarios.some((s) => s.id === value);
+                    if (isCustomValue) {
+                      setSelectedScenario('custom');
+                      setCustomScenario(value);
+                    } else {
+                      setSelectedScenario(value);
+                      setCustomScenario('');
+                    }
+                  }
+                }}
+                placeholder="Select or search for a Scenario..."
+                disabled={isLoadingBattleData}
+                dropdownPlacement="down"
+                allowCustom={true}
+              />
+              {selectedScenario === 'custom' && (
+                <div className="mt-2">
+                  <input
+                    type="text"
+                    className="w-full px-3 py-2 rounded-md border border-border bg-muted"
+                    placeholder="Enter custom Scenario name"
+                    value={customScenario}
+                    onChange={(e) => setCustomScenario(e.target.value)}
+                  />
+                </div>
+              )}
+            </div>
           </div>
         )}
       </div>

--- a/components/battle-session/create-battle-modal.tsx
+++ b/components/battle-session/create-battle-modal.tsx
@@ -142,8 +142,6 @@ export default function CreateBattleModal({
     return a.scenario_number - b.scenario_number;
   });
 
-  const showScenarioRoll = hasScenarioD6Roll(editionSlug);
-
   const opponentCampaignGangs = (campaignGangs ?? []).filter(
     (g) =>
       g.id !== effectiveGangId &&
@@ -445,74 +443,74 @@ export default function CreateBattleModal({
 
         {/* Scenario picker (create mode only) */}
         {!isAddMode && (
-          <div className="space-y-4">
-            {showScenarioRoll && (
-              <DiceRoller<Scenario>
-                items={sortedScenarios}
-                // scenario_number is numeric in Postgres, so it arrives as a string.
-                getRange={(s) =>
-                  s.scenario_number != null
-                    ? { min: Number(s.scenario_number), max: Number(s.scenario_number) }
-                    : null
-                }
-                getName={(s) => s.scenario_name}
-                inline
-                rollFn={() => rollNd6Outcome(1)}
-                buttonText="Roll D6"
-                disabled={isLoadingBattleData || sortedScenarios.length === 0}
-                onRolled={(rolled) => {
-                  const result = rolled[0];
-                  if (!result) return;
-                  setSelectedScenario(result.item.id);
-                  setCustomScenario('');
-                }}
-              />
-            )}
-            <div className={showScenarioRoll ? 'border-t pt-3' : undefined}>
-              <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
-                Scenario
-              </label>
-              <Combobox
-                options={[
-                  { value: 'custom', label: 'Custom' },
-                  ...sortedScenarios.map((s) => ({
-                    value: s.id,
-                    label: s.scenario_number ? `${s.scenario_number}. ${s.scenario_name}` : s.scenario_name,
-                  })),
-                ]}
-                value={selectedScenario === 'custom' ? 'custom' : selectedScenario}
-                onValueChange={(value) => {
-                  if (value === 'custom') {
-                    setSelectedScenario('custom');
-                    setCustomScenario('');
-                  } else {
-                    const isCustomValue = !sortedScenarios.some((s) => s.id === value);
-                    if (isCustomValue) {
-                      setSelectedScenario('custom');
-                      setCustomScenario(value);
-                    } else {
-                      setSelectedScenario(value);
-                      setCustomScenario('');
-                    }
+          <div>
+            {hasScenarioD6Roll(editionSlug) && (
+              <div className="mb-2">
+                <DiceRoller<Scenario>
+                  items={sortedScenarios}
+                  // scenario_number is numeric in Postgres, so it arrives as a string.
+                  getRange={(s) =>
+                    s.scenario_number != null
+                      ? { min: Number(s.scenario_number), max: Number(s.scenario_number) }
+                      : null
                   }
-                }}
-                placeholder="Select or search for a Scenario..."
-                disabled={isLoadingBattleData}
-                dropdownPlacement="down"
-                allowCustom={true}
-              />
-              {selectedScenario === 'custom' && (
-                <div className="mt-2">
-                  <input
-                    type="text"
-                    className="w-full px-3 py-2 rounded-md border border-border bg-muted"
-                    placeholder="Enter custom Scenario name"
-                    value={customScenario}
-                    onChange={(e) => setCustomScenario(e.target.value)}
-                  />
-                </div>
-              )}
-            </div>
+                  getName={(s) => s.scenario_name}
+                  inline
+                  rollFn={() => rollNd6Outcome(1)}
+                  buttonText="Roll D6"
+                  disabled={isLoadingBattleData || sortedScenarios.length === 0}
+                  onRolled={(rolled) => {
+                    const result = rolled[0];
+                    if (!result) return;
+                    setSelectedScenario(result.item.id);
+                    setCustomScenario('');
+                  }}
+                />
+              </div>
+            )}
+            <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
+              Scenario
+            </label>
+            <Combobox
+              options={[
+                { value: 'custom', label: 'Custom' },
+                ...sortedScenarios.map((s) => ({
+                  value: s.id,
+                  label: s.scenario_number ? `${s.scenario_number}. ${s.scenario_name}` : s.scenario_name,
+                })),
+              ]}
+              value={selectedScenario === 'custom' ? 'custom' : selectedScenario}
+              onValueChange={(value) => {
+                if (value === 'custom') {
+                  setSelectedScenario('custom');
+                  setCustomScenario('');
+                } else {
+                  const isCustomValue = !sortedScenarios.some((s) => s.id === value);
+                  if (isCustomValue) {
+                    setSelectedScenario('custom');
+                    setCustomScenario(value);
+                  } else {
+                    setSelectedScenario(value);
+                    setCustomScenario('');
+                  }
+                }
+              }}
+              placeholder="Select or search for a Scenario..."
+              disabled={isLoadingBattleData}
+              dropdownPlacement="down"
+              allowCustom={true}
+            />
+            {selectedScenario === 'custom' && (
+              <div className="mt-2">
+                <input
+                  type="text"
+                  className="w-full px-3 py-2 rounded-md border border-border bg-muted"
+                  placeholder="Enter custom Scenario name"
+                  value={customScenario}
+                  onChange={(e) => setCustomScenario(e.target.value)}
+                />
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/components/battle-session/create-battle-modal.tsx
+++ b/components/battle-session/create-battle-modal.tsx
@@ -10,7 +10,9 @@ import { createBattleSession, addParticipant } from '@/app/actions/battle-sessio
 import Modal from '@/components/ui/modal';
 import { Combobox } from '@/components/ui/combobox';
 import { buildGangComboboxOption } from '@/utils/gang-combobox-option';
-import { editionsConflict } from '@/types/edition';
+import { editionsConflict, hasScenarioD6Roll, sameEditionForDisplay } from '@/types/edition';
+import DiceRoller from '@/components/dice-roller';
+import { rollNd6Outcome } from '@/utils/dice';
 import { Button } from '@/components/ui/button';
 import UserSearchBar, { type UserSearchResult } from '@/components/shared/user-search-bar';
 import type { Scenario } from '@/types/campaign';
@@ -129,7 +131,11 @@ export default function CreateBattleModal({
     staleTime: 0,
   });
 
-  const scenarios = battleData?.scenarios ?? [];
+  // Scenario rows are all edition-backfilled, so this filters on display rather
+  // than guarding an action the way the opponent picker below does.
+  const scenarios = (battleData?.scenarios ?? []).filter((s) =>
+    sameEditionForDisplay(s.edition_slug, editionSlug)
+  );
   const sortedScenarios = [...scenarios].sort((a, b) => {
     if (a.scenario_number === null) return 1;
     if (b.scenario_number === null) return -1;
@@ -441,6 +447,30 @@ export default function CreateBattleModal({
             <label className="mb-1 block text-sm font-medium text-neutral-700 dark:text-neutral-300">
               Scenario
             </label>
+            {hasScenarioD6Roll(editionSlug) && (
+              <div className="mb-2">
+                <DiceRoller<Scenario>
+                  items={sortedScenarios}
+                  // scenario_number is numeric in Postgres, so it arrives as a string.
+                  getRange={(s) =>
+                    s.scenario_number != null
+                      ? { min: Number(s.scenario_number), max: Number(s.scenario_number) }
+                      : null
+                  }
+                  getName={(s) => s.scenario_name}
+                  inline
+                  rollFn={() => rollNd6Outcome(1)}
+                  buttonText="Roll D6"
+                  disabled={isLoadingBattleData || sortedScenarios.length === 0}
+                  onRolled={(rolled) => {
+                    const result = rolled[0];
+                    if (!result) return;
+                    setSelectedScenario(result.item.id);
+                    setCustomScenario('');
+                  }}
+                />
+              </div>
+            )}
             <Combobox
               options={[
                 { value: 'custom', label: 'Custom' },

--- a/components/campaigns/[id]/campaign-battle-log-modal.tsx
+++ b/components/campaigns/[id]/campaign-battle-log-modal.tsx
@@ -15,6 +15,7 @@ import { useMutation } from '@tanstack/react-query';
 import { Battle, BattleParticipant, CampaignGang, Territory as BaseTerritory, Scenario } from '@/types/campaign';
 import { getClaimerGangId, getWinnerIds } from '@/utils/battle-winners';
 import { useWinnerSelection } from '@/hooks/use-winner-selection';
+import { sameEditionForDisplay } from '@/types/edition';
 
 interface BattleLogTerritory extends BaseTerritory {
   default_gang_territory?: boolean;
@@ -22,6 +23,7 @@ interface BattleLogTerritory extends BaseTerritory {
 
 interface CampaignBattleLogModalProps {
   campaignId: string;
+  editionSlug?: string | null;
   availableGangs: CampaignGang[];
   territories?: BattleLogTerritory[];
   isOpen: boolean;
@@ -45,6 +47,7 @@ type GangEntry = {
 
 const CampaignBattleLogModal = ({
   campaignId,
+  editionSlug,
   availableGangs,
   territories = [],
   isOpen,
@@ -326,8 +329,11 @@ const CampaignBattleLogModal = ({
 
           if (isMounted) {
             const data = await response.json();
+            const editionScenarios = (data.scenarios as Scenario[]).filter((s) =>
+              sameEditionForDisplay(s.edition_slug, editionSlug)
+            );
             // Sort scenarios by scenario_number
-            const sortedScenarios = [...data.scenarios].sort((a, b) => {
+            const sortedScenarios = [...editionScenarios].sort((a, b) => {
               if (a.scenario_number === null) return 1;
               if (b.scenario_number === null) return -1;
               return a.scenario_number - b.scenario_number;
@@ -352,7 +358,7 @@ const CampaignBattleLogModal = ({
     return () => {
       isMounted = false;
     };
-  }, [isOpen, campaignId]);
+  }, [isOpen, campaignId, editionSlug]);
 
   // Populate form when modal opens with edit data and scenarios are loaded
   const [populatedForBattle, setPopulatedForBattle] = useState<string | null>(null);

--- a/components/campaigns/[id]/campaign-battle-logs-list.tsx
+++ b/components/campaigns/[id]/campaign-battle-logs-list.tsx
@@ -31,6 +31,7 @@ type MemberRole = 'OWNER' | 'ARBITRATOR' | 'MEMBER';
 
 interface CampaignBattleLogsListProps {
   campaignId: string;
+  editionSlug?: string | null;
   battles: Battle[];
   isAdmin: boolean;
   onBattleAdd: () => void;
@@ -69,6 +70,7 @@ const formatDate = (dateString: string | null) => {
 const CampaignBattleLogsList = forwardRef<CampaignBattleLogsListRef, CampaignBattleLogsListProps>((props, ref) => {
   const {
     campaignId,
+    editionSlug,
     battles,
     isAdmin,
     onBattleAdd,
@@ -1286,6 +1288,7 @@ const CampaignBattleLogsList = forwardRef<CampaignBattleLogsListRef, CampaignBat
       {/* Battle Log Modal for Add/Edit */}
       <CampaignBattleLogModal
         campaignId={campaignId}
+        editionSlug={editionSlug}
         availableGangs={availableGangs}
         territories={territories.map(t => ({
           id: t.id,

--- a/components/campaigns/[id]/campaign-battle-sessions.tsx
+++ b/components/campaigns/[id]/campaign-battle-sessions.tsx
@@ -10,12 +10,14 @@ export default function CampaignBattleSessions({
   userId,
   canAdd,
   campaignGangs,
+  editionSlug,
 }: {
   sessions: BattleSession[];
   campaignId: string;
   userId?: string;
   canAdd?: boolean;
   campaignGangs?: CampaignGang[];
+  editionSlug?: string | null;
 }) {
   return (
     <BattleSessionsList
@@ -24,6 +26,7 @@ export default function CampaignBattleSessions({
       canAdd={canAdd}
       userId={userId}
       campaignGangs={campaignGangs}
+      editionSlug={editionSlug}
       variant="table"
       sessionUrl={(id) => `/campaigns/${campaignId}/battle-session/${id}`}
       wrapper={(children) => <div className="mb-6">{children}</div>}

--- a/components/campaigns/[id]/campaign-page-content.tsx
+++ b/components/campaigns/[id]/campaign-page-content.tsx
@@ -972,6 +972,7 @@ export default function CampaignPageContent({
                   campaignId={campaignData.id}
                   userId={userId}
                   canAdd={safePermissions.canAddBattleLogs}
+                  editionSlug={campaignData.edition_slug ?? null}
                   campaignGangs={campaignData.members.flatMap((m: Member) =>
                     m.gangs
                       .filter((g) => g.status === 'ACCEPTED')
@@ -1003,6 +1004,7 @@ export default function CampaignPageContent({
                   <CampaignBattleLogsList
                     ref={battleLogsRef}
                     campaignId={campaignData.id}
+                    editionSlug={campaignData.edition_slug ?? null}
                     battles={campaignData.battles || []}
                     isAdmin={!!safePermissions.canEditBattleLogs}
                     onBattleAdd={refreshData}

--- a/types/campaign.ts
+++ b/types/campaign.ts
@@ -105,6 +105,7 @@ export interface Scenario {
   id: string;
   scenario_name: string;
   scenario_number: number | null;
+  edition_slug?: string | null;
 }
 
 /**

--- a/types/edition.ts
+++ b/types/edition.ts
@@ -192,6 +192,8 @@ const EDITION_CAPABILITIES = {
    * standard promote-to-Leader type picker with catalog subtypes.
    */
   championLeaderTypePromotion: { n23: false, n26: true },
+  /** The battle's scenario is rolled for on a D6 against the edition's numbered scenarios. */
+  scenarioD6Roll: { n23: false, n26: true },
 } as const satisfies Record<string, Record<EditionSlug, unknown>>;
 
 type EditionCapability = keyof typeof EDITION_CAPABILITIES;
@@ -326,6 +328,9 @@ export const hasGangerChampionKeepTypePromotion = (
 export const hasChampionLeaderTypePromotion = (
   editionSlug?: string | null
 ): boolean => can('championLeaderTypePromotion', editionSlug);
+
+export const hasScenarioD6Roll = (editionSlug?: string | null): boolean =>
+  can('scenarioD6Roll', editionSlug);
 
 export interface Edition {
   id: string;


### PR DESCRIPTION
## Summary
This PR adds edition-specific scenario filtering and introduces a D6 dice roll feature for selecting scenarios in Necromunda 2026 (N26). Scenarios are now tracked with their associated edition, allowing campaigns to display only scenarios relevant to their edition.

## Key Changes

- **Edition-scoped scenarios**: Added `edition_slug` field to `Scenario` type and updated all scenario queries to include and filter by edition
  - Modified scenario API endpoints to scope duplicate checks per edition
  - Updated `getScenariosCached` to fetch and attach edition information via `withEditionSlug`
  - Added `sameEditionForDisplay` helper function to filter scenarios by edition

- **D6 scenario rolling for N26**: Implemented new `scenarioD6Roll` edition capability
  - Added `DiceRoller` component to battle creation modal for editions that support scenario rolling
  - Integrated `rollNd6Outcome` utility to roll a single D6 and match against numbered scenarios
  - Feature is only available in N26 (disabled for N23)

- **Scenario filtering across components**:
  - `CreateBattleModal`: Filters available scenarios by edition before display and rolling
  - `ActiveSession`: Uses `useMemo` to filter scenarios by edition when updating battle session
  - `CampaignBattleLogModal`: Filters scenarios by campaign edition when loading for battle editing
  - `CampaignBattleLogsList` and `CampaignBattleSessions`: Pass `editionSlug` prop through component hierarchy

- **API improvements**:
  - Scenario duplicate validation now scoped to edition (allows same scenario number in different editions)
  - Updated error messages to clarify edition-specific constraints
  - Changed `.single()` to `.maybeSingle()` for more robust query handling

## Implementation Details

- The `withEditionSlug` helper transforms scenario rows with nested edition data into a flat structure with `edition_slug` field
- Scenario filtering uses display-level logic rather than action guards, since all scenario rows are edition-backfilled
- D6 rolling is conditionally rendered based on `hasScenarioD6Roll` capability check
- Cache tag updated from `global-scenarios` to `global-scenarios-with-edition` to reflect new data structure