### PR TITLE
Show N23/N26 breakdowns on admin stats

### DIFF
--- a/app/api/admin/stats/route.ts
+++ b/app/api/admin/stats/route.ts
@@ -2,8 +2,7 @@ import { NextResponse } from 'next/server'
 import { createClient } from "@/utils/supabase/server";
 import { checkAdmin } from "@/utils/auth";
 import { getUserCount } from '@/app/lib/get-stats-user';
-import { getGangCount } from '@/app/lib/get-stats-gang';
-import { getCampaignCount } from '@/app/lib/get-stats-campaign';
+import { getCampaignCountsByEdition, getGangCountsByEdition } from '@/app/lib/get-stats-by-edition';
 import { getGangActivityStats } from '@/app/lib/get-stats-gang-activity';
 import { getCampaignActivityStats } from '@/app/lib/get-stats-campaign-activity';
 
@@ -21,8 +20,8 @@ export async function GET() {
     const [userCount, gangCount, campaignCount, gangActivity, campaignActivity] =
       await Promise.all([
         getUserCount(),
-        getGangCount(),
-        getCampaignCount(),
+        getGangCountsByEdition(),
+        getCampaignCountsByEdition(),
         getGangActivityStats(),
         getCampaignActivityStats(),
       ]);
@@ -42,4 +41,3 @@ export async function GET() {
     );
   }
 }
-

--- a/app/lib/get-stats-activity.ts
+++ b/app/lib/get-stats-activity.ts
@@ -1,0 +1,40 @@
+import { unstable_cache } from 'next/cache';
+
+import type { ActivityStats, EditionCounts } from '@/types/stats';
+
+const ACTIVITY_WINDOWS_DAYS = [14, 30, 90, 180] as const;
+
+/**
+ * Shared 24h-cached activity windows for admin stats.
+ * Each period is loaded via the provided by-edition fetcher.
+ */
+export function makeActivityStats(
+  fetcher: (since: string) => Promise<EditionCounts | null>,
+  cacheKey: string,
+  tag: string
+): () => Promise<ActivityStats | null> {
+  const getCached = unstable_cache(
+    async () => {
+      if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+        return null;
+      }
+
+      const cutoffFor = (days: number) =>
+        new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+      const [last2Weeks, last1Month, last3Months, last6Months] =
+        await Promise.all(
+          ACTIVITY_WINDOWS_DAYS.map((days) => fetcher(cutoffFor(days)))
+        );
+
+      return { last2Weeks, last1Month, last3Months, last6Months };
+    },
+    [cacheKey],
+    {
+      tags: [tag],
+      revalidate: 86400,
+    }
+  );
+
+  return getCached;
+}

--- a/app/lib/get-stats-by-edition.ts
+++ b/app/lib/get-stats-by-edition.ts
@@ -1,0 +1,216 @@
+import { TAGS } from '@/utils/cache-tags';
+import { unstable_cache } from 'next/cache';
+
+import { createServiceRoleClient } from '@/utils/supabase/server';
+import { EDITION_N26 } from '@/types/edition';
+import type { StatWithEdition } from '@/types/stats';
+
+type ServiceRoleClient = ReturnType<typeof createServiceRoleClient>;
+
+async function getN26EditionId(
+  supabase: ServiceRoleClient
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('editions')
+    .select('id')
+    .eq('slug', EDITION_N26)
+    .maybeSingle();
+
+  if (error) {
+    console.error('Error fetching n26 edition id:', error);
+    return null;
+  }
+
+  return data?.id ?? null;
+}
+
+function splitEditionCounts(
+  total: number | null,
+  n26: number | null
+): StatWithEdition {
+  if (total === null || n26 === null) {
+    return { total, n23: null, n26: null };
+  }
+
+  return {
+    total,
+    n23: Math.max(0, total - n26),
+    n26,
+  };
+}
+
+async function countN26Gangs(
+  supabase: ServiceRoleClient,
+  n26EditionId: string,
+  since?: string
+): Promise<number | null> {
+  let officialQuery = supabase
+    .from('gangs')
+    .select('id, gang_types!inner(edition_id)', { count: 'exact', head: true })
+    .eq('gang_types.edition_id', n26EditionId);
+
+  let customQuery = supabase
+    .from('gangs')
+    .select('id, custom_gang_types!inner(edition_id)', {
+      count: 'exact',
+      head: true,
+    })
+    .eq('custom_gang_types.edition_id', n26EditionId);
+
+  if (since) {
+    officialQuery = officialQuery.gte('last_updated', since);
+    customQuery = customQuery.gte('last_updated', since);
+  }
+
+  const [official, custom] = await Promise.all([officialQuery, customQuery]);
+
+  if (official.error) {
+    console.error('Error fetching n26 official gang count:', official.error);
+    return null;
+  }
+  if (custom.error) {
+    console.error('Error fetching n26 custom gang count:', custom.error);
+    return null;
+  }
+
+  return (official.count ?? 0) + (custom.count ?? 0);
+}
+
+async function countN26Campaigns(
+  supabase: ServiceRoleClient,
+  n26EditionId: string,
+  since?: string
+): Promise<number | null> {
+  let query = supabase
+    .from('campaigns')
+    .select('id, campaign_types!inner(edition_id)', {
+      count: 'exact',
+      head: true,
+    })
+    .eq('campaign_types.edition_id', n26EditionId);
+
+  if (since) {
+    query = query.gte('updated_at', since);
+  }
+
+  const { count, error } = await query;
+
+  if (error) {
+    console.error('Error fetching n26 campaign count:', error);
+    return null;
+  }
+
+  return count ?? 0;
+}
+
+async function fetchGangCountsByEdition(
+  since?: string
+): Promise<StatWithEdition | null> {
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    return null;
+  }
+
+  const supabase = createServiceRoleClient();
+  const n26EditionId = await getN26EditionId(supabase);
+  if (!n26EditionId) {
+    return null;
+  }
+
+  let totalQuery = supabase
+    .from('gangs')
+    .select('*', { count: 'exact', head: true });
+
+  if (since) {
+    totalQuery = totalQuery.gte('last_updated', since);
+  }
+
+  const [{ count, error }, n26] = await Promise.all([
+    totalQuery,
+    countN26Gangs(supabase, n26EditionId, since),
+  ]);
+
+  if (error) {
+    console.error('Error fetching gang count:', error);
+    return null;
+  }
+
+  return splitEditionCounts(count ?? 0, n26);
+}
+
+async function fetchCampaignCountsByEdition(
+  since?: string
+): Promise<StatWithEdition | null> {
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    return null;
+  }
+
+  const supabase = createServiceRoleClient();
+  const n26EditionId = await getN26EditionId(supabase);
+  if (!n26EditionId) {
+    return null;
+  }
+
+  let totalQuery = supabase
+    .from('campaigns')
+    .select('*', { count: 'exact', head: true });
+
+  if (since) {
+    totalQuery = totalQuery.gte('updated_at', since);
+  }
+
+  const [{ count, error }, n26] = await Promise.all([
+    totalQuery,
+    countN26Campaigns(supabase, n26EditionId, since),
+  ]);
+
+  if (error) {
+    console.error('Error fetching campaign count:', error);
+    return null;
+  }
+
+  return splitEditionCounts(count ?? 0, n26);
+}
+
+const getCachedGangCountsByEdition = unstable_cache(
+  async () => fetchGangCountsByEdition(),
+  ['global-gang-counts-by-edition'],
+  {
+    tags: [TAGS.globalGangCount()],
+    revalidate: 86400,
+  }
+);
+
+const getCachedCampaignCountsByEdition = unstable_cache(
+  async () => fetchCampaignCountsByEdition(),
+  ['global-campaign-counts-by-edition'],
+  {
+    tags: [TAGS.globalCampaignCount()],
+    revalidate: 86400,
+  }
+);
+
+/**
+ * Gang counts split by edition. Totals (no `since`) are cached for 24h.
+ * Activity windows pass `since` and are not cached here — callers should cache.
+ */
+export async function getGangCountsByEdition(
+  since?: string
+): Promise<StatWithEdition | null> {
+  if (since) {
+    return fetchGangCountsByEdition(since);
+  }
+  return getCachedGangCountsByEdition();
+}
+
+/**
+ * Campaign counts split by edition. Totals (no `since`) are cached for 24h.
+ * Activity windows pass `since` and are not cached here — callers should cache.
+ */
+export async function getCampaignCountsByEdition(
+  since?: string
+): Promise<StatWithEdition | null> {
+  if (since) {
+    return fetchCampaignCountsByEdition(since);
+  }
+  return getCachedCampaignCountsByEdition();
+}

--- a/app/lib/get-stats-by-edition.ts
+++ b/app/lib/get-stats-by-edition.ts
@@ -1,53 +1,46 @@
 import { TAGS } from '@/utils/cache-tags';
 import { unstable_cache } from 'next/cache';
 
+import { getEditionIdBySlug } from '@/app/lib/editions';
 import { createServiceRoleClient } from '@/utils/supabase/server';
-import { EDITION_N26 } from '@/types/edition';
-import type { StatWithEdition } from '@/types/stats';
+import { EDITION_N23, EDITION_N26, type EditionSlug } from '@/types/edition';
+import type { EditionCounts } from '@/types/stats';
 
 type ServiceRoleClient = ReturnType<typeof createServiceRoleClient>;
 
-async function getN26EditionId(
-  supabase: ServiceRoleClient
-): Promise<string | null> {
-  const { data, error } = await supabase
-    .from('editions')
-    .select('id')
-    .eq('slug', EDITION_N26)
-    .maybeSingle();
-
-  if (error) {
-    console.error('Error fetching n26 edition id:', error);
-    return null;
-  }
-
-  return data?.id ?? null;
-}
-
-function splitEditionCounts(
+function buildEditionCounts(
   total: number | null,
-  n26: number | null
-): StatWithEdition {
-  if (total === null || n26 === null) {
-    return { total, n23: null, n26: null };
+  byEdition: Partial<Record<EditionSlug, number>> | null
+): EditionCounts {
+  if (total === null || byEdition === null) {
+    return { total, byEdition: null };
   }
 
-  return {
-    total,
-    n23: Math.max(0, total - n26),
-    n26,
-  };
+  const counted = Object.values(byEdition).reduce(
+    (sum, value) => sum + (value ?? 0),
+    0
+  );
+
+  if (counted > total) {
+    console.error(
+      'Edition breakdown exceeds total count; suppressing split',
+      { total, byEdition }
+    );
+    return { total, byEdition: null };
+  }
+
+  return { total, byEdition };
 }
 
-async function countN26Gangs(
+async function countGangsForEdition(
   supabase: ServiceRoleClient,
-  n26EditionId: string,
+  editionId: string,
   since?: string
 ): Promise<number | null> {
   let officialQuery = supabase
     .from('gangs')
     .select('id, gang_types!inner(edition_id)', { count: 'exact', head: true })
-    .eq('gang_types.edition_id', n26EditionId);
+    .eq('gang_types.edition_id', editionId);
 
   let customQuery = supabase
     .from('gangs')
@@ -55,7 +48,7 @@ async function countN26Gangs(
       count: 'exact',
       head: true,
     })
-    .eq('custom_gang_types.edition_id', n26EditionId);
+    .eq('custom_gang_types.edition_id', editionId);
 
   if (since) {
     officialQuery = officialQuery.gte('last_updated', since);
@@ -65,20 +58,20 @@ async function countN26Gangs(
   const [official, custom] = await Promise.all([officialQuery, customQuery]);
 
   if (official.error) {
-    console.error('Error fetching n26 official gang count:', official.error);
+    console.error('Error fetching edition official gang count:', official.error);
     return null;
   }
   if (custom.error) {
-    console.error('Error fetching n26 custom gang count:', custom.error);
+    console.error('Error fetching edition custom gang count:', custom.error);
     return null;
   }
 
   return (official.count ?? 0) + (custom.count ?? 0);
 }
 
-async function countN26Campaigns(
+async function countCampaignsForEdition(
   supabase: ServiceRoleClient,
-  n26EditionId: string,
+  editionId: string,
   since?: string
 ): Promise<number | null> {
   let query = supabase
@@ -87,7 +80,7 @@ async function countN26Campaigns(
       count: 'exact',
       head: true,
     })
-    .eq('campaign_types.edition_id', n26EditionId);
+    .eq('campaign_types.edition_id', editionId);
 
   if (since) {
     query = query.gte('updated_at', since);
@@ -96,25 +89,53 @@ async function countN26Campaigns(
   const { count, error } = await query;
 
   if (error) {
-    console.error('Error fetching n26 campaign count:', error);
+    console.error('Error fetching edition campaign count:', error);
     return null;
   }
 
   return count ?? 0;
 }
 
+async function resolveEditionId(slug: EditionSlug): Promise<string | null> {
+  try {
+    return await getEditionIdBySlug(slug);
+  } catch (error) {
+    console.error(`Error resolving ${slug} edition id:`, error);
+    return null;
+  }
+}
+
+async function countByKnownEditions(
+  countForEdition: (editionId: string) => Promise<number | null>
+): Promise<Partial<Record<EditionSlug, number>> | null> {
+  const [n23EditionId, n26EditionId] = await Promise.all([
+    resolveEditionId(EDITION_N23),
+    resolveEditionId(EDITION_N26),
+  ]);
+
+  const [n23, n26] = await Promise.all([
+    n23EditionId ? countForEdition(n23EditionId) : Promise.resolve(null),
+    n26EditionId ? countForEdition(n26EditionId) : Promise.resolve(null),
+  ]);
+
+  if (n23 === null && n26 === null) {
+    return null;
+  }
+
+  const byEdition: Partial<Record<EditionSlug, number>> = {};
+  if (n23 !== null) byEdition[EDITION_N23] = n23;
+  if (n26 !== null) byEdition[EDITION_N26] = n26;
+  return byEdition;
+}
+
 async function fetchGangCountsByEdition(
   since?: string
-): Promise<StatWithEdition | null> {
+): Promise<EditionCounts | null> {
   if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
     return null;
   }
 
   const supabase = createServiceRoleClient();
-  const n26EditionId = await getN26EditionId(supabase);
-  if (!n26EditionId) {
-    return null;
-  }
 
   let totalQuery = supabase
     .from('gangs')
@@ -124,9 +145,11 @@ async function fetchGangCountsByEdition(
     totalQuery = totalQuery.gte('last_updated', since);
   }
 
-  const [{ count, error }, n26] = await Promise.all([
+  const [{ count, error }, byEdition] = await Promise.all([
     totalQuery,
-    countN26Gangs(supabase, n26EditionId, since),
+    countByKnownEditions((editionId) =>
+      countGangsForEdition(supabase, editionId, since)
+    ),
   ]);
 
   if (error) {
@@ -134,21 +157,17 @@ async function fetchGangCountsByEdition(
     return null;
   }
 
-  return splitEditionCounts(count ?? 0, n26);
+  return buildEditionCounts(count ?? 0, byEdition);
 }
 
 async function fetchCampaignCountsByEdition(
   since?: string
-): Promise<StatWithEdition | null> {
+): Promise<EditionCounts | null> {
   if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
     return null;
   }
 
   const supabase = createServiceRoleClient();
-  const n26EditionId = await getN26EditionId(supabase);
-  if (!n26EditionId) {
-    return null;
-  }
 
   let totalQuery = supabase
     .from('campaigns')
@@ -158,9 +177,11 @@ async function fetchCampaignCountsByEdition(
     totalQuery = totalQuery.gte('updated_at', since);
   }
 
-  const [{ count, error }, n26] = await Promise.all([
+  const [{ count, error }, byEdition] = await Promise.all([
     totalQuery,
-    countN26Campaigns(supabase, n26EditionId, since),
+    countByKnownEditions((editionId) =>
+      countCampaignsForEdition(supabase, editionId, since)
+    ),
   ]);
 
   if (error) {
@@ -168,7 +189,7 @@ async function fetchCampaignCountsByEdition(
     return null;
   }
 
-  return splitEditionCounts(count ?? 0, n26);
+  return buildEditionCounts(count ?? 0, byEdition);
 }
 
 const getCachedGangCountsByEdition = unstable_cache(
@@ -195,7 +216,7 @@ const getCachedCampaignCountsByEdition = unstable_cache(
  */
 export async function getGangCountsByEdition(
   since?: string
-): Promise<StatWithEdition | null> {
+): Promise<EditionCounts | null> {
   if (since) {
     return fetchGangCountsByEdition(since);
   }
@@ -208,7 +229,7 @@ export async function getGangCountsByEdition(
  */
 export async function getCampaignCountsByEdition(
   since?: string
-): Promise<StatWithEdition | null> {
+): Promise<EditionCounts | null> {
   if (since) {
     return fetchCampaignCountsByEdition(since);
   }

--- a/app/lib/get-stats-campaign-activity.ts
+++ b/app/lib/get-stats-campaign-activity.ts
@@ -1,19 +1,20 @@
 import { TAGS } from '@/utils/cache-tags';
 import { unstable_cache } from 'next/cache';
 
-import { createServiceRoleClient } from '@/utils/supabase/server';
-import { ActivityStats } from '@/types/stats';
+import { getCampaignCountsByEdition } from '@/app/lib/get-stats-by-edition';
+import { ActivityStatsWithEdition } from '@/types/stats';
 
-export type { ActivityStats as CampaignActivityStats };
+export type { ActivityStatsWithEdition as CampaignActivityStats };
 
 /**
- * Get cached campaign activity counts by updated_at for admin display.
+ * Get cached campaign activity counts by updated_at for admin display,
+ * split by edition (N23 / N26).
  *
  * Revalidation strategies:
  * - Automatic: Every 86400 seconds (24 hours)
  * - Manual: Call revalidateTag(TAGS.globalCampaignActivity(), { expire: 0 }) as needed
  *
- * @returns Counts per period, or null if service role key is not available
+ * @returns Counts per period with edition breakdown, or null if service role key is not available
  */
 const getCachedCampaignActivityStats = unstable_cache(
   async () => {
@@ -21,28 +22,14 @@ const getCachedCampaignActivityStats = unstable_cache(
       return null;
     }
 
-    const supabase = createServiceRoleClient();
-
-    const countSince = async (days: number): Promise<number | null> => {
-      const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
-      const { count, error } = await supabase
-        .from('campaigns')
-        .select('*', { count: 'exact', head: true })
-        .gte('updated_at', cutoff);
-
-      if (error) {
-        console.error('Error fetching campaign activity count:', error);
-        return null;
-      }
-
-      return count ?? 0;
-    };
+    const cutoffFor = (days: number) =>
+      new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
 
     const [last2Weeks, last1Month, last3Months, last6Months] = await Promise.all([
-      countSince(14),
-      countSince(30),
-      countSince(90),
-      countSince(180),
+      getCampaignCountsByEdition(cutoffFor(14)),
+      getCampaignCountsByEdition(cutoffFor(30)),
+      getCampaignCountsByEdition(cutoffFor(90)),
+      getCampaignCountsByEdition(cutoffFor(180)),
     ]);
 
     return { last2Weeks, last1Month, last3Months, last6Months };
@@ -54,6 +41,6 @@ const getCachedCampaignActivityStats = unstable_cache(
   }
 );
 
-export async function getCampaignActivityStats(): Promise<ActivityStats | null> {
+export async function getCampaignActivityStats(): Promise<ActivityStatsWithEdition | null> {
   return getCachedCampaignActivityStats();
 }

--- a/app/lib/get-stats-campaign-activity.ts
+++ b/app/lib/get-stats-campaign-activity.ts
@@ -1,46 +1,25 @@
 import { TAGS } from '@/utils/cache-tags';
-import { unstable_cache } from 'next/cache';
 
 import { getCampaignCountsByEdition } from '@/app/lib/get-stats-by-edition';
-import { ActivityStatsWithEdition } from '@/types/stats';
+import { makeActivityStats } from '@/app/lib/get-stats-activity';
+import type { ActivityStats } from '@/types/stats';
 
-export type { ActivityStatsWithEdition as CampaignActivityStats };
+export type { ActivityStats as CampaignActivityStats };
 
 /**
  * Get cached campaign activity counts by updated_at for admin display,
- * split by edition (N23 / N26).
+ * split by edition.
  *
  * Revalidation strategies:
  * - Automatic: Every 86400 seconds (24 hours)
  * - Manual: Call revalidateTag(TAGS.globalCampaignActivity(), { expire: 0 }) as needed
- *
- * @returns Counts per period with edition breakdown, or null if service role key is not available
  */
-const getCachedCampaignActivityStats = unstable_cache(
-  async () => {
-    if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
-      return null;
-    }
-
-    const cutoffFor = (days: number) =>
-      new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
-
-    const [last2Weeks, last1Month, last3Months, last6Months] = await Promise.all([
-      getCampaignCountsByEdition(cutoffFor(14)),
-      getCampaignCountsByEdition(cutoffFor(30)),
-      getCampaignCountsByEdition(cutoffFor(90)),
-      getCampaignCountsByEdition(cutoffFor(180)),
-    ]);
-
-    return { last2Weeks, last1Month, last3Months, last6Months };
-  },
-  ['global-campaign-activity'],
-  {
-    tags: [TAGS.globalCampaignActivity()],
-    revalidate: 86400,
-  }
+const getCachedCampaignActivityStats = makeActivityStats(
+  getCampaignCountsByEdition,
+  'global-campaign-activity',
+  TAGS.globalCampaignActivity()
 );
 
-export async function getCampaignActivityStats(): Promise<ActivityStatsWithEdition | null> {
+export async function getCampaignActivityStats(): Promise<ActivityStats | null> {
   return getCachedCampaignActivityStats();
 }

--- a/app/lib/get-stats-campaign.ts
+++ b/app/lib/get-stats-campaign.ts
@@ -1,43 +1,12 @@
-import { TAGS } from '@/utils/cache-tags';
-import { unstable_cache } from 'next/cache';
-
-import { createServiceRoleClient } from '@/utils/supabase/server';
+import { getCampaignCountsByEdition } from '@/app/lib/get-stats-by-edition';
 
 /**
  * Get cached campaign count for public display.
  *
- * Revalidation strategies:
- * - Automatic: Every 86400 seconds (24 hours)
- * - Manual: Call revalidateTag(TAGS.globalCampaignCount(), { expire: 0 }) after campaign creation/deletion
+ * Shares the by-edition totals cache (24h, invalidated via TAGS.globalCampaignCount()).
  *
- * @returns The total number of campaigns in the database, or null if service role key is not available
+ * @returns The total number of campaigns in the database, or null if unavailable
  */
-const getCachedCampaignCount = unstable_cache(
-  async () => {
-    if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
-      return null;
-    }
-
-    const supabase = createServiceRoleClient();
-
-    const { count, error } = await supabase
-      .from('campaigns')
-      .select('*', { count: 'exact', head: true });
-
-    if (error) {
-      console.error('Error fetching campaign count:', error);
-      return null;
-    }
-
-    return count || 0;
-  },
-  ['global-campaign-count'],
-  {
-    tags: [TAGS.globalCampaignCount()],
-    revalidate: 86400,
-  }
-);
-
 export async function getCampaignCount(): Promise<number | null> {
-  return getCachedCampaignCount();
+  return (await getCampaignCountsByEdition())?.total ?? null;
 }

--- a/app/lib/get-stats-gang-activity.ts
+++ b/app/lib/get-stats-gang-activity.ts
@@ -1,46 +1,25 @@
 import { TAGS } from '@/utils/cache-tags';
-import { unstable_cache } from 'next/cache';
 
 import { getGangCountsByEdition } from '@/app/lib/get-stats-by-edition';
-import { ActivityStatsWithEdition } from '@/types/stats';
+import { makeActivityStats } from '@/app/lib/get-stats-activity';
+import type { ActivityStats } from '@/types/stats';
 
-export type { ActivityStatsWithEdition as GangActivityStats };
+export type { ActivityStats as GangActivityStats };
 
 /**
  * Get cached gang activity counts by last_updated for admin display,
- * split by edition (N23 / N26).
+ * split by edition.
  *
  * Revalidation strategies:
  * - Automatic: Every 86400 seconds (24 hours)
  * - Manual: Call revalidateTag(TAGS.globalGangActivity(), { expire: 0 }) as needed
- *
- * @returns Counts per period with edition breakdown, or null if service role key is not available
  */
-const getCachedGangActivityStats = unstable_cache(
-  async () => {
-    if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
-      return null;
-    }
-
-    const cutoffFor = (days: number) =>
-      new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
-
-    const [last2Weeks, last1Month, last3Months, last6Months] = await Promise.all([
-      getGangCountsByEdition(cutoffFor(14)),
-      getGangCountsByEdition(cutoffFor(30)),
-      getGangCountsByEdition(cutoffFor(90)),
-      getGangCountsByEdition(cutoffFor(180)),
-    ]);
-
-    return { last2Weeks, last1Month, last3Months, last6Months };
-  },
-  ['global-gang-activity'],
-  {
-    tags: [TAGS.globalGangActivity()],
-    revalidate: 86400,
-  }
+const getCachedGangActivityStats = makeActivityStats(
+  getGangCountsByEdition,
+  'global-gang-activity',
+  TAGS.globalGangActivity()
 );
 
-export async function getGangActivityStats(): Promise<ActivityStatsWithEdition | null> {
+export async function getGangActivityStats(): Promise<ActivityStats | null> {
   return getCachedGangActivityStats();
 }

--- a/app/lib/get-stats-gang-activity.ts
+++ b/app/lib/get-stats-gang-activity.ts
@@ -1,19 +1,20 @@
 import { TAGS } from '@/utils/cache-tags';
 import { unstable_cache } from 'next/cache';
 
-import { createServiceRoleClient } from '@/utils/supabase/server';
-import { ActivityStats } from '@/types/stats';
+import { getGangCountsByEdition } from '@/app/lib/get-stats-by-edition';
+import { ActivityStatsWithEdition } from '@/types/stats';
 
-export type { ActivityStats as GangActivityStats };
+export type { ActivityStatsWithEdition as GangActivityStats };
 
 /**
- * Get cached gang activity counts by last_updated for admin display.
+ * Get cached gang activity counts by last_updated for admin display,
+ * split by edition (N23 / N26).
  *
  * Revalidation strategies:
  * - Automatic: Every 86400 seconds (24 hours)
  * - Manual: Call revalidateTag(TAGS.globalGangActivity(), { expire: 0 }) as needed
  *
- * @returns Counts per period, or null if service role key is not available
+ * @returns Counts per period with edition breakdown, or null if service role key is not available
  */
 const getCachedGangActivityStats = unstable_cache(
   async () => {
@@ -21,28 +22,14 @@ const getCachedGangActivityStats = unstable_cache(
       return null;
     }
 
-    const supabase = createServiceRoleClient();
-
-    const countSince = async (days: number): Promise<number | null> => {
-      const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
-      const { count, error } = await supabase
-        .from('gangs')
-        .select('*', { count: 'exact', head: true })
-        .gte('last_updated', cutoff);
-
-      if (error) {
-        console.error('Error fetching gang activity count:', error);
-        return null;
-      }
-
-      return count ?? 0;
-    };
+    const cutoffFor = (days: number) =>
+      new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
 
     const [last2Weeks, last1Month, last3Months, last6Months] = await Promise.all([
-      countSince(14),
-      countSince(30),
-      countSince(90),
-      countSince(180),
+      getGangCountsByEdition(cutoffFor(14)),
+      getGangCountsByEdition(cutoffFor(30)),
+      getGangCountsByEdition(cutoffFor(90)),
+      getGangCountsByEdition(cutoffFor(180)),
     ]);
 
     return { last2Weeks, last1Month, last3Months, last6Months };
@@ -54,6 +41,6 @@ const getCachedGangActivityStats = unstable_cache(
   }
 );
 
-export async function getGangActivityStats(): Promise<ActivityStats | null> {
+export async function getGangActivityStats(): Promise<ActivityStatsWithEdition | null> {
   return getCachedGangActivityStats();
 }

--- a/app/lib/get-stats-gang.ts
+++ b/app/lib/get-stats-gang.ts
@@ -1,43 +1,12 @@
-import { TAGS } from '@/utils/cache-tags';
-import { unstable_cache } from 'next/cache';
-
-import { createServiceRoleClient } from '@/utils/supabase/server';
+import { getGangCountsByEdition } from '@/app/lib/get-stats-by-edition';
 
 /**
  * Get cached gang count for public display.
  *
- * Revalidation strategies:
- * - Automatic: Every 86400 seconds (24 hours)
- * - Manual: Call revalidateTag(TAGS.globalGangCount(), { expire: 0 }) after gang creation/deletion
+ * Shares the by-edition totals cache (24h, invalidated via TAGS.globalGangCount()).
  *
- * @returns The total number of gangs in the database, or null if service role key is not available
+ * @returns The total number of gangs in the database, or null if unavailable
  */
-const getCachedGangCount = unstable_cache(
-  async () => {
-    if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
-      return null;
-    }
-
-    const supabase = createServiceRoleClient();
-
-    const { count, error } = await supabase
-      .from('gangs')
-      .select('*', { count: 'exact', head: true });
-
-    if (error) {
-      console.error('Error fetching gang count:', error);
-      return null;
-    }
-
-    return count || 0;
-  },
-  ['global-gang-count'],
-  {
-    tags: [TAGS.globalGangCount()],
-    revalidate: 86400,
-  }
-);
-
 export async function getGangCount(): Promise<number | null> {
-  return getCachedGangCount();
+  return (await getGangCountsByEdition())?.total ?? null;
 }

--- a/components/admin/admin-stats-modal.tsx
+++ b/components/admin/admin-stats-modal.tsx
@@ -2,14 +2,14 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { LuChartColumn } from "react-icons/lu";
-import type { ActivityStats } from '@/types/stats';
+import type { ActivityStatsWithEdition, EditionCounts, StatWithEdition } from '@/types/stats';
 
 interface Stats {
   userCount: number;
-  gangCount: number | null;
-  campaignCount: number | null;
-  gangActivity: ActivityStats | null;
-  campaignActivity: ActivityStats | null;
+  gangCount: StatWithEdition | null;
+  campaignCount: StatWithEdition | null;
+  gangActivity: ActivityStatsWithEdition | null;
+  campaignActivity: ActivityStatsWithEdition | null;
 }
 
 interface AdminStatsModalProps {
@@ -21,12 +21,21 @@ function formatStatValue(value: number | null | undefined): string {
   return value !== null && value !== undefined ? value.toLocaleString() : 'N/A';
 }
 
+function EditionBreakdown({ edition }: { edition: EditionCounts | null | undefined }) {
+  return (
+    <div className="mt-1 space-y-0.5 text-right text-xs text-muted-foreground">
+      <p>{formatStatValue(edition?.n23)} (N23)</p>
+      <p>{formatStatValue(edition?.n26)} (N26)</p>
+    </div>
+  );
+}
+
 function ActivitySection({
   title,
   activity,
 }: {
   title: string;
-  activity: ActivityStats | null;
+  activity: ActivityStatsWithEdition | null;
 }) {
   const periods = [
     { label: 'Last 2 weeks', value: activity?.last2Weeks },
@@ -42,7 +51,8 @@ function ActivitySection({
         {periods.map(({ label, value }) => (
           <div key={label} className="p-2 bg-muted/50 rounded-lg border">
             <p className="text-center text-xs text-muted-foreground mb-2">{label}</p>
-            <p className="text-center text-lg md:text-xl font-bold">{formatStatValue(value)}</p>
+            <p className="text-center text-lg md:text-xl font-bold">{formatStatValue(value?.total)}</p>
+            <EditionBreakdown edition={value} />
           </div>
         ))}
       </div>
@@ -99,14 +109,16 @@ export function AdminStatsModal({ onClose, onSubmit }: AdminStatsModalProps) {
                   <div className="p-2 bg-muted/50 rounded-lg border">
                     <p className="text-center text-sm text-muted-foreground mb-2">Gangs</p>
                     <p className="text-center text-lg md:text-xl font-bold">
-                      {formatStatValue(stats.gangCount)}
+                      {formatStatValue(stats.gangCount?.total)}
                     </p>
+                    <EditionBreakdown edition={stats.gangCount} />
                   </div>
                   <div className="p-2 bg-muted/50 rounded-lg border">
                     <p className="text-center text-sm text-muted-foreground mb-2">Campaigns</p>
                     <p className="text-center text-lg md:text-xl font-bold">
-                      {formatStatValue(stats.campaignCount)}
+                      {formatStatValue(stats.campaignCount?.total)}
                     </p>
+                    <EditionBreakdown edition={stats.campaignCount} />
                   </div>
                 </div>
               </div>

--- a/components/admin/admin-stats-modal.tsx
+++ b/components/admin/admin-stats-modal.tsx
@@ -2,14 +2,15 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { LuChartColumn } from "react-icons/lu";
-import type { ActivityStatsWithEdition, EditionCounts, StatWithEdition } from '@/types/stats';
+import { EDITION_N23, EDITION_N26 } from '@/types/edition';
+import type { ActivityStats, EditionCounts } from '@/types/stats';
 
 interface Stats {
   userCount: number;
-  gangCount: StatWithEdition | null;
-  campaignCount: StatWithEdition | null;
-  gangActivity: ActivityStatsWithEdition | null;
-  campaignActivity: ActivityStatsWithEdition | null;
+  gangCount: EditionCounts | null;
+  campaignCount: EditionCounts | null;
+  gangActivity: ActivityStats | null;
+  campaignActivity: ActivityStats | null;
 }
 
 interface AdminStatsModalProps {
@@ -21,11 +22,19 @@ function formatStatValue(value: number | null | undefined): string {
   return value !== null && value !== undefined ? value.toLocaleString() : 'N/A';
 }
 
-function EditionBreakdown({ edition }: { edition: EditionCounts | null | undefined }) {
+function EditionBreakdown({ counts }: { counts: EditionCounts | null | undefined }) {
+  const byEdition = counts?.byEdition;
+  if (
+    byEdition == null ||
+    (byEdition[EDITION_N23] == null && byEdition[EDITION_N26] == null)
+  ) {
+    return null;
+  }
+
   return (
     <div className="mt-1 space-y-0.5 text-right text-xs text-muted-foreground">
-      <p>{formatStatValue(edition?.n23)} (N23)</p>
-      <p>{formatStatValue(edition?.n26)} (N26)</p>
+      <p>{formatStatValue(byEdition[EDITION_N23])} (N23)</p>
+      <p>{formatStatValue(byEdition[EDITION_N26])} (N26)</p>
     </div>
   );
 }
@@ -35,7 +44,7 @@ function ActivitySection({
   activity,
 }: {
   title: string;
-  activity: ActivityStatsWithEdition | null;
+  activity: ActivityStats | null;
 }) {
   const periods = [
     { label: 'Last 2 weeks', value: activity?.last2Weeks },
@@ -52,7 +61,7 @@ function ActivitySection({
           <div key={label} className="p-2 bg-muted/50 rounded-lg border">
             <p className="text-center text-xs text-muted-foreground mb-2">{label}</p>
             <p className="text-center text-lg md:text-xl font-bold">{formatStatValue(value?.total)}</p>
-            <EditionBreakdown edition={value} />
+            <EditionBreakdown counts={value} />
           </div>
         ))}
       </div>
@@ -111,14 +120,14 @@ export function AdminStatsModal({ onClose, onSubmit }: AdminStatsModalProps) {
                     <p className="text-center text-lg md:text-xl font-bold">
                       {formatStatValue(stats.gangCount?.total)}
                     </p>
-                    <EditionBreakdown edition={stats.gangCount} />
+                    <EditionBreakdown counts={stats.gangCount} />
                   </div>
                   <div className="p-2 bg-muted/50 rounded-lg border">
                     <p className="text-center text-sm text-muted-foreground mb-2">Campaigns</p>
                     <p className="text-center text-lg md:text-xl font-bold">
                       {formatStatValue(stats.campaignCount?.total)}
                     </p>
-                    <EditionBreakdown edition={stats.campaignCount} />
+                    <EditionBreakdown counts={stats.campaignCount} />
                   </div>
                 </div>
               </div>

--- a/types/stats.ts
+++ b/types/stats.ts
@@ -4,3 +4,19 @@ export interface ActivityStats {
   last3Months: number | null;
   last6Months: number | null;
 }
+
+export interface EditionCounts {
+  n23: number | null;
+  n26: number | null;
+}
+
+export interface StatWithEdition extends EditionCounts {
+  total: number | null;
+}
+
+export interface ActivityStatsWithEdition {
+  last2Weeks: StatWithEdition | null;
+  last1Month: StatWithEdition | null;
+  last3Months: StatWithEdition | null;
+  last6Months: StatWithEdition | null;
+}

--- a/types/stats.ts
+++ b/types/stats.ts
@@ -1,22 +1,13 @@
-export interface ActivityStats {
-  last2Weeks: number | null;
-  last1Month: number | null;
-  last3Months: number | null;
-  last6Months: number | null;
-}
+import type { EditionSlug } from '@/types/edition';
 
 export interface EditionCounts {
-  n23: number | null;
-  n26: number | null;
-}
-
-export interface StatWithEdition extends EditionCounts {
   total: number | null;
+  byEdition: Partial<Record<EditionSlug, number>> | null;
 }
 
-export interface ActivityStatsWithEdition {
-  last2Weeks: StatWithEdition | null;
-  last1Month: StatWithEdition | null;
-  last3Months: StatWithEdition | null;
-  last6Months: StatWithEdition | null;
+export interface ActivityStats {
+  last2Weeks: EditionCounts | null;
+  last1Month: EditionCounts | null;
+  last3Months: EditionCounts | null;
+  last6Months: EditionCounts | null;
 }


### PR DESCRIPTION
Wire by-edition gang and campaign counts into the admin stats API and modal so totals and activity windows show edition splits under each count.