### PR TITLE
Convert BackgroundImage to Server Component and simplify rendering

### DIFF
--- a/components/background-image.tsx
+++ b/components/background-image.tsx
@@ -1,29 +1,16 @@
-'use client';
-
 import Image from 'next/image';
-import { useState } from 'react';
 
 export default function BackgroundImage() {
-  const [imageError, setImageError] = useState(false);
-
-  if (imageError) {
-    return (
-      <div className="fixed inset-0 z-[-1] bg-gray-900">
-        {/* Fallback dark background */}
-      </div>
-    );
-  }
-
   return (
-    <div className="fixed inset-0 z-[-1] print:hidden">
+    <div className="fixed inset-0 z-[-1] bg-gray-900 print:hidden">
       <Image
         src="https://iojoritxhpijprgkjfre.supabase.co/storage/v1/object/public/site-images/background_numv5r.avif"
-        alt="Background"
+        alt=""
         fill
         priority
-        style={{ objectFit: 'cover' }}
-        quality={100}
-        onError={() => setImageError(true)}
+        sizes="100vw"
+        className="object-cover"
+        quality={85}
       />
     </div>
   );


### PR DESCRIPTION
### Motivation

- Remove unnecessary client-side JavaScript used only for a decorative background so the markup is included in server-rendered output. 
- Let the wrapper's dark background act as the natural fallback instead of a runtime error handler. 

### Description

- Removed `'use client'`, `useState`, and the `onError` handler so `BackgroundImage` is a Server Component. 
- Added `bg-gray-900` to the wrapper so the dark fallback is present server-side and preserved `fixed inset-0 z-[-1] print:hidden` positioning. 
- Kept `next/image` with the existing Supabase Storage `src`, converted `alt` to `""`, preserved `fill` and `priority`, added `sizes="100vw"`, swapped to `className="object-cover"`, and lowered `quality` from `100` to `85`.

### Testing

- `git diff --check` was run and found no issues. 
- `npm run lint` (ESLint) was executed and passed. 
- `npm run build` (Next.js build) was executed but failed due to an external Google Fonts fetch failing in this environment; the failure is environmental and unrelated to the component changes.