### PR TITLE
fix(admin): make Equipment Options rows responsive on mobile

### DIFF
--- a/components/admin/admin-edit-equipment.tsx
+++ b/components/admin/admin-edit-equipment.tsx
@@ -945,7 +945,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                       )}
 
                       {grantsEquipment.options.map((option, index) => (
-                        <div key={index} className="flex items-center gap-2 p-2 bg-card rounded-sm border">
+                        <div key={index} className="flex flex-col sm:flex-row sm:items-center gap-2 p-2 bg-card rounded-sm border">
                           <select
                             value={option.equipment_id}
                             onChange={(e) => {
@@ -953,7 +953,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                               newOptions[index] = { ...newOptions[index], equipment_id: e.target.value };
                               setGrantsEquipment({ ...grantsEquipment, options: newOptions });
                             }}
-                            className="flex-1 p-2 border rounded-md"
+                            className="flex-1 min-w-0 p-2 border rounded-md"
                             disabled={!selectedEquipmentId}
                           >
                             <option value="">Select equipment...</option>
@@ -966,35 +966,37 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                                 </option>
                               ))}
                           </select>
-                          <div className="flex items-center gap-1">
-                            <span className="text-sm text-muted-foreground">Cost:</span>
-                            <Input
-                              type="number"
-                              value={option.additional_cost}
-                              onChange={(e) => {
-                                const newOptions = [...grantsEquipment.options];
-                                newOptions[index] = {
-                                  ...newOptions[index],
-                                  additional_cost: parseInt(e.target.value) || 0
-                                };
+                          <div className="flex items-center gap-2">
+                            <div className="flex items-center gap-1">
+                              <span className="text-sm text-muted-foreground">Cost:</span>
+                              <Input
+                                type="number"
+                                value={option.additional_cost}
+                                onChange={(e) => {
+                                  const newOptions = [...grantsEquipment.options];
+                                  newOptions[index] = {
+                                    ...newOptions[index],
+                                    additional_cost: parseInt(e.target.value) || 0
+                                  };
+                                  setGrantsEquipment({ ...grantsEquipment, options: newOptions });
+                                }}
+                                className="w-24"
+                                placeholder="E.g. 130"
+                                disabled={!selectedEquipmentId}
+                              />
+                            </div>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                const newOptions = grantsEquipment.options.filter((_, i) => i !== index);
                                 setGrantsEquipment({ ...grantsEquipment, options: newOptions });
                               }}
-                              className="w-24"
-                              placeholder="E.g. 130"
+                              className="hover:text-red-500 focus:outline-hidden p-1"
                               disabled={!selectedEquipmentId}
-                            />
+                            >
+                              <HiX className="h-4 w-4" />
+                            </button>
                           </div>
-                          <button
-                            type="button"
-                            onClick={() => {
-                              const newOptions = grantsEquipment.options.filter((_, i) => i !== index);
-                              setGrantsEquipment({ ...grantsEquipment, options: newOptions });
-                            }}
-                            className="hover:text-red-500 focus:outline-hidden p-1"
-                            disabled={!selectedEquipmentId}
-                          >
-                            <HiX className="h-4 w-4" />
-                          </button>
                         </div>
                       ))}
                     </div>


### PR DESCRIPTION
## Summary

Each row in the Grants Equipment // Equipment Options*section of the admin Edit Equipment modal is currently a fixed-direction flex row containing a select and a Cost input, also a remove button. 

On mobile viewports the selects exceeded the container width.

## Fix

- Row wrapper: `flex items-center` changes to `flex flex-col sm:flex-row sm:items-center` this means they stack on mobile
- Select: added `min-w-0` so it can shrink below
- Cost input + × button are grouped into a single sub-flex so they stay together on mobile and desktop

## Test plan

- [x] Mobile viewport: each option row now stacks — select on top, `Cost:` below. No overflow, no side-scroll.
- [x] Desktop (≥ 640 px): row layout is unchanged from before
- [x] `npx tsc --noEmit` passes.

## Screenshots
<img width="203" height="438" alt="Screenshot From 2026-08-24 23-52-00" src="https://github.com/user-attachments/assets/2bf1eebf-dc35-48db-90b2-384b84e0de6d" />
<img width="671" height="570" alt="Screenshot From 2026-08-25 00-02-02" src="https://github.com/user-attachments/assets/f6806315-ec9a-4036-aa1e-6f1854d39564" />
