### PR TITLE
Show an advancement icon beside XP on N26 gang fighter cards

### DIFF
--- a/app/lib/fighter-advancements.ts
+++ b/app/lib/fighter-advancements.ts
@@ -1,22 +1,56 @@
 import { getGangFightersBundle } from '@/app/lib/shared/gang-data';
+import { countAdvancementsTaken } from '@/utils/advancementRanks';
 
 /**
  * Get gang fighters (id/name/status columns) — selector over the shared
  * gang fighters bundle, so it reads the same cache entry as the gang page
  * instead of maintaining a duplicate copy of the gang's fighter list.
+ *
+ * Also carries starting_xp and advancements_taken so the fighter-page
+ * Combobox can derive open Advancements without a second fetch.
  */
 export const getGangFighters = async (gangId: string, supabase: any) => {
   const bundle = await getGangFightersBundle(gangId, supabase);
+
+  const advancementEffectsByFighter = new Map<string, unknown[]>();
+  for (const effect of bundle.effects) {
+    if (!effect.fighter_id) continue;
+    const category =
+      effect.fighter_effect_type?.fighter_effect_category?.category_name;
+    if (category !== 'advancements') continue;
+
+    const list = advancementEffectsByFighter.get(effect.fighter_id);
+    if (list) {
+      list.push(effect);
+    } else {
+      advancementEffectsByFighter.set(effect.fighter_id, [effect]);
+    }
+  }
+
+  const skillsByFighter = new Map<string, Record<string, { is_advance?: boolean }>>();
+  for (const skill of bundle.skills) {
+    if (!skill.fighter_id) continue;
+    const key = skill.id ?? `${skill.fighter_id}-${skill.created_at}`;
+    const existing = skillsByFighter.get(skill.fighter_id) ?? {};
+    existing[key] = { is_advance: skill.is_advance || false };
+    skillsByFighter.set(skill.fighter_id, existing);
+  }
+
   return bundle.fighters.map((f: any) => ({
     id: f.id,
     fighter_name: f.fighter_name,
     fighter_type: f.fighter_type,
     xp: f.xp,
+    starting_xp: f.starting_xp ?? null,
+    advancements_taken: countAdvancementsTaken(
+      { advancements: advancementEffectsByFighter.get(f.id) ?? [] },
+      skillsByFighter.get(f.id) ?? {},
+    ),
     killed: f.killed,
     retired: f.retired,
     enslaved: f.enslaved,
     starved: f.starved,
     recovery: f.recovery,
-    captured: f.captured
+    captured: f.captured,
   }));
 };

--- a/components/fighter/fighter-advancement-list.tsx
+++ b/components/fighter/fighter-advancement-list.tsx
@@ -9,7 +9,7 @@ import { TypeSpecificData } from '@/types/fighter-effect';
 import { createClient } from '@/utils/supabase/client';
 import { getSkillSetRank } from "@/utils/skillSetRank";
 import { characteristicRank } from "@/utils/characteristicRank";
-import { openAdvancementsFor } from "@/utils/advancementRanks";
+import { countAdvancementsTaken, openAdvancementsFor } from "@/utils/advancementRanks";
 import { List } from "@/components/ui/list";
 import { UserPermissions } from '@/types/user-permissions';
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -3374,9 +3374,9 @@ export function AdvancementsList({
       });
   }, [advancements, advancementSkills]);
 
-  const advancementCount = advancements.length + advancementSkills.length;
+  // Taken count: characteristic effects plus is_advance skills (shared with gang cards).
+  const advancementCount = countAdvancementsTaken({ advancements }, skills);
 
-  // advancementCount is the taken count: effects plus is_advance skills.
   const openAdvancements = openAdvancementsFor(
     editionSlug,
     fighterStartingXp,

--- a/components/fighter/fighter-page.tsx
+++ b/components/fighter/fighter-page.tsx
@@ -691,6 +691,7 @@ export default function FighterPage({
               onValueChange={(value) => router.push(`/fighter/${value}`)}
               placeholder="Select a fighter..."
               className="w-full"
+              showLabelWhenClosed
             />
           </div>
 

--- a/components/fighter/fighter-page.tsx
+++ b/components/fighter/fighter-page.tsx
@@ -32,7 +32,7 @@ import { GiHandcuffs } from "react-icons/gi";
 import { applyWeaponModifiers } from '@/utils/effect-modifiers';
 import { sortFightersByPositioning } from '@/utils/fighter-positioning';
 import { hasCumulativeXp } from '@/types/edition';
-import { openAdvancementsFor } from '@/utils/advancementRanks';
+import { nextTierStartFor, openAdvancementsFor } from '@/utils/advancementRanks';
 
 interface FighterPageProps {
   initialFighterData: any;
@@ -634,19 +634,24 @@ export default function FighterPage({
       if (f.captured) statusIcons.push(<GiHandcuffs className="text-red-600 w-4 h-4" key="captured" />);
 
       const baseText = `${f.fighter_name} - ${f.fighter_type}`;
+      const currentXp = f.xp ?? 0;
       const openAdvancements = isCumulativeXp
         ? openAdvancementsFor(
             editionSlug,
             f.starting_xp ?? null,
-            f.xp ?? 0,
+            currentXp,
             f.advancements_taken ?? 0,
           )
         : 0;
       const showAdvancementIcon = isCumulativeXp && openAdvancements > 0;
-      const xpSuffix =
-        !isCumulativeXp && f.xp !== undefined && f.xp !== null
-          ? ` (${f.xp} XP)`
-          : '';
+      const xpSuffix = (() => {
+        if (f.xp === undefined || f.xp === null) return '';
+        if (isCumulativeXp) {
+          const nextTierStart = nextTierStartFor(editionSlug, currentXp);
+          return ` (${currentXp}/${nextTierStart ?? '–'} XP)`;
+        }
+        return ` (${currentXp} XP)`;
+      })();
       const displayText = `${baseText}${xpSuffix}`;
 
       return {
@@ -656,11 +661,13 @@ export default function FighterPage({
           <span className="flex items-center gap-1 min-w-0">
             <span className="truncate">
               {baseText}
-              {xpSuffix}
+              {xpSuffix && (
+                <span className="text-neutral-500">{xpSuffix}</span>
+              )}
             </span>
             {showAdvancementIcon && (
               <TbArrowBigUpFilled
-                className="h-4 w-4 shrink-0"
+                className="h-4 w-4 shrink-0 text-neutral-500"
                 aria-label="Advancement available"
               />
             )}

--- a/components/fighter/fighter-page.tsx
+++ b/components/fighter/fighter-page.tsx
@@ -26,11 +26,13 @@ import { Combobox } from "@/components/ui/combobox";
 import { IoSkull } from "react-icons/io5";
 import { MdChair } from "react-icons/md";
 import { GiCrossedChains } from "react-icons/gi";
-import { TbMeatOff } from "react-icons/tb";
+import { TbMeatOff, TbArrowBigUpFilled } from "react-icons/tb";
 import { FaMedkit } from "react-icons/fa";
 import { GiHandcuffs } from "react-icons/gi";
 import { applyWeaponModifiers } from '@/utils/effect-modifiers';
 import { sortFightersByPositioning } from '@/utils/fighter-positioning';
+import { hasCumulativeXp } from '@/types/edition';
+import { openAdvancementsFor } from '@/utils/advancementRanks';
 
 interface FighterPageProps {
   initialFighterData: any;
@@ -39,6 +41,8 @@ interface FighterPageProps {
     fighter_name: string;
     fighter_type: string;
     xp: number | null;
+    starting_xp?: number | null;
+    advancements_taken?: number;
     killed?: boolean;
     retired?: boolean;
     enslaved?: boolean;
@@ -162,6 +166,8 @@ interface FighterPageState {
     fighter_name: string;
     fighter_type: string;
     xp: number | null;
+    starting_xp?: number | null;
+    advancements_taken?: number;
     killed?: boolean;
     retired?: boolean;
     enslaved?: boolean;
@@ -613,6 +619,7 @@ export default function FighterPage({
       : null;
 
   // Prepare options for Combobox
+  const isCumulativeXp = hasCumulativeXp(editionSlug);
   const fighterOptions = sortFightersByPositioning(
     fighterData.gangFighters,
     fighterData.gang?.positioning
@@ -626,15 +633,38 @@ export default function FighterPage({
       if (f.recovery) statusIcons.push(<FaMedkit className="text-blue-500 w-4 h-4" key="recovery" />);
       if (f.captured) statusIcons.push(<GiHandcuffs className="text-red-600 w-4 h-4" key="captured" />);
 
-      const displayText = `${f.fighter_name} - ${f.fighter_type}${f.xp !== undefined ? ` (${f.xp} XP)` : ''}`;
+      const baseText = `${f.fighter_name} - ${f.fighter_type}`;
+      const openAdvancements = isCumulativeXp
+        ? openAdvancementsFor(
+            editionSlug,
+            f.starting_xp ?? null,
+            f.xp ?? 0,
+            f.advancements_taken ?? 0,
+          )
+        : 0;
+      const showAdvancementIcon = isCumulativeXp && openAdvancements > 0;
+      const xpSuffix =
+        !isCumulativeXp && f.xp !== undefined && f.xp !== null
+          ? ` (${f.xp} XP)`
+          : '';
+      const displayText = `${baseText}${xpSuffix}`;
 
       return {
         value: f.id,
         displayValue: displayText,
         label: (
-          <span className="flex items-center gap-1">
-            <span>{displayText}</span>
-            {statusIcons.length > 0 && <span className="flex items-center gap-0.5">{statusIcons}</span>}
+          <span className="flex items-center gap-1 min-w-0">
+            <span className="truncate">
+              {baseText}
+              {xpSuffix}
+            </span>
+            {showAdvancementIcon && (
+              <TbArrowBigUpFilled
+                className="h-4 w-4 shrink-0"
+                aria-label="Advancement available"
+              />
+            )}
+            {statusIcons.length > 0 && <span className="flex items-center gap-0.5 shrink-0">{statusIcons}</span>}
           </span>
         )
       };

--- a/components/gang/fighter-card.tsx
+++ b/components/gang/fighter-card.tsx
@@ -460,11 +460,14 @@ const FighterCard = memo(function FighterCard({
 
   // Advancements earned but not yet taken. Zero in editions that do not rank by
   // XP, so the icon is N26-only without an explicit edition check here.
-  const openAdvancements = openAdvancementsFor(
-    edition_slug,
-    starting_xp,
-    xp,
-    countAdvancementsTaken(effects, skills)
+  const openAdvancements = useMemo(
+    () => openAdvancementsFor(
+      edition_slug,
+      starting_xp,
+      xp,
+      countAdvancementsTaken(effects, skills)
+    ),
+    [edition_slug, starting_xp, xp, effects, skills]
   );
 
   // Determine a unique and valid id for the fighter card based on its status.

--- a/components/gang/fighter-card.tsx
+++ b/components/gang/fighter-card.tsx
@@ -6,6 +6,7 @@ import { Equipment } from '@/types/equipment';
 import { FighterProps, FighterEffect, Vehicle, VehicleEquipment, FighterSkills } from '@/types/fighter';
 import { hasSaveCharacteristic } from '@/types/edition';
 import { calculateAdjustedStats, applySpecialRulesModifiers } from '@/utils/effect-modifiers';
+import { countAdvancementsTaken, openAdvancementsFor } from '@/utils/advancementRanks';
 import { injuryAggregationLabel } from '@/utils/injuryTarget';
 import { TbMeatOff } from "react-icons/tb";
 import { GiHandcuffs, GiImprisoned } from "react-icons/gi";
@@ -457,6 +458,15 @@ const FighterCard = memo(function FighterCard({
 
   const isInactive = killed || retired || enslaved || recovery;
 
+  // Advancements earned but not yet taken. Zero in editions that do not rank by
+  // XP, so the icon is N26-only without an explicit edition check here.
+  const openAdvancements = openAdvancementsFor(
+    edition_slug,
+    starting_xp,
+    xp,
+    countAdvancementsTaken(effects, skills)
+  );
+
   // Determine a unique and valid id for the fighter card based on its status.
   // The combined state 'is_inactive_and_recovery' takes precedence over the individual states.
   const fighterCardId =
@@ -677,7 +687,13 @@ const FighterCard = memo(function FighterCard({
           )}
           
           <div>
-            <StatsTable data={stats} isCrew={isCrew} viewMode={viewMode} editionSlug={edition_slug} />
+            <StatsTable
+              data={stats}
+              isCrew={isCrew}
+              viewMode={viewMode}
+              editionSlug={edition_slug}
+              hasAvailableAdvancements={openAdvancements > 0}
+            />
           </div>
 
           {/* Show fighter weapons */}

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -358,7 +358,7 @@ export function Combobox({
             )}
           >
             <span className="min-w-0 flex-1 truncate text-sm text-foreground">
-              {selectedOption.displayValue || selectedOption.label}
+              {selectedOption.label}
             </span>
           </div>
         )}

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -49,6 +49,13 @@ interface ComboboxProps {
   dropdownPlacement?: 'auto' | 'down' | 'up'
   /** Text shown when the filtered options list is empty. Defaults to "No results found". */
   noResultsText?: string
+  /**
+   * When the selected option's label is a ReactNode, render that label in the
+   * closed input instead of displayValue. Default keeps displayValue so option
+   * decorations (e.g. "Already assigned") stay out of the closed summary.
+   * Opt in only for surfaces that need closed-state decorations (fighter switcher).
+   */
+  showLabelWhenClosed?: boolean
 }
 
 function getVisualViewportRect() {
@@ -81,7 +88,8 @@ export function Combobox({
   clearable = false,
   onFocus,
   dropdownPlacement = 'auto',
-  noResultsText = 'No results found'
+  noResultsText = 'No results found',
+  showLabelWhenClosed = false,
 }: ComboboxProps) {
   type DropdownDirection = 'up' | 'down'
   type DropdownPosition = {
@@ -358,7 +366,9 @@ export function Combobox({
             )}
           >
             <span className="min-w-0 flex-1 truncate text-sm text-foreground">
-              {selectedOption.label}
+              {showLabelWhenClosed
+                ? selectedOption.label
+                : (selectedOption.displayValue || selectedOption.label)}
             </span>
           </div>
         )}

--- a/components/ui/fighter-card-stats-table.tsx
+++ b/components/ui/fighter-card-stats-table.tsx
@@ -1,4 +1,8 @@
+'use client';
+
 import React from 'react';
+import { Tooltip } from 'react-tooltip';
+import { TbArrowBigUpFilled } from 'react-icons/tb';
 import { GangViewMode, isFullSizeGangViewMode } from '@/components/gang/ViewModeDropdown';
 import { initiativeAndMentalCharacteristicSuffix } from '@/types/edition';
 
@@ -69,6 +73,8 @@ interface StatsTableProps {
   isCrew?: boolean;
   viewMode?: GangViewMode;
   editionSlug?: string | null;
+  /** N26: show a level-up icon beside XP when the fighter has unspent rank advancements. */
+  hasAvailableAdvancements?: boolean;
 }
 
 // Add a type for valid stat keys
@@ -92,7 +98,9 @@ const formatStatValue = (
   return `${value.slice(0, -1)}${initiativeAndMentalCharacteristicSuffix(editionSlug)}`;
 };
 
-export function StatsTable({ data, isCrew, viewMode, editionSlug }: StatsTableProps) {
+export function StatsTable({ data, isCrew, viewMode, editionSlug, hasAvailableAdvancements }: StatsTableProps) {
+  const advancementTooltipId = `advancement-available-${React.useId()}`;
+
   if (!data || Object.keys(data).length === 0) {
     return <p>No characteristics available</p>;
   }
@@ -228,12 +236,38 @@ export function StatsTable({ data, isCrew, viewMode, editionSlug }: StatsTablePr
                   ${getColumnBorderClass(key)}`}
                 style={{ width: columnWidth }}
               >
-                {formatStatValue(key, value, editionSlug)}
+                {key === 'XP' ? (
+                  <span className="inline-flex items-center justify-center gap-0.5 whitespace-nowrap">
+                    {formatStatValue(key, value, editionSlug)}
+                    {hasAvailableAdvancements && (
+                      <TbArrowBigUpFilled
+                        className={`${isFullSizeView ? 'h-4 w-4' : 'h-2.5 w-2.5'} cursor-help`}
+                        aria-label="Advancement available"
+                        data-tooltip-id={advancementTooltipId}
+                        data-tooltip-content="Advancement available"
+                      />
+                    )}
+                  </span>
+                ) : (
+                  formatStatValue(key, value, editionSlug)
+                )}
               </td>
             ))}
           </tr>
         </tbody>
       </table>
+      {hasAvailableAdvancements && (
+        <Tooltip
+          id={advancementTooltipId}
+          place="top"
+          className="bg-neutral-900! text-white! text-xs! z-[2000]! print:hidden!"
+          delayHide={100}
+          style={{
+            padding: '6px',
+            maxWidth: '20rem',
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/components/ui/fighter-card-stats-table.tsx
+++ b/components/ui/fighter-card-stats-table.tsx
@@ -241,7 +241,7 @@ export function StatsTable({ data, isCrew, viewMode, editionSlug, hasAvailableAd
                     {formatStatValue(key, value, editionSlug)}
                     {hasAvailableAdvancements && (
                       <TbArrowBigUpFilled
-                        className={`${isFullSizeView ? 'h-4 w-4' : 'h-2.5 w-2.5'} cursor-help`}
+                        className={`${isFullSizeView ? 'h-3 w-3' : 'h-2.5 w-2.5'} cursor-help`}
                         aria-label="Advancement available"
                         data-tooltip-id={advancementTooltipId}
                         data-tooltip-content="Advancement available"

--- a/utils/advancementRanks.ts
+++ b/utils/advancementRanks.ts
@@ -149,6 +149,23 @@ export function nextTierStartFor(
 }
 
 /**
+ * How many Advancements a model has already taken.
+ *
+ * A characteristic lands as a fighter_effect in the 'advancements' category, a
+ * skill as a fighter_skill flagged is_advance. Starting and free skills are not
+ * Advancements and carry is_advance false.
+ */
+export function countAdvancementsTaken(
+  effects: { advancements?: unknown[] } | null | undefined,
+  skills: Record<string, { is_advance?: boolean }> | null | undefined,
+): number {
+  const characteristics = effects?.advancements?.length ?? 0;
+  const skillAdvances = Object.values(skills ?? {}).filter((skill) => skill?.is_advance).length;
+
+  return characteristics + skillAdvances;
+}
+
+/**
  * Advancements earned but not yet taken. Derived on read so it cannot drift.
  *
  * Floored at zero: taking one is not gated on having earned one, so a fighter


### PR DESCRIPTION
Surfaces open rank Advancements next to the XP value with TbArrowBigUpFilled and a react-tooltip, using the same openAdvancementsFor derivation as the fighter Advancements list.