### PR TITLE
Post Discord battle reports on completion, not insertion

### DIFF
--- a/supabase/edge-functions/discord-campaign-bot/index.ts
+++ b/supabase/edge-functions/discord-campaign-bot/index.ts
@@ -22,6 +22,19 @@ Deno.serve(async (req) => {
     const payload = await req.json();
     const battle = payload.record;
 
+    // Post only on a transition into played. Rows predating the status column have none.
+    const statusOf = (row: any) => row?.status ?? "played";
+    const becamePlayed =
+      payload.type === "INSERT"
+        ? statusOf(battle) === "played"
+        : payload.type === "UPDATE"
+          ? statusOf(battle) === "played" && statusOf(payload.old_record) !== "played"
+          : false;
+
+    if (!becamePlayed) {
+      return new Response("Not a newly completed battle", { status: 200 });
+    }
+
     const { data: campaign } = await supabase
       .from("campaigns")
       .select("campaign_name, discord_channel_id, discord_channel_type")

--- a/supabase/webhooks/discord_campaign_bot.sql
+++ b/supabase/webhooks/discord_campaign_bot.sql
@@ -1,0 +1,58 @@
+-- Database Webhook: campaign_battles -> discord-campaign-bot.
+--
+-- Posts the battle report when a battle becomes played. Two triggers because
+-- Postgres rejects OLD in the WHEN clause of a combined INSERT OR UPDATE trigger.
+--
+-- Applied manually, not by CI. Takes the secret from the trigger already
+-- installed, so it can be pasted into the Supabase SQL editor without putting a
+-- credential in the query history. Do not use Database > Webhooks: that UI names
+-- the hook itself and forces a Supabase-managed JWT, which this function rejects.
+--
+-- Everything is inside the DO block, so the whole swap is one atomic statement.
+
+DO $$
+DECLARE
+  url    text := 'https://iojoritxhpijprgkjfre.supabase.co/functions/v1/discord-campaign-bot';
+  secret text;
+  hdrs   text;
+BEGIN
+  SELECT (regexp_match(pg_get_triggerdef(oid), '"Authorization"\s*:\s*"([^"]+)"'))[1]
+    INTO secret
+  FROM pg_trigger
+  WHERE tgrelid = 'public.campaign_battles'::regclass
+    AND NOT tgisinternal
+    AND tgname IN ('campaign_battles', 'campaign_battles_completed')
+    AND pg_get_triggerdef(oid) LIKE '%discord-campaign-bot%'
+  LIMIT 1;
+
+  IF secret IS NULL OR secret = '' THEN
+    RAISE EXCEPTION
+      'No existing discord-campaign-bot trigger on campaign_battles to read the secret from. '
+      'Recreate it with the secret supplied explicitly.';
+  END IF;
+
+  hdrs := jsonb_build_object(
+    'Content-type', 'application/json',
+    'Authorization', secret
+  )::text;
+
+  DROP TRIGGER IF EXISTS campaign_battles ON public.campaign_battles;
+  DROP TRIGGER IF EXISTS campaign_battles_completed ON public.campaign_battles;
+
+  -- format() because trigger arguments must be literal constants, so the secret
+  -- cannot be interpolated into CREATE TRIGGER directly.
+  EXECUTE format(
+    $f$CREATE TRIGGER campaign_battles
+         AFTER INSERT ON public.campaign_battles
+         FOR EACH ROW WHEN (NEW.status = 'played')
+         EXECUTE FUNCTION supabase_functions.http_request(
+           %L, 'POST', %L, '{}', '5000')$f$, url, hdrs);
+
+  EXECUTE format(
+    $f$CREATE TRIGGER campaign_battles_completed
+         AFTER UPDATE ON public.campaign_battles
+         FOR EACH ROW WHEN (NEW.status = 'played'
+                            AND OLD.status IS DISTINCT FROM 'played')
+         EXECUTE FUNCTION supabase_functions.http_request(
+           %L, 'POST', %L, '{}', '5000')$f$, url, hdrs);
+END $$;


### PR DESCRIPTION
A battle log will soon be able to start life as a challenge, so "row inserted" stops meaning "battle played". Both halves of the webhook key off a transition into the played status instead.

The condition is in the trigger WHEN clauses, so the database never calls the function for an issued challenge or an edit of an already-reported battle. The edge function carries the same rule, which is what keeps this mergeable on its own: if the trigger script has not been run yet, the old INSERT-only trigger stays in place and the function still declines to report a challenge.

Safe to merge in any order relative to the manual trigger step. Nothing here creates a non-played row, so behaviour is unchanged: inserts of played battles post exactly once, edits post nothing.