### PR TITLE
fix(admin): use shared Modal component for equipment adjusted cost dialog (create)

### DIFF
--- a/components/admin/admin-create-fighter-type.tsx
+++ b/components/admin/admin-create-fighter-type.tsx
@@ -316,6 +316,24 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
     setSpecialRules(prev => prev.filter(rule => rule !== ruleToRemove));
   };
 
+  const handleAddAdjustedCost = () => {
+    if (!selectedAdjustedCostEquipment || !adjustedCostAmount) {
+      toast.error('Please select equipment and enter an adjusted cost');
+      return false;
+    }
+
+    const cost = parseInt(adjustedCostAmount);
+    if (isNaN(cost) || cost < 0) {
+      toast.error('Please enter a valid cost (must be 0 or greater)');
+      return false;
+    }
+
+    setEquipmentDiscounts(prev => [
+      ...prev,
+      { equipment_id: selectedAdjustedCostEquipment, adjusted_cost: cost },
+    ]);
+  };
+
   const handleSubmit = async () => {
     // Check if selected fighter subtype is Crew
     const isCrew = selectedFighterSubtypes.includes('Crew');
@@ -1155,15 +1173,7 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
                     setSelectedAdjustedCostEquipment("");
                     setAdjustedCostAmount("");
                   }}
-                  onConfirm={() => {
-                    setEquipmentDiscounts(prev => [
-                      ...prev,
-                      {
-                        equipment_id: selectedAdjustedCostEquipment,
-                        adjusted_cost: parseInt(adjustedCostAmount),
-                      },
-                    ]);
-                  }}
+                  onConfirm={handleAddAdjustedCost}
                   confirmText="Save Adjusted Cost"
                   confirmDisabled={!selectedAdjustedCostEquipment || !adjustedCostAmount || parseInt(adjustedCostAmount) < 0}
                 >

--- a/components/admin/admin-create-fighter-type.tsx
+++ b/components/admin/admin-create-fighter-type.tsx
@@ -13,6 +13,7 @@ import { hasAlignment, hasSaveCharacteristic, allowsMultipleSubtypes, hasStartin
 import { toggleFighterSubtype } from '@/utils/fighter-subtype-picker';
 import { getSkillSetRank } from "@/utils/skillSetRank";
 import { compareEquipmentCategories } from "@/utils/getEquipmentCategoryRank";
+import Modal from '@/components/ui/modal';
 
 interface AdminCreateFighterTypeModalProps {
   onClose: () => void;
@@ -1145,95 +1146,65 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
               )}
 
               {showAdjustedCostDialog && (
-                <div 
-                  className="fixed inset-0 bg-black/50 dark:bg-neutral-700/50 flex items-center justify-center z-50"
-                  onClick={(e) => {
-                    if (e.target === e.currentTarget) {
-                      setShowAdjustedCostDialog(false);
-                      setSelectedAdjustedCostEquipment("");
-                      setAdjustedCostAmount("");
-                    }
+                <Modal
+                  title="Equipment Adjusted Cost Menu"
+                  helper="Select equipment and enter an adjusted cost"
+                  width="sm"
+                  onClose={() => {
+                    setShowAdjustedCostDialog(false);
+                    setSelectedAdjustedCostEquipment("");
+                    setAdjustedCostAmount("");
                   }}
+                  onConfirm={() => {
+                    setEquipmentDiscounts(prev => [
+                      ...prev,
+                      {
+                        equipment_id: selectedAdjustedCostEquipment,
+                        adjusted_cost: parseInt(adjustedCostAmount),
+                      },
+                    ]);
+                  }}
+                  confirmText="Save Adjusted Cost"
+                  confirmDisabled={!selectedAdjustedCostEquipment || !adjustedCostAmount || parseInt(adjustedCostAmount) < 0}
                 >
-                  <div className="bg-card p-6 rounded-lg shadow-lg w-[400px]">
-                    <h3 className="text-xl font-bold mb-4">Equipment Adjusted Cost Menu</h3>
-                    <p className="text-sm text-muted-foreground mb-4">Select equipment and enter an adjusted cost</p>
-                    
-                    <div className="space-y-4">
-                      <div>
-                        <label className="block text-sm font-medium mb-1">Equipment</label>
-                        <select
-                          value={selectedAdjustedCostEquipment}
-                          onChange={(e) => setSelectedAdjustedCostEquipment(e.target.value)}
-                          className="w-full p-2 border rounded-md"
-                        >
-                          <option value="">Select equipment</option>
-                          {filteredEquipment
-                            .filter(item => !equipmentDiscounts.some(
-                              adjusted_cost => adjusted_cost.equipment_id === item.id
-                            ))
-                            .map((item) => (
-                              <option key={item.id} value={item.id}>
-                                {item.equipment_name}
-                              </option>
-                            ))}
-                        </select>
-                      </div>
+                  <div className="space-y-4">
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Equipment</label>
+                      <select
+                        value={selectedAdjustedCostEquipment}
+                        onChange={(e) => setSelectedAdjustedCostEquipment(e.target.value)}
+                        className="w-full p-2 border rounded-md"
+                      >
+                        <option value="">Select equipment</option>
+                        {filteredEquipment
+                          .filter(item => !equipmentDiscounts.some(
+                            adjusted_cost => adjusted_cost.equipment_id === item.id
+                          ))
+                          .map((item) => (
+                            <option key={item.id} value={item.id}>
+                              {item.equipment_name}
+                            </option>
+                          ))}
+                      </select>
+                    </div>
 
-                      <div>
-                        <label className="block text-sm font-medium mb-1">Adjusted Cost (credits)</label>
-                        <Input
-                          type="number"
-                          value={adjustedCostAmount}
-                          onChange={(e) => setAdjustedCostAmount(e.target.value)}
-                          placeholder="Enter adjusted cost in credits"
-                          min="0"
-                          onKeyDown={(e) => {
-                            if (e.key === '-') {
-                              e.preventDefault();
-                            }
-                          }}
-                        />
-                      </div>
-
-                      <div className="flex gap-2 justify-end mt-6">
-                        <Button
-                          variant="outline"
-                          onClick={() => {
-                            setShowAdjustedCostDialog(false);
-                            setSelectedAdjustedCostEquipment("");
-                            setAdjustedCostAmount("");
-                          }}
-                        >
-                          Cancel
-                        </Button>
-                        <Button
-                          onClick={() => {
-                            if (selectedAdjustedCostEquipment && adjustedCostAmount) {
-                              const adjusted_cost = parseInt(adjustedCostAmount);
-                              if (adjusted_cost >= 0) {
-                                setEquipmentDiscounts(prev => [
-                                  ...prev,
-                                  {
-                                    equipment_id: selectedAdjustedCostEquipment,
-                                    adjusted_cost
-                                  }
-                                ]);
-                                setShowAdjustedCostDialog(false);
-                                setSelectedAdjustedCostEquipment("");
-                                setAdjustedCostAmount("");
-                              }
-                            }
-                          }}
-                          disabled={!selectedAdjustedCostEquipment || !adjustedCostAmount || parseInt(adjustedCostAmount) < 0}
-                          className="bg-neutral-900 text-white rounded-sm hover:bg-gray-800"
-                        >
-                          Save Adjusted Cost
-                        </Button>
-                      </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1">Adjusted Cost (credits)</label>
+                      <Input
+                        type="number"
+                        value={adjustedCostAmount}
+                        onChange={(e) => setAdjustedCostAmount(e.target.value)}
+                        placeholder="Enter adjusted cost in credits"
+                        min="0"
+                        onKeyDown={(e) => {
+                          if (e.key === '-') {
+                            e.preventDefault();
+                          }
+                        }}
+                      />
                     </div>
                   </div>
-                </div>
+                </Modal>
               )}
             </div>
 


### PR DESCRIPTION
## Summary

Follow-up to #2053. The **Add Equipment Adjusted Cost** dialog in the admin *Create Fighter Type* form had the same old modal that #2053 fixed for the edit form. This PR applies the same refactor here.

## Changes

- `components/admin/admin-create-fighter-type.tsx`: replaced the old dialog with `<Modal>`
- Form fields and validation are preserved.
- State reset for the three form fields (`showAdjustedCostDialog`, `selectedAdjustedCostEquipment`, `adjustedCostAmount`) is centralised in a single `onClose` handler

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Manually verified in local dev:
  - Modal opens with the same fields as before
  - Cancel / × / backdrop click all close the modal AND reset the form
  - Save adds the chip, closes the modal, and resets the form
  - Reopening shows an empty form
  - Save button correctly disabled until both fields are filled
