### PR TITLE
Fix Fancy card print missing the top-bar stroke on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,18 @@ For questions about contributing, feel free to ask in our [Discord server](https
    ```
 
 4. **Mobile device testing**
-   On your desktop, make sure you have the NODE_ENV variable setup with the value 'development'. Then run the following:
-   ```bash
-   npm run dev --host
+
+   `npm run dev` already listens on the LAN. The startup log prints a **Network** URL (for example `http://192.168.1.115:3000`). Open that URL on a phone on the same Wi-Fi.
+
+   Next.js still blocks HMR and other `/_next` assets from that origin until you allow it in `next.config.js`:
+
+   ```js
+   allowedDevOrigins: ['192.168.1.115'],
    ```
-   
-   On your mobile device, when connected to your wifi, access the website using the IP of your desktop on your local network (e.g. 192.168.1.5):
-   http://192.168.1.5:3000
+
+   Use the same IP as the Network URL, then restart the dev server. If you skip this, the page may load but you will see `Blocked cross-origin request to Next.js dev resource` in the terminal.
+
+   Do not commit this `next.config.js` change when you push. `allowedDevOrigins` is your local IP and should stay off the repo.
 
 5. **Access to the DB Schema**
    The Supabase DB schema can be accessed through https://supabase-schema.vercel.app/

--- a/app/globals.css
+++ b/app/globals.css
@@ -215,6 +215,13 @@ Enforcing `cursor: pointer` has the default value. */
     background-image: none !important;
   }
 
+  /* CSS backgrounds on this bar are stripped above; iOS Safari also often skips
+     printing nested background-images. The stroke is an <img> (.fancy-print-top-bar-art)
+     and is shown only for Fancy print (body.fancy-print). */
+  .fancy-print-top-bar-art {
+    display: none !important;
+  }
+
   .print-fighters {
     zoom: 0.55;
   }
@@ -232,8 +239,10 @@ Enforcing `cursor: pointer` has the default value. */
     background-color: #faf9f7 !important;
   }
 
-  body.fancy-print .fancy-print-top-bar {
-    background-image: url('https://iojoritxhpijprgkjfre.supabase.co/storage/v1/object/public/site-images/top-bar-stroke-v3_s97f2k.png') !important;
+  body.fancy-print .fancy-print-top-bar-art {
+    display: block !important;
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
   }
 
   body.fancy-print .fancy-print-keep-color-heading {

--- a/app/globals.css
+++ b/app/globals.css
@@ -241,8 +241,6 @@ Enforcing `cursor: pointer` has the default value. */
 
   body.fancy-print .fancy-print-top-bar-art {
     display: block !important;
-    -webkit-print-color-adjust: exact !important;
-    print-color-adjust: exact !important;
   }
 
   body.fancy-print .fancy-print-keep-color-heading {

--- a/components/gang/fancy-print-top-bar-art.tsx
+++ b/components/gang/fancy-print-top-bar-art.tsx
@@ -1,0 +1,15 @@
+const FANCY_TOP_BAR_STROKE_SRC =
+  "https://iojoritxhpijprgkjfre.supabase.co/storage/v1/object/public/site-images/top-bar-stroke-v3_s97f2k.png";
+
+export function FancyPrintTopBarArt() {
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={FANCY_TOP_BAR_STROKE_SRC}
+      alt=""
+      aria-hidden
+      className="fancy-print-top-bar-art pointer-events-none absolute inset-0 size-full"
+      style={{ objectFit: "fill" }}
+    />
+  );
+}

--- a/components/gang/fighter-card.tsx
+++ b/components/gang/fighter-card.tsx
@@ -15,6 +15,7 @@ import { MdChair } from "react-icons/md";
 import { FaMedkit } from "react-icons/fa";
 import { Weapon } from '@/types/equipment';
 import { FighterCardActionMenu } from './fighter-card-action-menu';
+import { FancyPrintTopBarArt } from './fancy-print-top-bar-art';
 import { useViewportWidth } from '@/hooks/use-viewport-width';
 import { GangViewMode, isCompactGangViewMode } from './ViewModeDropdown';
 import { CgMoreVerticalO } from "react-icons/cg";
@@ -604,14 +605,7 @@ const FighterCard = memo(function FighterCard({
               height: '65px',
               zIndex: 0,
             }}>
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src="https://iojoritxhpijprgkjfre.supabase.co/storage/v1/object/public/site-images/top-bar-stroke-v3_s97f2k.png"
-              alt=""
-              aria-hidden
-              className="fancy-print-top-bar-art pointer-events-none absolute inset-0 size-full"
-              style={{ objectFit: 'fill' }}
-            />
+            <FancyPrintTopBarArt />
             <div className={`absolute z-10 left-0 ${image_url ? 'right-[156px] md:right-[206px]' : 'right-[84px] md:right-[112px]'} pl-4 sm:pl-8 flex items-center gap-2 overflow-hidden whitespace-nowrap`} style={{ height: '62px', marginTop: '0px' }}>
               {label && (
                 <div className="inline-flex items-center rounded-sm bg-card px-1 text-sm font-bold font-mono text-foreground uppercase print:border-2 print:border-black">

--- a/components/gang/fighter-card.tsx
+++ b/components/gang/fighter-card.tsx
@@ -598,15 +598,20 @@ const FighterCard = memo(function FighterCard({
       <div className={`flex ${isNormalView ? 'mb-[80px]' : 'mb-[90px]'}`}>
         <div className="flex w-full">
           <div
-            className={`absolute inset-0 bg-no-repeat bg-cover fancy-print-top-bar ${isNormalView ? 'mt-4' : 'mt-2'}`}
+            className={`absolute inset-0 fancy-print-top-bar ${isNormalView ? 'mt-4' : 'mt-2'}`}
             style={{
-              backgroundImage: "url('https://iojoritxhpijprgkjfre.supabase.co/storage/v1/object/public/site-images/top-bar-stroke-v3_s97f2k.png')",
               width: '100%',
               height: '65px',
               zIndex: 0,
-              backgroundPosition: 'center',
-              backgroundSize: '100% 100%'
             }}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src="https://iojoritxhpijprgkjfre.supabase.co/storage/v1/object/public/site-images/top-bar-stroke-v3_s97f2k.png"
+              alt=""
+              aria-hidden
+              className="fancy-print-top-bar-art pointer-events-none absolute inset-0 size-full"
+              style={{ objectFit: 'fill' }}
+            />
             <div className={`absolute z-10 left-0 ${image_url ? 'right-[156px] md:right-[206px]' : 'right-[84px] md:right-[112px]'} pl-4 sm:pl-8 flex items-center gap-2 overflow-hidden whitespace-nowrap`} style={{ height: '62px', marginTop: '0px' }}>
               {label && (
                 <div className="inline-flex items-center rounded-sm bg-card px-1 text-sm font-bold font-mono text-foreground uppercase print:border-2 print:border-black">

--- a/components/gang/print-gang.tsx
+++ b/components/gang/print-gang.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { FighterProps, Vehicle, FighterEffect } from "@/types/fighter";
 import { Equipment } from "@/types/equipment";
@@ -22,6 +22,22 @@ import { PatreonSupporterIcon } from "@/components/ui/patreon-supporter-icon";
 import { decodeHtmlEntities, isHtmlEffectivelyEmpty } from "@/utils/htmlCleanUp";
 
 const ROSTER_FIGHTER_NOTE_MAX_CHARS = 110;
+
+const FANCY_TOP_BAR_STROKE_SRC =
+  "https://iojoritxhpijprgkjfre.supabase.co/storage/v1/object/public/site-images/top-bar-stroke-v3_s97f2k.png";
+
+function FancyPrintTopBarArt() {
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={FANCY_TOP_BAR_STROKE_SRC}
+      alt=""
+      aria-hidden
+      className="fancy-print-top-bar-art pointer-events-none absolute inset-0 size-full"
+      style={{ objectFit: "fill" }}
+    />
+  );
+}
 
 function getRosterFighterNotePreview(note: string | undefined): string | null {
   if (!note || isHtmlEffectivelyEmpty(note)) return null;
@@ -193,18 +209,19 @@ export default function PrintGang({ gang }: PrintGangProps) {
   const [cardsGangCardsPosition, setCardsGangCardsPosition] = useState<"before" | "after">("before");
   const [scaleCardsToContent, setScaleCardsToContent] = useState(true);
 
-  // Handle print with style
-  const handlePrint = () => {
-    if (printStyle === 'fancy') {
-      document.body.classList.add('fancy-print');
-    } else {
-      document.body.classList.remove('fancy-print');
-    }
+  // Keep fancy-print on the body while Fancy is selected. iOS Safari's window.print()
+  // is non-blocking, so adding/removing the class around the print call drops it
+  // before the snapshot. Safari share-sheet print also never hits handlePrint.
+  useEffect(() => {
+    const enable = viewMode === "cards" && printStyle === "fancy";
+    document.body.classList.toggle("fancy-print", enable);
+    return () => {
+      document.body.classList.remove("fancy-print");
+    };
+  }, [viewMode, printStyle]);
 
-    setTimeout(() => {
-      window.print();
-      document.body.classList.remove('fancy-print');
-    }, 100);
+  const handlePrint = () => {
+    window.print();
   };
 
   // Use pre-filtered list when "Inactive Fighters Loadouts" is off (server-side filter is reliable)
@@ -1010,7 +1027,7 @@ export default function PrintGang({ gang }: PrintGangProps) {
               ["--ring" as any]: "var(--light-ring)",
             }} // Enforce light theme colors for Cards View
           >
-            <div className={`print-gang-cards justify-center print:justify-start flex flex-wrap content-start gap-[6px] ${scaleCardsToContent ? 'items-stretch [&_.fighter-card-bg]:h-auto! [&_.fighter-card-bg]:flex! [&_.fighter-card-bg]:flex-col!' : 'items-start [&_.fighter-card-bg]:h-[435px]!'} [&_.fighter-card-bg]:w-[630px]! [&_.fighter-card-bg]:shadow-none! [&_.fighter-card-bg]:border-[3px]! [&_.fighter-card-bg]:break-inside-avoid [&_.fighter-card-bg]:rounded-lg [&_.fighter-card-bg]:text-base! [&_.fighter-card-bg]:bg-[#faf9f7]! [&_.fighter-card-bg]:text-black! [&_.fighter-card-bg:hover]:scale-100! [&_.fighter-card-bg:hover]:shadow-none! [&_.fighter-card-bg]:transition-none! [&_.fighter-card-bg_.grid]:gap-y-0! [&_.fighter-card-bg_.grid]:mt-1! [&_.fighter-card-bg_.inline-flex.rounded-sm]:border-2! [&_.fighter-card-bg_.inline-flex.rounded-sm]:border-black! [&_.fighter-card-bg_.bg-secondary]:shadow-none! [&_.fighter-card-bg]:bg-[url('https://iojoritxhpijprgkjfre.supabase.co/storage/v1/object/public/site-images/fighter-card-background-5-light_web_ynpbac.webp')]! ${printStyle === 'eco' ? '[&_.fighter-card-bg]:bg-none! [&_.fighter-card-bg]:bg-transparent! [&_.fancy-print-top-bar]:bg-none! [&_.fancy-print-keep-color-heading]:text-inherit! [&_.fancy-print-keep-color-subtitle]:text-inherit!' : '[&_.fancy-print-keep-color-heading]:text-white! [&_.fancy-print-keep-color-subtitle]:text-gray-300!'}`}>
+            <div className={`print-gang-cards justify-center print:justify-start flex flex-wrap content-start gap-[6px] ${scaleCardsToContent ? 'items-stretch [&_.fighter-card-bg]:h-auto! [&_.fighter-card-bg]:flex! [&_.fighter-card-bg]:flex-col!' : 'items-start [&_.fighter-card-bg]:h-[435px]!'} [&_.fighter-card-bg]:w-[630px]! [&_.fighter-card-bg]:shadow-none! [&_.fighter-card-bg]:border-[3px]! [&_.fighter-card-bg]:break-inside-avoid [&_.fighter-card-bg]:rounded-lg [&_.fighter-card-bg]:text-base! [&_.fighter-card-bg]:bg-[#faf9f7]! [&_.fighter-card-bg]:text-black! [&_.fighter-card-bg:hover]:scale-100! [&_.fighter-card-bg:hover]:shadow-none! [&_.fighter-card-bg]:transition-none! [&_.fighter-card-bg_.grid]:gap-y-0! [&_.fighter-card-bg_.grid]:mt-1! [&_.fighter-card-bg_.inline-flex.rounded-sm]:border-2! [&_.fighter-card-bg_.inline-flex.rounded-sm]:border-black! [&_.fighter-card-bg_.bg-secondary]:shadow-none! [&_.fighter-card-bg]:bg-[url('https://iojoritxhpijprgkjfre.supabase.co/storage/v1/object/public/site-images/fighter-card-background-5-light_web_ynpbac.webp')]! ${printStyle === 'eco' ? '[&_.fighter-card-bg]:bg-none! [&_.fighter-card-bg]:bg-transparent! [&_.fancy-print-top-bar]:bg-none! [&_.fancy-print-top-bar-art]:hidden! [&_.fancy-print-keep-color-heading]:text-inherit! [&_.fancy-print-keep-color-subtitle]:text-inherit!' : '[&_.fancy-print-keep-color-heading]:text-white! [&_.fancy-print-keep-color-subtitle]:text-gray-300!'}`}>
               {cardsGangCardsPosition === "before" && (
                 <>
                   {/* Gang Card */}
@@ -1020,15 +1037,13 @@ export default function PrintGang({ gang }: PrintGangProps) {
                     <div className="flex mb-[50px]">
                       <div className="flex w-full">
                         <div
-                          className="absolute inset-0 bg-no-repeat bg-cover fancy-print-top-bar mt-2"
+                          className="absolute inset-0 fancy-print-top-bar mt-2"
                           style={{
-                            backgroundImage: "url('https://iojoritxhpijprgkjfre.supabase.co/storage/v1/object/public/site-images/top-bar-stroke-v3_s97f2k.png')",
                             width: '100%',
                             height: '65px',
                             zIndex: 0,
-                            backgroundPosition: 'center',
-                            backgroundSize: '100% 100%'
                           }}>
+                          <FancyPrintTopBarArt />
                           <div className="absolute z-10 pl-4 flex items-center gap-2 w-[80%] overflow-hidden whitespace-nowrap" style={{ height: '62px', marginTop: '0px' }}>
                             <div className="flex flex-col items-baseline w-full">
                               <div className="text-2xl font-semibold text-white ml-4 print:text-foreground fancy-print-keep-color-heading">{name}</div>
@@ -1222,15 +1237,13 @@ export default function PrintGang({ gang }: PrintGangProps) {
                       <div className="flex mb-[50px]">
                         <div className="flex w-full">
                           <div
-                            className="absolute inset-0 bg-no-repeat bg-cover fancy-print-top-bar mt-2"
+                            className="absolute inset-0 fancy-print-top-bar mt-2"
                             style={{
-                              backgroundImage: "url('https://iojoritxhpijprgkjfre.supabase.co/storage/v1/object/public/site-images/top-bar-stroke-v3_s97f2k.png')",
                               width: '100%',
                               height: '65px',
                               zIndex: 0,
-                              backgroundPosition: 'center',
-                              backgroundSize: '100% 100%'
                             }}>
+                            <FancyPrintTopBarArt />
                             <div className="absolute z-10 pl-4 flex items-center gap-2 w-[80%] overflow-hidden whitespace-nowrap" style={{ height: '62px', marginTop: '0px' }}>
                               <div className="flex flex-col items-baseline w-full">
                                 <div className="text-xl font-semibold text-white ml-4 print:text-foreground fancy-print-keep-color-heading">Additional Details</div>
@@ -1479,15 +1492,13 @@ export default function PrintGang({ gang }: PrintGangProps) {
                 <div className="flex mb-[50px]">
                   <div className="flex w-full">
                     <div
-                      className="absolute inset-0 bg-no-repeat bg-cover fancy-print-top-bar mt-2"
+                      className="absolute inset-0 fancy-print-top-bar mt-2"
                       style={{
-                        backgroundImage: "url('https://iojoritxhpijprgkjfre.supabase.co/storage/v1/object/public/site-images/top-bar-stroke-v3_s97f2k.png')",
                         width: '100%',
                         height: '65px',
                         zIndex: 0,
-                        backgroundPosition: 'center',
-                        backgroundSize: '100% 100%'
                       }}>
+                      <FancyPrintTopBarArt />
                       <div className="absolute z-10 pl-4 flex items-center gap-2 w-[80%] overflow-hidden whitespace-nowrap" style={{ height: '62px', marginTop: '0px' }}>
                         <div className="flex flex-col items-baseline w-full">
                           <div className="text-2xl font-semibold text-white ml-4 print:text-foreground fancy-print-keep-color-heading">{name}</div>
@@ -1681,15 +1692,13 @@ export default function PrintGang({ gang }: PrintGangProps) {
                   <div className="flex mb-[50px]">
                     <div className="flex w-full">
                       <div
-                        className="absolute inset-0 bg-no-repeat bg-cover fancy-print-top-bar mt-2"
+                        className="absolute inset-0 fancy-print-top-bar mt-2"
                         style={{
-                          backgroundImage: "url('https://iojoritxhpijprgkjfre.supabase.co/storage/v1/object/public/site-images/top-bar-stroke-v3_s97f2k.png')",
                           width: '100%',
                           height: '65px',
                           zIndex: 0,
-                          backgroundPosition: 'center',
-                          backgroundSize: '100% 100%'
                         }}>
+                        <FancyPrintTopBarArt />
                         <div className="absolute z-10 pl-4 flex items-center gap-2 w-[80%] overflow-hidden whitespace-nowrap" style={{ height: '62px', marginTop: '0px' }}>
                           <div className="flex flex-col items-baseline w-full">
                             <div className="text-2xl font-semibold text-white ml-4 print:text-foreground fancy-print-keep-color-heading">Additional Details</div>

--- a/components/gang/print-gang.tsx
+++ b/components/gang/print-gang.tsx
@@ -15,6 +15,7 @@ import { MdCheckBoxOutlineBlank } from "react-icons/md";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
 import FighterCard from "./fighter-card";
+import { FancyPrintTopBarArt } from "./fancy-print-top-bar-art";
 import { PRINT_GANG_VIEW_MODE } from "./ViewModeDropdown";
 import { Badge } from "@/components/ui/badge";
 import { GiAncientRuins } from "react-icons/gi";
@@ -22,22 +23,6 @@ import { PatreonSupporterIcon } from "@/components/ui/patreon-supporter-icon";
 import { decodeHtmlEntities, isHtmlEffectivelyEmpty } from "@/utils/htmlCleanUp";
 
 const ROSTER_FIGHTER_NOTE_MAX_CHARS = 110;
-
-const FANCY_TOP_BAR_STROKE_SRC =
-  "https://iojoritxhpijprgkjfre.supabase.co/storage/v1/object/public/site-images/top-bar-stroke-v3_s97f2k.png";
-
-function FancyPrintTopBarArt() {
-  return (
-    // eslint-disable-next-line @next/next/no-img-element
-    <img
-      src={FANCY_TOP_BAR_STROKE_SRC}
-      alt=""
-      aria-hidden
-      className="fancy-print-top-bar-art pointer-events-none absolute inset-0 size-full"
-      style={{ objectFit: "fill" }}
-    />
-  );
-}
 
 function getRosterFighterNotePreview(note: string | undefined): string | null {
   if (!note || isHtmlEffectivelyEmpty(note)) return null;
@@ -1027,7 +1012,7 @@ export default function PrintGang({ gang }: PrintGangProps) {
               ["--ring" as any]: "var(--light-ring)",
             }} // Enforce light theme colors for Cards View
           >
-            <div className={`print-gang-cards justify-center print:justify-start flex flex-wrap content-start gap-[6px] ${scaleCardsToContent ? 'items-stretch [&_.fighter-card-bg]:h-auto! [&_.fighter-card-bg]:flex! [&_.fighter-card-bg]:flex-col!' : 'items-start [&_.fighter-card-bg]:h-[435px]!'} [&_.fighter-card-bg]:w-[630px]! [&_.fighter-card-bg]:shadow-none! [&_.fighter-card-bg]:border-[3px]! [&_.fighter-card-bg]:break-inside-avoid [&_.fighter-card-bg]:rounded-lg [&_.fighter-card-bg]:text-base! [&_.fighter-card-bg]:bg-[#faf9f7]! [&_.fighter-card-bg]:text-black! [&_.fighter-card-bg:hover]:scale-100! [&_.fighter-card-bg:hover]:shadow-none! [&_.fighter-card-bg]:transition-none! [&_.fighter-card-bg_.grid]:gap-y-0! [&_.fighter-card-bg_.grid]:mt-1! [&_.fighter-card-bg_.inline-flex.rounded-sm]:border-2! [&_.fighter-card-bg_.inline-flex.rounded-sm]:border-black! [&_.fighter-card-bg_.bg-secondary]:shadow-none! [&_.fighter-card-bg]:bg-[url('https://iojoritxhpijprgkjfre.supabase.co/storage/v1/object/public/site-images/fighter-card-background-5-light_web_ynpbac.webp')]! ${printStyle === 'eco' ? '[&_.fighter-card-bg]:bg-none! [&_.fighter-card-bg]:bg-transparent! [&_.fancy-print-top-bar]:bg-none! [&_.fancy-print-top-bar-art]:hidden! [&_.fancy-print-keep-color-heading]:text-inherit! [&_.fancy-print-keep-color-subtitle]:text-inherit!' : '[&_.fancy-print-keep-color-heading]:text-white! [&_.fancy-print-keep-color-subtitle]:text-gray-300!'}`}>
+            <div className={`print-gang-cards justify-center print:justify-start flex flex-wrap content-start gap-[6px] ${scaleCardsToContent ? 'items-stretch [&_.fighter-card-bg]:h-auto! [&_.fighter-card-bg]:flex! [&_.fighter-card-bg]:flex-col!' : 'items-start [&_.fighter-card-bg]:h-[435px]!'} [&_.fighter-card-bg]:w-[630px]! [&_.fighter-card-bg]:shadow-none! [&_.fighter-card-bg]:border-[3px]! [&_.fighter-card-bg]:break-inside-avoid [&_.fighter-card-bg]:rounded-lg [&_.fighter-card-bg]:text-base! [&_.fighter-card-bg]:bg-[#faf9f7]! [&_.fighter-card-bg]:text-black! [&_.fighter-card-bg:hover]:scale-100! [&_.fighter-card-bg:hover]:shadow-none! [&_.fighter-card-bg]:transition-none! [&_.fighter-card-bg_.grid]:gap-y-0! [&_.fighter-card-bg_.grid]:mt-1! [&_.fighter-card-bg_.inline-flex.rounded-sm]:border-2! [&_.fighter-card-bg_.inline-flex.rounded-sm]:border-black! [&_.fighter-card-bg_.bg-secondary]:shadow-none! [&_.fighter-card-bg]:bg-[url('https://iojoritxhpijprgkjfre.supabase.co/storage/v1/object/public/site-images/fighter-card-background-5-light_web_ynpbac.webp')]! ${printStyle === 'eco' ? '[&_.fighter-card-bg]:bg-none! [&_.fighter-card-bg]:bg-transparent! [&_.fancy-print-top-bar-art]:hidden! [&_.fancy-print-keep-color-heading]:text-inherit! [&_.fancy-print-keep-color-subtitle]:text-inherit!' : '[&_.fancy-print-keep-color-heading]:text-white! [&_.fancy-print-keep-color-subtitle]:text-gray-300!'}`}>
               {cardsGangCardsPosition === "before" && (
                 <>
                   {/* Gang Card */}


### PR DESCRIPTION
Keep fancy-print on the body while Fancy is selected, and render the stroke as an img so iOS Safari still prints it. Document LAN mobile testing and allowedDevOrigins in the README.