### PR TITLE
feat(campaigns): allow owners and arbitrators to rename territories

### DIFF
--- a/app/actions/campaigns/[id]/campaign-territories.ts
+++ b/app/actions/campaigns/[id]/campaign-territories.ts
@@ -6,7 +6,8 @@ import { logTerritoryLost, logTerritoryClaimed } from "../../logs/gang-campaign-
 import { getAuthenticatedUser } from '@/utils/auth';
 import { checkCampaignArbitrator } from '@/utils/user-permissions';
 import { editionsConflict, editionSlugFromJoin } from '@/types/edition';
-import { TERRITORY_NAME_CHAR_LIMIT } from '@/utils/campaigns/territory-name';
+import { normaliseTerritoryName, validateTerritoryName } from '@/utils/campaigns/territory-name';
+
 
 export interface AssignGangToTerritoryParams {
   campaignId: string;
@@ -334,15 +335,10 @@ export async function createCustomCampaignTerritory(params: CreateCustomCampaign
     const supabase = await createClient();
     const { campaignId, territoryName } = params;
 
-    const trimmedName = territoryName.trim();
-    if (!trimmedName) {
-      return { success: false, error: 'Territory name is required' };
-    }
-    if (trimmedName.length > TERRITORY_NAME_CHAR_LIMIT) {
-      return {
-        success: false,
-        error: `Territory name must be ${TERRITORY_NAME_CHAR_LIMIT} characters or less`
-      };
+    const trimmedName = normaliseTerritoryName(territoryName);
+    const nameError = validateTerritoryName(trimmedName);
+    if (nameError) {
+      return { success: false, error: nameError };
     }
 
     const user = await getAuthenticatedUser(supabase);
@@ -493,22 +489,12 @@ export async function updateTerritoryStatus(params: UpdateTerritoryStatusParams)
       description: description
     };
 
-    // Only validate/authorize rename when a new name is provided and it differs
+    // Only authorize/validate rename when a new name is provided and it differs
     if (territory_name !== undefined) {
-      const normalisedName = territory_name.trim();
-      const currentName = (territoryData.territory_name ?? '').trim();
+      const normalisedName = normaliseTerritoryName(territory_name);
+      const currentName = normaliseTerritoryName(territoryData.territory_name);
 
       if (normalisedName !== currentName) {
-        if (!normalisedName) {
-          return { success: false, error: 'Territory name is required' };
-        }
-        if (normalisedName.length > TERRITORY_NAME_CHAR_LIMIT) {
-          return {
-            success: false,
-            error: `Territory name must be ${TERRITORY_NAME_CHAR_LIMIT} characters or less`
-          };
-        }
-
         const user = await getAuthenticatedUser(supabase);
         const hasPermission = await checkCampaignArbitrator(user.id, campaignId);
         if (!hasPermission) {
@@ -517,6 +503,12 @@ export async function updateTerritoryStatus(params: UpdateTerritoryStatusParams)
             error: 'Only campaign owners and arbitrators can rename territories'
           };
         }
+
+        const nameError = validateTerritoryName(normalisedName);
+        if (nameError) {
+          return { success: false, error: nameError };
+        }
+
         updatePayload.territory_name = normalisedName;
       }
     }

--- a/app/actions/campaigns/[id]/campaign-territories.ts
+++ b/app/actions/campaigns/[id]/campaign-territories.ts
@@ -335,17 +335,17 @@ export async function createCustomCampaignTerritory(params: CreateCustomCampaign
     const supabase = await createClient();
     const { campaignId, territoryName } = params;
 
-    const trimmedName = normaliseTerritoryName(territoryName);
-    const nameError = validateTerritoryName(trimmedName);
-    if (nameError) {
-      return { success: false, error: nameError };
-    }
-
     const user = await getAuthenticatedUser(supabase);
 
     const hasPermission = await checkCampaignArbitrator(user.id, campaignId);
     if (!hasPermission) {
       return { success: false, error: 'Only campaign owners and arbitrators can create custom territories' };
+    }
+
+    const trimmedName = normaliseTerritoryName(territoryName);
+    const nameError = validateTerritoryName(trimmedName);
+    if (nameError) {
+      return { success: false, error: nameError };
     }
 
     const { error } = await supabase

--- a/app/actions/campaigns/[id]/campaign-territories.ts
+++ b/app/actions/campaigns/[id]/campaign-territories.ts
@@ -6,6 +6,7 @@ import { logTerritoryLost, logTerritoryClaimed } from "../../logs/gang-campaign-
 import { getAuthenticatedUser } from '@/utils/auth';
 import { checkCampaignArbitrator } from '@/utils/user-permissions';
 import { editionsConflict, editionSlugFromJoin } from '@/types/edition';
+import { TERRITORY_NAME_CHAR_LIMIT } from '@/utils/campaigns/territory-name';
 
 export interface AssignGangToTerritoryParams {
   campaignId: string;
@@ -42,6 +43,8 @@ export interface UpdateTerritoryStatusParams {
   playing_card: string | null;
   /** Stored on `campaign_territories.description`; null clears the value */
   description: string | null;
+  /** When provided, renames the campaign territory instance (owners/arbitrators only) */
+  territory_name?: string;
 }
 
 /**
@@ -335,6 +338,12 @@ export async function createCustomCampaignTerritory(params: CreateCustomCampaign
     if (!trimmedName) {
       return { success: false, error: 'Territory name is required' };
     }
+    if (trimmedName.length > TERRITORY_NAME_CHAR_LIMIT) {
+      return {
+        success: false,
+        error: `Territory name must be ${TERRITORY_NAME_CHAR_LIMIT} characters or less`
+      };
+    }
 
     const user = await getAuthenticatedUser(supabase);
 
@@ -454,24 +463,67 @@ export async function removeTerritoryFromCampaign(params: RemoveTerritoryParams)
 export async function updateTerritoryStatus(params: UpdateTerritoryStatusParams) {
   try {
     const supabase = await createClient();
-    const { campaignId, territoryId, ruined, default_gang_territory, playing_card, description } = params;
+    const {
+      campaignId,
+      territoryId,
+      ruined,
+      default_gang_territory,
+      playing_card,
+      description,
+      territory_name
+    } = params;
 
-    // Get the gang holding this territory so we can invalidate their cache
-    const { data: territoryData } = await supabase
+    // Get current territory so we can invalidate gang cache and detect renames
+    const { data: territoryData, error: selectError } = await supabase
       .from('campaign_territories')
-      .select('gang_id')
+      .select('gang_id, territory_name')
       .eq('id', territoryId)
       .eq('campaign_id', campaignId)
       .single();
 
+    if (selectError || !territoryData) {
+      console.error('Error fetching territory for status update:', selectError);
+      return { success: false, error: 'Territory not found' };
+    }
+
+    const updatePayload: Record<string, unknown> = {
+      ruined: ruined,
+      default_gang_territory: default_gang_territory,
+      playing_card: playing_card,
+      description: description
+    };
+
+    // Only validate/authorize rename when a new name is provided and it differs
+    if (territory_name !== undefined) {
+      const normalisedName = territory_name.trim();
+      const currentName = (territoryData.territory_name ?? '').trim();
+
+      if (normalisedName !== currentName) {
+        if (!normalisedName) {
+          return { success: false, error: 'Territory name is required' };
+        }
+        if (normalisedName.length > TERRITORY_NAME_CHAR_LIMIT) {
+          return {
+            success: false,
+            error: `Territory name must be ${TERRITORY_NAME_CHAR_LIMIT} characters or less`
+          };
+        }
+
+        const user = await getAuthenticatedUser(supabase);
+        const hasPermission = await checkCampaignArbitrator(user.id, campaignId);
+        if (!hasPermission) {
+          return {
+            success: false,
+            error: 'Only campaign owners and arbitrators can rename territories'
+          };
+        }
+        updatePayload.territory_name = normalisedName;
+      }
+    }
+
     const { error } = await supabase
       .from('campaign_territories')
-      .update({ 
-        ruined: ruined,
-        default_gang_territory: default_gang_territory,
-        playing_card: playing_card,
-        description: description
-      })
+      .update(updatePayload)
       .eq('id', territoryId)
       .eq('campaign_id', campaignId);
 
@@ -480,7 +532,7 @@ export async function updateTerritoryStatus(params: UpdateTerritoryStatusParams)
     invalidateCampaign(campaignId);
 
     // Invalidate gang cache to update territory display on gang page
-    if (territoryData?.gang_id) {
+    if (territoryData.gang_id) {
       invalidateGangCampaignMembership(territoryData.gang_id);
     }
 

--- a/app/lib/campaigns/[id]/get-campaign-data.ts
+++ b/app/lib/campaigns/[id]/get-campaign-data.ts
@@ -392,12 +392,38 @@ async function _getCampaignTerritories(campaignId: string, supabase: SupabaseCli
     }
   }
 
+  // Catalog/template names for Reset-to-original in the edit modal
+  const templateTerritoryIds = [
+    ...new Set(
+      (territories ?? [])
+        .map((t) => t.territory_id)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0)
+    ),
+  ];
+  let templateNameById: Record<string, string> = {};
+  if (templateTerritoryIds.length > 0) {
+    const { data: templates, error: templatesError } = await supabase
+      .from('territories')
+      .select('id, territory_name')
+      .in('id', templateTerritoryIds);
+
+    if (!templatesError && templates) {
+      templateNameById = Object.fromEntries(
+        templates.map((t) => [t.id, t.territory_name])
+      );
+    }
+  }
+
   return territories?.map(territory => {
     const gangDetails = territoryGangsData.find(g => g.id === territory.gang_id);
+    const originalTerritoryName = territory.territory_id
+      ? (templateNameById[territory.territory_id] ?? null)
+      : null;
     return {
       id: territory.id,
       territory_id: territory.territory_id,
       territory_name: territory.territory_name,
+      original_territory_name: originalTerritoryName,
       gang_id: territory.gang_id,
       created_at: territory.created_at,
       ruined: territory.ruined || false,

--- a/components/campaigns/[id]/campaign-add-territory-list.tsx
+++ b/components/campaigns/[id]/campaign-add-territory-list.tsx
@@ -11,6 +11,7 @@ import { ImInfo } from "react-icons/im";
 import { Tooltip } from 'react-tooltip';
 import type { CampaignType } from '@/types/campaign';
 import { sameEditionForDisplay } from '@/types/edition';
+import { TERRITORY_NAME_CHAR_LIMIT } from '@/utils/campaigns/territory-name';
 
 interface Territory {
   id: string;
@@ -230,8 +231,8 @@ export default function TerritoryList({
               type="text"
               value={newTerritoryName}
               onChange={(e) => setNewTerritoryName(e.target.value)}
-              placeholder="Add a custom Territory (max 70 characters)"
-              maxLength={70}
+              placeholder={`Add a custom Territory (max ${TERRITORY_NAME_CHAR_LIMIT} characters)`}
+              maxLength={TERRITORY_NAME_CHAR_LIMIT}
               className="grow text-sm"
               onKeyDown={(e) => {
                 if (e.key === 'Enter') {

--- a/components/campaigns/[id]/campaign-page-content.tsx
+++ b/components/campaigns/[id]/campaign-page-content.tsx
@@ -76,6 +76,8 @@ interface Territory {
   id: string;
   territory_id: string | null;
   territory_name: string;
+  /** Catalog/template name when linked via territory_id; null for custom territories */
+  original_territory_name?: string | null;
   playing_card?: string | null;
   gang_id: string | null;
   created_at: string;
@@ -258,6 +260,8 @@ export default function CampaignPageContent({
       ruined?: boolean;
       default_gang_territory?: boolean;
       playing_card?: string | null;
+      description?: string | null;
+      territory_name?: string;
     };
   }
 

--- a/components/campaigns/[id]/campaign-territory-edit-modal.tsx
+++ b/components/campaigns/[id]/campaign-territory-edit-modal.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from 'react'
 import { toast } from 'sonner'
 import Modal from "@/components/ui/modal"
+import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Combobox } from "@/components/ui/combobox"
@@ -14,6 +15,12 @@ import {
   territoryPlayingCardEditOptions,
   parseStandardPlayingCard
 } from "@/utils/campaigns/territory-playing-card-options"
+import {
+  TERRITORY_NAME_CHAR_LIMIT,
+  normaliseTerritoryName
+} from "@/utils/campaigns/territory-name"
+
+const TERRITORY_DESCRIPTION_CHAR_LIMIT = 1500;
 
 interface TerritoryEditModalProps {
   isOpen: boolean;
@@ -23,12 +30,18 @@ interface TerritoryEditModalProps {
     default_gang_territory: boolean;
     playing_card: string | null;
     description: string | null;
+    /** Only included when the user may rename and the name actually changed */
+    territory_name?: string;
   }) => void;
   territoryName: string;
+  /** Catalog/template name; Reset restores this when the instance was renamed */
+  originalTerritoryName?: string | null;
   currentRuined: boolean;
   currentDefaultGangTerritory: boolean;
   currentPlayingCard?: string | null;
   currentDescription?: string | null;
+  /** Owners/arbitrators may rename; members see the name as read-only */
+  canRename?: boolean;
   groupedTerritories?: Array<{
     id: string;
     territory_name: string;
@@ -64,23 +77,24 @@ function normaliseDescription(value: string | null | undefined): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
-const TERRITORY_DESCRIPTION_CHAR_LIMIT = 1500;
-
 export default function TerritoryEditModal({
   isOpen,
   onClose,
   onConfirm,
   territoryName,
+  originalTerritoryName,
   currentRuined,
   currentDefaultGangTerritory,
   currentPlayingCard,
   currentDescription,
+  canRename = false,
   groupedTerritories = [],
   selectedTerritoryId,
   onSelectTerritory,
   isUpdating = false
 }: TerritoryEditModalProps) {
   const initialPlayingCard = deriveInitialPlayingCardSelection(currentPlayingCard);
+  const [name, setName] = useState(territoryName);
   const [ruined, setRuined] = useState(currentRuined);
   const [defaultGangTerritory, setDefaultGangTerritory] = useState(currentDefaultGangTerritory);
   const [selectedRef, setSelectedRef] = useState(initialPlayingCard.selectedRef);
@@ -100,11 +114,12 @@ export default function TerritoryEditModal({
   }, [selectedRef, customPlayingCard]);
 
   const [prevResetKey, setPrevResetKey] = useState('');
-  const resetKey = `${isOpen}:${currentRuined}:${currentDefaultGangTerritory}:${currentPlayingCard}:${currentDescription}`;
+  const resetKey = `${isOpen}:${selectedTerritoryId ?? ''}:${territoryName}:${currentRuined}:${currentDefaultGangTerritory}:${currentPlayingCard}:${currentDescription}`;
   if (resetKey !== prevResetKey) {
     setPrevResetKey(resetKey);
     if (isOpen) {
       const next = deriveInitialPlayingCardSelection(currentPlayingCard);
+      setName(territoryName);
       setRuined(currentRuined);
       setDefaultGangTerritory(currentDefaultGangTerritory);
       setSelectedRef(next.selectedRef);
@@ -113,7 +128,18 @@ export default function TerritoryEditModal({
     }
   }
 
+  const nameChanged =
+    canRename &&
+    normaliseTerritoryName(name) !== normaliseTerritoryName(territoryName);
+
+  const originalName = normaliseTerritoryName(originalTerritoryName);
+  const canResetToOriginal =
+    canRename &&
+    !!originalName &&
+    normaliseTerritoryName(name) !== originalName;
+
   const hasChanged =
+    nameChanged ||
     ruined !== currentRuined ||
     defaultGangTerritory !== currentDefaultGangTerritory ||
     normalisePlayingCard(effectivePlayingCard ?? undefined) !== normalisePlayingCard(currentPlayingCard) ||
@@ -124,8 +150,17 @@ export default function TerritoryEditModal({
       ? TERRITORY_PLAYING_CARD_CUSTOM
       : selectedRef || TERRITORY_PLAYING_CARD_NONE;
   const isDescriptionOverLimit = getCharCount(description) > TERRITORY_DESCRIPTION_CHAR_LIMIT;
+  const isNameMissing = canRename && !normaliseTerritoryName(name);
+  const helperName = canRename
+    ? (normaliseTerritoryName(name) || territoryName)
+    : territoryName;
 
   const handleConfirm = () => {
+    if (isNameMissing) {
+      toast.error('Please enter a territory name');
+      return false;
+    }
+
     if (selectedRef === TERRITORY_PLAYING_CARD_CUSTOM && !customPlayingCard.trim()) {
       toast.error('Please enter a custom playing card value');
       return false;
@@ -141,7 +176,8 @@ export default function TerritoryEditModal({
       ruined,
       default_gang_territory: defaultGangTerritory,
       playing_card: effectivePlayingCard,
-      description: normaliseDescription(description)
+      description: normaliseDescription(description),
+      ...(nameChanged ? { territory_name: normaliseTerritoryName(name) } : {})
     });
     return true;
   };
@@ -167,6 +203,43 @@ export default function TerritoryEditModal({
             }))}
             placeholder="Select a territory to edit"
           />
+        </div>
+      )}
+
+      {canRename ? (
+        <div>
+          <label className="block text-sm font-medium text-muted-foreground mb-1">
+            Name *
+          </label>
+          <div className="flex items-center gap-2">
+            <Input
+              type="text"
+              className="w-full"
+              placeholder={`Territory name (max ${TERRITORY_NAME_CHAR_LIMIT} characters)`}
+              value={name}
+              maxLength={TERRITORY_NAME_CHAR_LIMIT}
+              required
+              aria-required="true"
+              onChange={(e) => setName(e.target.value)}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="shrink-0"
+              disabled={!canResetToOriginal}
+              onClick={() => setName(originalName)}
+            >
+              Reset
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div>
+          <label className="block text-sm font-medium text-muted-foreground mb-1">
+            Name
+          </label>
+          <p className="text-sm text-foreground py-2">{territoryName}</p>
         </div>
       )}
 
@@ -214,7 +287,7 @@ export default function TerritoryEditModal({
           htmlFor="ruined-checkbox" 
           className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
         >
-          Mark as Ruined
+          Ruined
         </label>
       </div>
       
@@ -263,12 +336,12 @@ export default function TerritoryEditModal({
     <>
       <Modal
         title="Edit Territory"
-        helper={`Modify settings for ${territoryName}`}
+        helper={`Modify settings for ${helperName}`}
         content={modalContent}
         onClose={onClose}
         onConfirm={handleConfirm}
         confirmText="Update Territory"
-        confirmDisabled={!hasChanged || isUpdating || isDescriptionOverLimit}
+        confirmDisabled={!hasChanged || isUpdating || isDescriptionOverLimit || isNameMissing}
         width="2xl"
       />
       <Tooltip

--- a/components/campaigns/[id]/campaign-territory-list.tsx
+++ b/components/campaigns/[id]/campaign-territory-list.tsx
@@ -49,6 +49,8 @@ interface Territory {
   id: string;
   territory_id: string | null;
   territory_name: string;
+  /** Catalog/template name when linked via territory_id; null for custom territories */
+  original_territory_name?: string | null;
   playing_card?: string | null;
   description?: string | null;
   gang_id: string | null;
@@ -82,6 +84,7 @@ interface TerritoryUpdate {
     default_gang_territory?: boolean;
     playing_card?: string | null;
     description?: string | null;
+    territory_name?: string;
   };
 }
 
@@ -311,7 +314,8 @@ export default function CampaignTerritoryList({
       default_gang_territory: boolean;
       playing_card: string | null;
       description: string | null;
-      territoryName: string;
+      territory_name?: string;
+      displayName: string;
     }) => {
       const result = await updateTerritoryStatus({
         campaignId,
@@ -319,7 +323,10 @@ export default function CampaignTerritoryList({
         ruined: variables.ruined,
         default_gang_territory: variables.default_gang_territory,
         playing_card: variables.playing_card,
-        description: variables.description
+        description: variables.description,
+        ...(variables.territory_name !== undefined
+          ? { territory_name: variables.territory_name }
+          : {})
       });
       if (!result.success) {
         throw new Error(result.error || 'Failed to update territory');
@@ -338,11 +345,17 @@ export default function CampaignTerritoryList({
           ruined: variables.ruined,
           default_gang_territory: variables.default_gang_territory,
           playing_card: variables.playing_card,
-          description: variables.description
+          description: variables.description,
+          ...(variables.territory_name !== undefined
+            ? { territory_name: variables.territory_name }
+            : {})
         }
       });
       
-      return { previousTerritories, territoryName: variables.territoryName };
+      return {
+        previousTerritories,
+        territoryName: variables.displayName
+      };
     },
     retry: 2,
     retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 10000),
@@ -376,8 +389,12 @@ export default function CampaignTerritoryList({
     default_gang_territory: boolean;
     playing_card: string | null;
     description: string | null;
+    territory_name?: string;
   }) => {
     if (!territoryToEdit) return false;
+
+    const displayName =
+      updates.territory_name ?? territoryToEdit.territory_name;
 
     updateTerritoryMutation.mutate({
       territoryId: territoryToEdit.id,
@@ -385,7 +402,10 @@ export default function CampaignTerritoryList({
       default_gang_territory: updates.default_gang_territory,
       playing_card: updates.playing_card,
       description: updates.description,
-      territoryName: territoryToEdit.territory_name
+      ...(updates.territory_name !== undefined
+        ? { territory_name: updates.territory_name }
+        : {}),
+      displayName
     });
     
     return true;
@@ -768,20 +788,20 @@ export default function CampaignTerritoryList({
           }}
           onConfirm={handleTerritoryUpdate}
           territoryName={territoryToEdit.territory_name}
+          originalTerritoryName={territoryToEdit.original_territory_name}
           currentRuined={territoryToEdit.ruined || false}
           currentDefaultGangTerritory={territoryToEdit.default_gang_territory || false}
           currentPlayingCard={territoryToEdit.playing_card ?? null}
           currentDescription={territoryToEdit.description ?? null}
-          {...({
-            groupedTerritories: editGroupTerritories,
-            selectedTerritoryId: territoryToEdit.id,
-            onSelectTerritory: (territoryId: string) => {
-              const selected = editGroupTerritories.find((territory) => territory.id === territoryId);
-              if (selected) {
-                setTerritoryToEdit(selected);
-              }
+          canRename={permissions.canManageTerritories}
+          groupedTerritories={editGroupTerritories}
+          selectedTerritoryId={territoryToEdit.id}
+          onSelectTerritory={(territoryId: string) => {
+            const selected = editGroupTerritories.find((territory) => territory.id === territoryId);
+            if (selected) {
+              setTerritoryToEdit(selected);
             }
-          } as any)}
+          }}
           isUpdating={updateTerritoryMutation.isPending}
         />
       )}

--- a/utils/campaigns/territory-name.ts
+++ b/utils/campaigns/territory-name.ts
@@ -4,3 +4,17 @@ export const TERRITORY_NAME_CHAR_LIMIT = 70;
 export function normaliseTerritoryName(value: string | null | undefined): string {
   return typeof value === 'string' ? value.trim() : '';
 }
+
+/**
+ * Validate a territory name (already normalised / trimmed).
+ * @returns error message, or null when valid
+ */
+export function validateTerritoryName(normalisedName: string): string | null {
+  if (!normalisedName) {
+    return 'Territory name is required';
+  }
+  if (normalisedName.length > TERRITORY_NAME_CHAR_LIMIT) {
+    return `Territory name must be ${TERRITORY_NAME_CHAR_LIMIT} characters or less`;
+  }
+  return null;
+}

--- a/utils/campaigns/territory-name.ts
+++ b/utils/campaigns/territory-name.ts
@@ -1,0 +1,6 @@
+/** Max length for campaign territory instance names (custom create + rename). */
+export const TERRITORY_NAME_CHAR_LIMIT = 70;
+
+export function normaliseTerritoryName(value: string | null | undefined): string {
+  return typeof value === 'string' ? value.trim() : '';
+}


### PR DESCRIPTION
Add rename + reset-to-template in the edit modal, enforce the 70-char limit on create/rename, and gate rename to campaign owners/arbitrators.