### PR TITLE
feat(cache): add conditional Redis cacheHandler for self-hosted deploys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,26 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # HMAC key for one-click email unsubscribe tokens. MUST match the UNSUBSCRIBE_SECRET
 # set on the send-notification-email edge function (supabase secrets set).
 UNSUBSCRIBE_SECRET=a-long-random-string
+
+# --- Redis-backed Next.js cache (self-hosted / Coolify only) ---
+# Leave false on Vercel: with this unset the app uses Next's built-in Data Cache
+# exactly as before. Set to true only where a Redis instance is available.
+# Must be present at BUILD time, because next.config.js reads it to decide whether
+# to register the custom cacheHandler.
+USE_REDIS_CACHE=false
+
+# SECRET. Runtime only - it is intentionally NOT available during `next build`,
+# and the build must succeed without it. Only needed when USE_REDIS_CACHE=true;
+# if it is missing the handler falls back to a local in-memory cache.
+REDIS_URL=
+
+# Optional. Key namespace, default: munda-manager:next-cache
+# Only matters if two apps share one Redis instance.
+REDIS_CACHE_PREFIX=
+
+# Optional. Per-operation timeout in ms, default: 1000
+REDIS_CACHE_TIMEOUT_MS=
+
+# Optional. Set to 1 to log cache GET/SET/HIT/MISS and tag invalidations.
+# Logs keys and counts only, never cached values.
+NEXT_PRIVATE_DEBUG_CACHE=

--- a/README.md
+++ b/README.md
@@ -627,3 +627,42 @@ interface FighterProps {
 ```
 
 
+
+## Self-Hosted Caching (Coolify)
+
+On Vercel the app uses Next's built-in Data Cache and nothing here applies. When
+self-hosting, `cache-handler.js` can back the Next.js `cacheHandler` with Redis so
+cached data is shared between instances and survives a redeploy.
+
+It is off unless `USE_REDIS_CACHE=true` is set **at build time** — `next.config.js`
+reads it to decide whether to register the handler at all. `REDIS_URL` is a runtime
+secret and is deliberately not needed during `next build`; without it the handler
+falls back to an in-process cache, which is what makes the build work.
+
+| Variable | Required | Notes |
+|---|---|---|
+| `USE_REDIS_CACHE` | build | `true` enables the handler |
+| `REDIS_URL` | runtime | Secret. Absent ⇒ in-memory fallback |
+| `REDIS_CACHE_PREFIX` | no | Default `munda-manager:next-cache` |
+| `REDIS_CACHE_TIMEOUT_MS` | no | Default `1000` |
+| `NEXT_PRIVATE_DEBUG_CACHE` | no | `1` logs HIT/MISS/SET and invalidations |
+
+`unstable_cache` entries are stored under `…:v1:fetch:` and persist across deploys;
+rendered pages are stored per build id so a new build never serves the previous
+build's payloads. Tags from `utils/cache-tags.ts` are indexed as Redis sets, so
+`revalidateTag` deletes exactly the affected keys rather than scanning the keyspace.
+
+To confirm Redis is receiving entries:
+
+```bash
+redis-cli -u "$REDIS_URL" DBSIZE
+redis-cli -u "$REDIS_URL" --scan --pattern 'munda-manager:next-cache:*' | head -50
+redis-cli -u "$REDIS_URL" SMEMBERS 'munda-manager:next-cache:v1:tag:gang-<GANG_ID>'
+redis-cli -u "$REDIS_URL" MONITOR   # watch live traffic while browsing
+
+# flush the app's cache (e.g. after changing the shape of a cached value)
+redis-cli -u "$REDIS_URL" --scan --pattern 'munda-manager:next-cache:*' \
+  | xargs -r -n 500 redis-cli -u "$REDIS_URL" DEL
+```
+
+To roll back to stock Next.js caching, unset `USE_REDIS_CACHE` and rebuild.

--- a/README.md
+++ b/README.md
@@ -662,6 +662,12 @@ therefore grows unbounded until writes fail with OOM — at which point the cach
 working and invalidations start being dropped. Under `allkeys-lru` it just evicts, which
 is the failure mode the handler is designed around.
 
+**Recovery after a Redis outage.** Cache entries have no TTL, so an invalidation that
+cannot reach Redis would otherwise leave stale data that nothing expires. If that
+happens the handler marks the cache dirty: it stops serving Redis hits, and once Redis
+is reachable again it drops the whole namespace before trusting it. Expect one cold
+cache — and a burst of Supabase reads — after an outage. Both transitions are logged.
+
 **Do not expose the instance.** Entries hold whatever `unstable_cache` wrapped — gang,
 fighter and campaign data, profiles, permission results — so treat it like any other
 datastore with real data in it: private network only, and require auth (and TLS) if it

--- a/README.md
+++ b/README.md
@@ -647,6 +647,26 @@ falls back to an in-process cache, which is what makes the build work.
 | `REDIS_CACHE_TIMEOUT_MS` | no | Default `1000` |
 | `NEXT_PRIVATE_DEBUG_CACHE` | no | `1` logs HIT/MISS/SET and invalidations |
 
+### Redis instance requirements
+
+**Configure the instance as a cache, not a store:**
+
+```
+maxmemory 256mb                 # size to taste
+maxmemory-policy allkeys-lru
+```
+
+Cache entries carry no TTL on purpose, so that tag invalidation stays the only thing
+that expires them. On Redis's actual default policy (`noeviction`) the keyspace
+therefore grows unbounded until writes fail with OOM — at which point the cache stops
+working and invalidations start being dropped. Under `allkeys-lru` it just evicts, which
+is the failure mode the handler is designed around.
+
+**Do not expose the instance.** Entries hold whatever `unstable_cache` wrapped — gang,
+fighter and campaign data, profiles, permission results — so treat it like any other
+datastore with real data in it: private network only, and require auth (and TLS) if it
+is ever reachable beyond the Coolify network.
+
 `unstable_cache` entries are stored under `…:v1:fetch:` and persist across deploys;
 rendered pages are stored per build id so a new build never serves the previous
 build's payloads. Tags from `utils/cache-tags.ts` are indexed as Redis sets, so

--- a/cache-handler.js
+++ b/cache-handler.js
@@ -154,6 +154,30 @@ function fallbackSet(key, entry) {
 const tagKey = (tag) => `${PREFIX}:tag:${tag}`;
 const markerKey = (tag) => `${PREFIX}:rt:${tag}`;
 
+// Module-scoped, because Next builds a handler per request and serverDistDir is the
+// same for all of them. The promise itself is memoised rather than the value: caching
+// the value would need its guard set before the await below, so a second concurrent
+// caller would get the 'shared' placeholder while the first was still reading.
+let buildIdPromise;
+function getBuildId(serverDistDir) {
+  if (!buildIdPromise) {
+    buildIdPromise = (async () => {
+      const node = await loadNode();
+      if (node && serverDistDir) {
+        try {
+          return node
+            .readFileSync(node.join(serverDistDir, '..', 'BUILD_ID'), 'utf8')
+            .trim();
+        } catch {
+          // Falls back to a shared namespace.
+        }
+      }
+      return 'shared';
+    })();
+  }
+  return buildIdPromise;
+}
+
 function headerTags(data) {
   const header = data?.headers?.[TAGS_HEADER];
   return typeof header === 'string' && header ? header.split(',') : [];
@@ -167,7 +191,6 @@ export default class RedisCacheHandler {
   constructor(ctx = {}) {
     this.revalidatedTags = ctx.revalidatedTags || [];
     this.serverDistDir = ctx.serverDistDir;
-    this.buildId = undefined;
 
     // Next builds a handler per request; the client below is module-scoped.
     if (!announced) {
@@ -292,6 +315,9 @@ export default class RedisCacheHandler {
           for (const member of results[i] || []) keys.add(String(member));
         }
 
+        // Accepted race: a set() re-populating one of these keys between the two
+        // round trips has its fresh value deleted. Costs a miss, never staleness,
+        // since deletion is the safe direction. Making it atomic needs a Lua script.
         const write = redis.multi();
         for (const key of keys) write.del(key);
         for (const tag of list) write.del(tagKey(tag));
@@ -318,22 +344,7 @@ export default class RedisCacheHandler {
   // build would serve the previous build's RSC data.
   async #entryKey(key, kind) {
     if (kind === 'FETCH') return `${PREFIX}:fetch:${key}`;
-
-    if (this.buildId === undefined) {
-      this.buildId = 'shared';
-      const node = await loadNode();
-      if (node && this.serverDistDir) {
-        try {
-          this.buildId = node
-            .readFileSync(node.join(this.serverDistDir, '..', 'BUILD_ID'), 'utf8')
-            .trim();
-        } catch {
-          // Falls back to a shared namespace.
-        }
-      }
-    }
-
-    return `${PREFIX}:${this.buildId}:page:${key}`;
+    return `${PREFIX}:${await getBuildId(this.serverDistDir)}:page:${key}`;
   }
 
   async #decode(entryKey, payload) {

--- a/cache-handler.js
+++ b/cache-handler.js
@@ -183,6 +183,27 @@ function headerTags(data) {
   return typeof header === 'string' && header ? header.split(',') : [];
 }
 
+// Atomic so a set() landing mid-invalidation cannot have its fresh value deleted.
+// Keys come from SMEMBERS inside the script, so they cannot be declared in KEYS[] —
+// single-instance only, as is the multi-key DEL this replaced.
+const REVALIDATE_TAG_SCRIPT = `
+local prefix, now, ttl = ARGV[1], ARGV[2], ARGV[3]
+local deleted = 0
+for i = 4, #ARGV do
+  local tag = ARGV[i]
+  redis.call('SET', prefix .. ':rt:' .. tag, now, 'EX', ttl)
+  local setKey = prefix .. ':tag:' .. tag
+  local members = redis.call('SMEMBERS', setKey)
+  for j = 1, #members, 500 do
+    local batch = {}
+    for k = j, math.min(j + 499, #members) do batch[#batch + 1] = members[k] end
+    deleted = deleted + redis.call('DEL', unpack(batch))
+  end
+  redis.call('DEL', setKey)
+end
+return deleted
+`;
+
 /** Mirrors Next's areTagsExpired: a tag invalidated at T kills entries older than T. */
 const isExpiredBy = (markers, lastModified) =>
   markers.some((marker) => marker != null && Number(marker) > lastModified);
@@ -300,31 +321,11 @@ export default class RedisCacheHandler {
     const now = String(Date.now());
     const deleted = await withRedis(
       'revalidateTag',
-      async (redis) => {
-        const read = redis.multi();
-        for (const tag of list) {
-          // The marker is what invalidates implicit `_N_T_/…` soft tags and any
-          // entry whose tag index was lost — neither of which the index can cover.
-          read.set(markerKey(tag), now, { EX: MARKER_TTL_SECONDS });
-          read.sMembers(tagKey(tag));
-        }
-        const results = await read.exec();
-
-        const keys = new Set();
-        for (let i = 1; i < results.length; i += 2) {
-          for (const member of results[i] || []) keys.add(String(member));
-        }
-
-        // Accepted race: a set() re-populating one of these keys between the two
-        // round trips has its fresh value deleted. Costs a miss, never staleness,
-        // since deletion is the safe direction. Making it atomic needs a Lua script.
-        const write = redis.multi();
-        for (const key of keys) write.del(key);
-        for (const tag of list) write.del(tagKey(tag));
-        await write.exec();
-
-        return keys.size;
-      },
+      (redis) =>
+        redis.eval(REVALIDATE_TAG_SCRIPT, {
+          keys: [],
+          arguments: [PREFIX, now, String(MARKER_TTL_SECONDS), ...list],
+        }),
       null
     );
 

--- a/cache-handler.js
+++ b/cache-handler.js
@@ -91,7 +91,10 @@ async function connect() {
 
   // Throwing from this listener stops node-redis reconnecting after a socket error.
   client.on('error', (error) => logError('client', error));
-  client.on('ready', () => debug('connected'));
+  client.on('ready', () => {
+    debug('connected');
+    purgeNamespace().catch(() => {});
+  });
 
   bufferClient = client.withTypeMapping({ [redis.RESP_TYPES.BLOB_STRING]: Buffer });
   connecting = client.connect().catch((error) => logError('connect', error));
@@ -122,6 +125,54 @@ async function withRedis(scope, fn, fallback) {
   } catch (error) {
     logError(scope, error);
     return fallback;
+  }
+}
+
+// An invalidation that could not reach Redis leaves entries no marker can expire
+// and no TTL will remove, so they would return as valid hits once Redis recovers.
+// Treat the namespace as untrustworthy until it has been dropped.
+let dirty = false;
+let purge = null;
+
+function markDirty(tags) {
+  dirty = true;
+  console.error(
+    `[redis-cache] invalidation lost (${tags.join(', ')}); cache dirty until purged`
+  );
+}
+
+async function purgeNamespace() {
+  if (!dirty) return;
+  if (purge) return purge;
+
+  purge = (async () => {
+    let cursor = '0';
+    do {
+      const batch = await withRedis(
+        'purge',
+        async (redis) => {
+          const scanned = await redis.scan(cursor, {
+            MATCH: `${PREFIX}:*`,
+            COUNT: 500,
+          });
+          if (scanned.keys.length) await redis.unlink(scanned.keys);
+          return scanned;
+        },
+        null
+      );
+      if (!batch) return;
+      cursor = String(batch.cursor);
+    } while (cursor !== '0');
+
+    fallbackStore.clear();
+    dirty = false;
+    console.error('[redis-cache] dirty cache purged; Redis trusted again');
+  })();
+
+  try {
+    await purge;
+  } finally {
+    purge = null;
   }
 }
 
@@ -232,6 +283,14 @@ export default class RedisCacheHandler {
       return null;
     }
 
+    if (dirty) {
+      await purgeNamespace();
+      if (dirty) {
+        debug('get DIRTY', key);
+        return null;
+      }
+    }
+
     const result = await withRedis(
       'get',
       async (redis, buffers) => {
@@ -250,7 +309,7 @@ export default class RedisCacheHandler {
         entry = await this.#decode(entryKey, result.payload);
         if (entry && isExpiredBy(result.markers, entry.lastModified)) {
           debug('get EXPIRED', key);
-          this.#drop(entryKey);
+          this.#drop(entryKey, entry.tags);
           return null;
         }
       }
@@ -274,7 +333,7 @@ export default class RedisCacheHandler {
       );
       if (isExpiredBy(markers, entry.lastModified)) {
         debug('get EXPIRED', key);
-        this.#drop(entryKey);
+        this.#drop(entryKey, entry.tags);
         return null;
       }
     }
@@ -310,9 +369,12 @@ export default class RedisCacheHandler {
     });
   }
 
-  async revalidateTag(tags) {
+  // durations is Next's `{ expire?: number }`. Any value is treated as immediate
+  // invalidation: stricter than stale-then-expire, never staler.
+  async revalidateTag(tags, durations) {
     const list = [tags].flat().filter(Boolean);
     if (!list.length) return;
+    if (durations?.expire) debug('revalidateTag expire treated as immediate');
 
     for (const [key, hit] of fallbackStore) {
       if (hit.entry.tags?.some((tag) => list.includes(tag))) fallbackStore.delete(key);
@@ -330,11 +392,7 @@ export default class RedisCacheHandler {
     );
 
     if (deleted === null) {
-      if (REDIS_ENABLED) {
-        console.error(
-          `[redis-cache] revalidateTag lost while Redis was unavailable: ${list.join(', ')}`
-        );
-      }
+      if (REDIS_ENABLED) markDirty(list);
       return;
     }
 
@@ -360,8 +418,12 @@ export default class RedisCacheHandler {
     }
   }
 
-  #drop(entryKey) {
+  #drop(entryKey, tags = []) {
     fallbackStore.delete(entryKey);
-    withRedis('drop', (redis) => redis.del(entryKey));
+    withRedis('drop', async (redis) => {
+      const multi = redis.multi().del(entryKey);
+      for (const tag of tags) multi.sRem(tagKey(tag), entryKey);
+      await multi.exec();
+    });
   }
 }

--- a/cache-handler.js
+++ b/cache-handler.js
@@ -1,0 +1,355 @@
+// Next dynamic-imports this file from disk at runtime (next-server.ts →
+// formatDynamicImportPath), so it is never compiled: keep it plain ESM JS.
+//
+// Nothing Node-only may be imported at the top level. Next bundles this module
+// into the edge chunk for `runtime = 'edge'` routes, where a top-level `redis`
+// import fails to resolve node:crypto at module evaluation and breaks the build.
+// Both loaders below degrade to null so an edge context falls through to misses.
+
+let nodeDeps;
+async function loadNode() {
+  if (nodeDeps !== undefined) return nodeDeps;
+  try {
+    const [v8, fs, pathMod] = await Promise.all([
+      import('node:v8'),
+      import('node:fs'),
+      import('node:path'),
+    ]);
+    nodeDeps = {
+      serialize: v8.serialize,
+      deserialize: v8.deserialize,
+      readFileSync: fs.readFileSync,
+      join: pathMod.default.join,
+    };
+  } catch {
+    nodeDeps = null;
+  }
+  return nodeDeps;
+}
+
+let redisDeps;
+async function loadRedis() {
+  if (redisDeps !== undefined) return redisDeps;
+  try {
+    const redis = await import('redis');
+    redisDeps = { createClient: redis.createClient, RESP_TYPES: redis.RESP_TYPES };
+  } catch (error) {
+    logError('import', error);
+    redisDeps = null;
+  }
+  return redisDeps;
+}
+
+const PREFIX = `${process.env.REDIS_CACHE_PREFIX || 'munda-manager:next-cache'}:v1`;
+const TIMEOUT_MS = Number(process.env.REDIS_CACHE_TIMEOUT_MS) || 1000;
+const DEBUG = !!process.env.NEXT_PRIVATE_DEBUG_CACHE;
+const TAGS_HEADER = 'x-next-cache-tags';
+const MARKER_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+const FALLBACK_MAX_ENTRIES = 1000;
+const FALLBACK_TTL_MS = 60_000;
+const ERROR_LOG_INTERVAL_MS = 10_000;
+
+// REDIS_URL is deliberately absent during `next build` on Coolify, and the build
+// must not reach for Redis even if it leaks in, so both signals disable it.
+const IS_BUILD = process.env.NEXT_PHASE === 'phase-production-build';
+const REDIS_ENABLED = !IS_BUILD && !!process.env.REDIS_URL;
+
+const debug = (...args) => {
+  if (DEBUG) console.log('[redis-cache]', ...args);
+};
+
+let lastErrorLoggedAt = 0;
+function logError(scope, error) {
+  const now = Date.now();
+  if (!DEBUG && now - lastErrorLoggedAt < ERROR_LOG_INTERVAL_MS) return;
+  lastErrorLoggedAt = now;
+  console.error(`[redis-cache] ${scope}:`, error?.message || error);
+}
+
+let client;
+let bufferClient;
+let connecting;
+let announced = false;
+
+async function connect() {
+  if (!REDIS_ENABLED) return null;
+  if (client) return client;
+
+  const redis = await loadRedis();
+  if (!redis) return null;
+  if (client) return client;
+
+  client = redis.createClient({
+    url: process.env.REDIS_URL,
+    pingInterval: 30_000,
+    socket: {
+      connectTimeout: 5_000,
+      reconnectStrategy: (retries) => Math.min(retries * 100, 3_000),
+    },
+  });
+
+  // Throwing from this listener stops node-redis reconnecting after a socket error.
+  client.on('error', (error) => logError('client', error));
+  client.on('ready', () => debug('connected'));
+
+  bufferClient = client.withTypeMapping({ [redis.RESP_TYPES.BLOB_STRING]: Buffer });
+  connecting = client.connect().catch((error) => logError('connect', error));
+
+  return client;
+}
+
+function withTimeout(promise, scope) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`${scope} timed out`)), TIMEOUT_MS);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+async function withRedis(scope, fn, fallback) {
+  if (!REDIS_ENABLED) return fallback;
+
+  try {
+    const redis = await connect();
+    if (!redis) return fallback;
+
+    if (!redis.isReady) {
+      await withTimeout(connecting, scope).catch(() => {});
+      if (!redis.isReady) return fallback;
+    }
+    return await withTimeout(fn(redis, bufferClient), scope);
+  } catch (error) {
+    logError(scope, error);
+    return fallback;
+  }
+}
+
+const fallbackStore = new Map();
+
+function fallbackGet(key) {
+  const hit = fallbackStore.get(key);
+  if (!hit) return undefined;
+  if (hit.expiresAt && hit.expiresAt < Date.now()) {
+    fallbackStore.delete(key);
+    return undefined;
+  }
+  fallbackStore.delete(key);
+  fallbackStore.set(key, hit);
+  return hit.entry;
+}
+
+function fallbackSet(key, entry) {
+  fallbackStore.delete(key);
+  fallbackStore.set(key, {
+    entry,
+    // During the build this tier is the only store, so it must not expire.
+    expiresAt: REDIS_ENABLED ? Date.now() + FALLBACK_TTL_MS : 0,
+  });
+  while (fallbackStore.size > FALLBACK_MAX_ENTRIES) {
+    fallbackStore.delete(fallbackStore.keys().next().value);
+  }
+}
+
+const tagKey = (tag) => `${PREFIX}:tag:${tag}`;
+const markerKey = (tag) => `${PREFIX}:rt:${tag}`;
+
+function headerTags(data) {
+  const header = data?.headers?.[TAGS_HEADER];
+  return typeof header === 'string' && header ? header.split(',') : [];
+}
+
+/** Mirrors Next's areTagsExpired: a tag invalidated at T kills entries older than T. */
+const isExpiredBy = (markers, lastModified) =>
+  markers.some((marker) => marker != null && Number(marker) > lastModified);
+
+export default class RedisCacheHandler {
+  constructor(ctx = {}) {
+    this.revalidatedTags = ctx.revalidatedTags || [];
+    this.serverDistDir = ctx.serverDistDir;
+    this.buildId = undefined;
+
+    // Next builds a handler per request; the client below is module-scoped.
+    if (!announced) {
+      announced = true;
+      debug('init', REDIS_ENABLED ? 'redis' : 'memory');
+    }
+  }
+
+  resetRequestCache() {}
+
+  async get(key, ctx = {}) {
+    const { kind } = ctx;
+    const entryKey = await this.#entryKey(key, kind);
+    const ctxTags = [...(ctx.tags || []), ...(ctx.softTags || [])];
+
+    if (ctxTags.some((tag) => this.revalidatedTags.includes(tag))) {
+      debug('get REVALIDATED', key);
+      return null;
+    }
+
+    const result = await withRedis(
+      'get',
+      async (redis, buffers) => {
+        const [payload, markers] = await Promise.all([
+          buffers.get(entryKey),
+          ctxTags.length ? redis.mGet(ctxTags.map(markerKey)) : [],
+        ]);
+        return { payload, markers };
+      },
+      null
+    );
+
+    let entry;
+    if (result) {
+      if (result.payload) {
+        entry = await this.#decode(entryKey, result.payload);
+        if (entry && isExpiredBy(result.markers, entry.lastModified)) {
+          debug('get EXPIRED', key);
+          this.#drop(entryKey);
+          return null;
+        }
+      }
+    } else {
+      entry = fallbackGet(entryKey);
+    }
+
+    if (!entry) {
+      debug('get MISS', key, kind);
+      return null;
+    }
+
+    // Page entries carry their tags in the stored headers rather than in ctx, so
+    // anything the pipeline above could not know about needs a second lookup.
+    const extraTags = (entry.tags || []).filter((tag) => !ctxTags.includes(tag));
+    if (extraTags.length && result) {
+      const markers = await withRedis(
+        'get:tags',
+        (redis) => redis.mGet(extraTags.map(markerKey)),
+        []
+      );
+      if (isExpiredBy(markers, entry.lastModified)) {
+        debug('get EXPIRED', key);
+        this.#drop(entryKey);
+        return null;
+      }
+    }
+
+    debug('get HIT', key, kind);
+    return { value: entry.value, lastModified: entry.lastModified };
+  }
+
+  async set(key, data, ctx = {}) {
+    const kind = data?.kind || ctx.kind;
+    const entryKey = await this.#entryKey(key, kind);
+    const tags = [...new Set([...(ctx.tags || []), ...headerTags(data)])];
+    const entry = { value: data, lastModified: Date.now(), tags };
+
+    fallbackSet(entryKey, entry);
+    debug('set', key, kind, `tags=${tags.length}`);
+
+    await withRedis('set', async (redis) => {
+      const node = await loadNode();
+      if (!node) return;
+
+      let payload;
+      try {
+        payload = node.serialize(entry);
+      } catch (error) {
+        logError('serialize', error);
+        return;
+      }
+
+      const multi = redis.multi().set(entryKey, payload);
+      for (const tag of tags) multi.sAdd(tagKey(tag), entryKey);
+      await multi.exec();
+    });
+  }
+
+  async revalidateTag(tags) {
+    const list = [tags].flat().filter(Boolean);
+    if (!list.length) return;
+
+    for (const [key, hit] of fallbackStore) {
+      if (hit.entry.tags?.some((tag) => list.includes(tag))) fallbackStore.delete(key);
+    }
+
+    const now = String(Date.now());
+    const deleted = await withRedis(
+      'revalidateTag',
+      async (redis) => {
+        const read = redis.multi();
+        for (const tag of list) {
+          // The marker is what invalidates implicit `_N_T_/…` soft tags and any
+          // entry whose tag index was lost — neither of which the index can cover.
+          read.set(markerKey(tag), now, { EX: MARKER_TTL_SECONDS });
+          read.sMembers(tagKey(tag));
+        }
+        const results = await read.exec();
+
+        const keys = new Set();
+        for (let i = 1; i < results.length; i += 2) {
+          for (const member of results[i] || []) keys.add(String(member));
+        }
+
+        const write = redis.multi();
+        for (const key of keys) write.del(key);
+        for (const tag of list) write.del(tagKey(tag));
+        await write.exec();
+
+        return keys.size;
+      },
+      null
+    );
+
+    if (deleted === null) {
+      if (REDIS_ENABLED) {
+        console.error(
+          `[redis-cache] revalidateTag lost while Redis was unavailable: ${list.join(', ')}`
+        );
+      }
+      return;
+    }
+
+    debug('revalidateTag', list.join(','), `deleted=${deleted}`);
+  }
+
+  // Fetch entries outlive a deploy; compiled page payloads must not, or a new
+  // build would serve the previous build's RSC data.
+  async #entryKey(key, kind) {
+    if (kind === 'FETCH') return `${PREFIX}:fetch:${key}`;
+
+    if (this.buildId === undefined) {
+      this.buildId = 'shared';
+      const node = await loadNode();
+      if (node && this.serverDistDir) {
+        try {
+          this.buildId = node
+            .readFileSync(node.join(this.serverDistDir, '..', 'BUILD_ID'), 'utf8')
+            .trim();
+        } catch {
+          // Falls back to a shared namespace.
+        }
+      }
+    }
+
+    return `${PREFIX}:${this.buildId}:page:${key}`;
+  }
+
+  async #decode(entryKey, payload) {
+    const node = await loadNode();
+    if (!node) return undefined;
+    try {
+      return node.deserialize(payload);
+    } catch (error) {
+      logError('deserialize', error);
+      this.#drop(entryKey);
+      return undefined;
+    }
+  }
+
+  #drop(entryKey) {
+    fallbackStore.delete(entryKey);
+    withRedis('drop', (redis) => redis.del(entryKey));
+  }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,17 @@
+import { fileURLToPath } from 'node:url'
+
+// Coolify sets USE_REDIS_CACHE at build time; Vercel never does, so it keeps the
+// built-in Data Cache with no config keys set at all.
+const useRedisCache = process.env.USE_REDIS_CACHE === 'true'
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  ...(useRedisCache
+    ? {
+        cacheHandler: fileURLToPath(new URL('./cache-handler.js', import.meta.url)),
+        cacheMaxMemorySize: 0,
+      }
+    : {}),
   reactStrictMode: true,
   poweredByHeader: false,
   // SEO optimizations

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "react-leaflet": "^5.0.0",
         "react-switch": "^7.1.0",
         "react-tooltip": "^6.0.8",
+        "redis": "^5.12.1",
         "sonner": "^2.0.7"
       },
       "devDependencies": {
@@ -2097,6 +2098,78 @@
         "leaflet": "^1.9.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
+      }
+    },
+    "node_modules/@redis/bloom": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.12.1.tgz",
+      "integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
+      "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.12.1.tgz",
+      "integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.12.1.tgz",
+      "integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.12.1.tgz",
+      "integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -4485,6 +4558,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/color-convert": {
@@ -7813,6 +7895,22 @@
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/redis": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
+      "integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@redis/bloom": "5.12.1",
+        "@redis/client": "5.12.1",
+        "@redis/json": "5.12.1",
+        "@redis/search": "5.12.1",
+        "@redis/time-series": "5.12.1"
+      },
+      "engines": {
+        "node": ">= 18.19.0"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-leaflet": "^5.0.0",
     "react-switch": "^7.1.0",
     "react-tooltip": "^6.0.8",
+    "redis": "^5.12.1",
     "sonner": "^2.0.7"
   },
   "devDependencies": {


### PR DESCRIPTION
Backs the singular Next.js `cacheHandler` with Redis when `USE_REDIS_CACHE=true`, so a self-hosted (Coolify) deploy shares its Data Cache between instances and keeps it across redeploys. Vercel sets neither variable, so no config keys are written at all and the built-in Data Cache is used exactly as before.

No application code changes: all 49 `unstable_cache` call sites and the tag helpers in `utils/cache-tags.ts` are untouched, and nothing migrates to `use cache`.

## How the conditional works

`next.config.js` spreads in `cacheHandler` + `cacheMaxMemorySize: 0` only when the flag is set, using `fileURLToPath(new URL(...))` since `require.resolve` does not exist under `"type": "module"`.

**Building without `REDIS_URL`** is guarded on both `NEXT_PHASE` and the absence of the URL; the build falls back to an in-process cache and never opens a socket. This matters because Coolify deliberately withholds `REDIS_URL` at build time.

## Storage

Entries are `v8.serialize`d, because page values carry `Buffer`s and a `Map<string, Buffer>` that JSON would destroy. `unstable_cache` entries survive a redeploy; rendered pages are namespaced per build id so a new build cannot serve the previous build's payloads.

```
<prefix>:v1:fetch:<key>          unstable_cache — survives deploys
<prefix>:v1:<buildId>:page:<key> APP_PAGE / APP_ROUTE / PAGES / IMAGE
<prefix>:v1:tag:<tag>            SET of entry keys
<prefix>:v1:rt:<tag>             invalidation marker, 30d TTL
```

## Tag invalidation

Tags are indexed as Redis sets, so `revalidateTag` deletes exactly the affected keys — no `KEYS` or `SCAN`. It also writes a per-tag invalidation marker, which is what covers implicit `_N_T_` soft tags (Next never stores those on `set`, so they can never appear in an index) and any index lost to `allkeys-lru` eviction.

## Redis instance requirements

The instance must be configured as a **cache**: `maxmemory` plus `maxmemory-policy allkeys-lru`. Entries carry no TTL by design, so under Redis's actual default (`noeviction`) the keyspace grows until writes fail with OOM and invalidations start being dropped — a worse failure mode than the eviction this design already handles. Documented in the README.

## One incompatibility found and fixed

`app/api/notifications/[id]/route.ts` uses `runtime = 'edge'`, and Next bundles the cache handler into the edge chunk, where a top-level `redis` import fails to resolve `node:crypto` and **breaks the build**. All Node-only imports are therefore lazy. The route itself is unchanged.

## Verification

- Default build (no env vars) registers no handler — `required-server-files.json` shows `cacheHandler: undefined`.
- Coolify build (`USE_REDIS_CACHE=true`, no `REDIS_URL`) succeeds. Measured against a live Redis with a reachable `REDIS_URL` present: **zero connections, zero keys written** during the build.
- Runtime against Redis 7.0: MISS → SET → HIT for both `FETCH` and `APP_PAGE`, page keys correctly namespaced under the real build id, entry TTL `-1` (no imposed expiry), one shared connection.
- 11/11 semantics checks pass, including Buffer/`Map` survival, precise tag deletion, array tags, `{ expire: 0 }`, soft-tag invalidation via marker, no false expiry on writes after invalidation, and graceful degradation on an unreachable Redis.
- Cross-process invalidation confirmed end-to-end: an external process invalidated a tag and the running server saw the miss and re-fetched.
- `eslint` clean for the changed files.

## Known cost

Warm renders are **~2 ms slower**, because `cacheMaxMemorySize: 0` makes every read a network hop where the default keeps a 50 MB in-process LRU. Five batches of 20 requests per configuration:

| | Default | Redis |
|---|---|---|
| `/contributors` | 2.9–3.8 ms | 4.6–6.3 ms |
| `/terms` | 2.7–3.4 ms | 4.6–5.9 ms |

(An earlier revision of this description said 4–6 ms. That came from single unreplicated samples and overstated the cost by roughly 2×; run-to-run variance on identical code is ~1.7 ms, so the figures above are medians over repeated batches.)

Measured on trivial static pages, so still worth re-checking on a real page in Coolify.

## Rollback

Unset `USE_REDIS_CACHE` and rebuild — returns to stock Next.js caching with no code change.

---

Note for deployment: the build requires `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` to prerender `/confirm-email`. Pre-existing behaviour, but Coolify's build environment needs them present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019oMe8t68sQ2TXDavdvJtgT