### PR TITLE
fix(equipment): scope custom equipment to the gang's edition in every…

### DIFF
--- a/supabase/functions/get_equipment_detailed_data.sql
+++ b/supabase/functions/get_equipment_detailed_data.sql
@@ -616,10 +616,8 @@ AS $$
             OR ($4 IS NOT NULL AND COALESCE(ftl.is_ftl, false) = $4) -- fighter's list requested
             OR ($5 IS NOT NULL AND true = $5)                        -- trading post requested
         )
-        -- Unrestricted: only custom equipment from the gang's edition
         AND (
-            NOT ($4 IS NULL AND $5 IS NULL)
-            OR gd.edition_id IS NULL
+            gd.edition_id IS NULL
             OR ce.edition_id = gd.edition_id
         )
 $$;


### PR DESCRIPTION
… picker mode

get_equipment_detailed_data only applied its edition filter when both fighter_type_equipment and equipment_tradingpost were NULL, a combination the app never sends: the picker always passes at least one. Official equipment survived that because its Trading Post and fighter's-list rows are per-edition content in the first place, but custom equipment reaches a gang through ce.user_id = auth.uid(), which offers the owner's entire catalogue regardless of edition -- so an n26 gang was shown its owner's n23 custom items, and an n23 gang its n26 ones.

Apply the filter unconditionally on the custom branch. Production data has 1532 n26 gangs whose owner also owns n23 custom equipment (and 859 n23 gangs the other way round); no custom equipment is currently curated into a custom Trading Post from a different edition, so the change removes only the leak.