### PR TITLE
chore: route test previews through Coolify

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -82,7 +82,7 @@ jobs:
             "https://coolify.mundamanager.com/api/v1/applications/$COOLIFY_TEST_APP_UUID"
 
           curl --fail-with-body --silent --show-error \
-            -X GET \
+            -X POST \
             -H "Authorization: Bearer $COOLIFY_API_TOKEN" \
             "https://coolify.mundamanager.com/api/v1/deploy?uuid=$COOLIFY_TEST_APP_UUID"
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -59,6 +59,33 @@ jobs:
             -m githubOrg="$GIT_ORG" \
             -m githubRepo="$GIT_REPO")
           echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      # Keep the existing preview-test workflow, but serve the selected PR from
+      # the fixed Coolify test application instead of moving a Vercel alias.
+      # Every push to the labeled PR re-deploys its branch to test.mundamanager.com.
+      - name: Deploy preview-test branch to Coolify
+        if: contains(github.event.pull_request.labels.*.name, 'preview-test')
+        env:
+          COOLIFY_API_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          COOLIFY_TEST_APP_UUID: ${{ secrets.COOLIFY_TEST_APP_UUID }}
+          GIT_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          payload=$(jq -nc --arg branch "$GIT_REF" '{git_branch:$branch}')
+
+          curl --fail-with-body --silent --show-error \
+            -X PATCH \
+            -H "Authorization: Bearer $COOLIFY_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            "https://coolify.mundamanager.com/api/v1/applications/$COOLIFY_TEST_APP_UUID"
+
+          curl --fail-with-body --silent --show-error \
+            -X GET \
+            -H "Authorization: Bearer $COOLIFY_API_TOKEN" \
+            "https://coolify.mundamanager.com/api/v1/deploy?uuid=$COOLIFY_TEST_APP_UUID"
+
       - name: Comment preview URL on PR
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -59,14 +59,6 @@ jobs:
             -m githubOrg="$GIT_ORG" \
             -m githubRepo="$GIT_REPO")
           echo "url=$url" >> "$GITHUB_OUTPUT"
-      # Point test.mundamanager.com at this deployment, but only for the one PR
-      # labeled `preview-test`. Every push to that PR re-points the domain, so it
-      # always serves the PR's latest changes; move the label to switch PRs.
-      - name: Point test domain at this deployment
-        if: contains(github.event.pull_request.labels.*.name, 'preview-test')
-        run: |
-          vercel alias set "${{ steps.deploy.outputs.url }}" test.mundamanager.com \
-            --token=${{ secrets.VERCEL_TOKEN }} --scope="$VERCEL_ORG_ID"
       - name: Comment preview URL on PR
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
Preserves the existing `preview-test` label workflow while moving `test.mundamanager.com` from Vercel to the fixed Coolify test application.

When a PR has the `preview-test` label, the workflow now:
1. Updates the Coolify test application's `git_branch` to the PR branch.
2. Triggers a deployment of that Coolify application.
3. Repeats this on subsequent pushes to the labeled PR, so `test.mundamanager.com` stays on the PR's latest commit.

Normal Vercel PR preview deployments remain unchanged.

Required GitHub Actions secrets before merging/testing:
- `COOLIFY_API_TOKEN` — Coolify API token with permission to update/deploy the test application.
- `COOLIFY_TEST_APP_UUID` — UUID of the Coolify application serving `test.mundamanager.com`.