### PR TITLE
feat(gang): add dedicated Resources modal with optional log reasons

### DIFF
--- a/app/actions/logs/gang-resource-logs.ts
+++ b/app/actions/logs/gang-resource-logs.ts
@@ -12,11 +12,46 @@ export interface LogGangResourceChangesParams {
   oldState: GangResourceState;
   newState: GangResourceState;
   user_id?: string;
+  /** Optional per-resource reasons keyed by the same names used in oldState/newState */
+  reasons?: Record<string, string>;
+}
+
+function capitalizeResourceName(resourceName: string): string {
+  return resourceName.charAt(0).toUpperCase() + resourceName.slice(1);
+}
+
+/** First line only: "Reputation increased by 5 (reason)" */
+function formatResourceDeltaSummary(
+  displayName: string,
+  oldValue: number,
+  newValue: number,
+  reason?: string
+): string {
+  const delta = Math.abs(newValue - oldValue);
+  const direction = newValue > oldValue ? 'increased' : 'decreased';
+  return reason
+    ? `${displayName} ${direction} by ${delta} (${reason})`
+    : `${displayName} ${direction} by ${delta}`;
+}
+
+/**
+ * Two-line resource change description, e.g.:
+ * Reputation increased by 5 (reason)
+ * Reputation: 10 → 15
+ */
+function formatResourceChangeDescription(
+  displayName: string,
+  oldValue: number,
+  newValue: number,
+  reason?: string
+): string {
+  const summary = formatResourceDeltaSummary(displayName, oldValue, newValue, reason);
+  return `${summary}\n${displayName}: ${oldValue} → ${newValue}`;
 }
 
 export async function logGangResourceChanges(params: LogGangResourceChangesParams): Promise<GangLogActionResult> {
   try {
-    const { gang_id, oldState, newState, user_id } = params;
+    const { gang_id, oldState, newState, user_id, reasons } = params;
     const logPromises: Promise<GangLogActionResult>[] = [];
 
     // Check if credits, rating, or wealth changed - use new format
@@ -35,7 +70,6 @@ export async function logGangResourceChanges(params: LogGangResourceChangesParam
         oldCredits !== undefined && newCredits !== undefined &&
         oldRating !== undefined && newRating !== undefined &&
         oldWealth !== undefined && newWealth !== undefined) {
-      // Create single log entry with formatted financial changes
       const financialChanges = formatFinancialChanges(
         oldCredits,
         newCredits,
@@ -53,10 +87,21 @@ export async function logGangResourceChanges(params: LogGangResourceChangesParam
         actionType = 'credits_spent';
       }
 
+      let description = financialChanges;
+      if (oldCredits !== newCredits) {
+        const summary = formatResourceDeltaSummary(
+          'Credits',
+          oldCredits,
+          newCredits,
+          reasons?.['credits']
+        );
+        description = `${summary}\n${financialChanges}`;
+      }
+
       logPromises.push(createGangLog({
         gang_id,
         action_type: actionType,
-        description: financialChanges,
+        description,
         user_id
       }));
     }
@@ -72,14 +117,18 @@ export async function logGangResourceChanges(params: LogGangResourceChangesParam
 
       if (oldValue !== newValue) {
         const increased = newValue > oldValue;
-        const capitalizedName = resourceName.charAt(0).toUpperCase() + resourceName.slice(1);
+        const capitalizedName = capitalizeResourceName(resourceName);
         const actionType = `${capitalizedName} ${increased ? 'gained' : 'spent'}`;
-        const description = `${capitalizedName} ${increased ? 'increased' : 'decreased'} from ${oldValue} to ${newValue}`;
 
         logPromises.push(createGangLog({
           gang_id,
           action_type: actionType,
-          description,
+          description: formatResourceChangeDescription(
+            capitalizedName,
+            oldValue,
+            newValue,
+            reasons?.[resourceName]
+          ),
           user_id
         }));
       }

--- a/app/actions/update-gang.ts
+++ b/app/actions/update-gang.ts
@@ -7,6 +7,7 @@ import { updateGangFinancials } from '@/utils/gang-rating-and-wealth';
 import { getAuthenticatedUser } from '@/utils/auth';
 import { logGangResourceChanges } from './logs/gang-resource-logs';
 import { gangEditionSlug, hasTradePoints } from '@/types/edition';
+import { sanitizeResourceReason } from '@/utils/sanitize-resource-reason';
 
 interface UpdateGangParams {
   gang_id: string;
@@ -14,6 +15,7 @@ interface UpdateGangParams {
   name?: string;
   credits?: number;
   credits_operation?: 'add' | 'subtract';
+  credits_reason?: string;
   alignment?: string;
   gang_colour?: string;
   alliance_id?: string | null;
@@ -21,14 +23,17 @@ interface UpdateGangParams {
   gang_origin_id?: string | null;
   reputation?: number;
   reputation_operation?: 'add' | 'subtract';
+  reputation_reason?: string;
   trade_points?: number;
   trade_points_operation?: 'add' | 'subtract';
+  trade_points_reason?: string;
   // Dynamic resources - array of updates for campaign_gang_resources
   resources?: Array<{
     resource_id: string;
     resource_name: string;
     is_custom: boolean;
     quantity_delta: number;
+    reason?: string;
   }>;
   gang_variants?: string[];
   note?: string;
@@ -460,6 +465,28 @@ export async function updateGang(params: UpdateGangParams): Promise<UpdateGangRe
         newState['trade points'] = updates.trade_points ?? (gang.trade_points || 0);
       }
 
+      const reasons: Record<string, string> = {};
+      const creditsReason = sanitizeResourceReason(params.credits_reason);
+      if (creditsReason) {
+        reasons['credits'] = creditsReason;
+      }
+      const reputationReason = sanitizeResourceReason(params.reputation_reason);
+      if (reputationReason) {
+        reasons['reputation'] = reputationReason;
+      }
+      const tradePointsReason = sanitizeResourceReason(params.trade_points_reason);
+      if (tradePointsReason) {
+        reasons['trade points'] = tradePointsReason;
+      }
+      if (params.resources) {
+        for (const resource of params.resources) {
+          const reason = sanitizeResourceReason(resource.reason);
+          if (reason) {
+            reasons[resource.resource_name] = reason;
+          }
+        }
+      }
+
       // Only log if something changed
       if (Object.keys(oldResourceStates).length > 0 || creditsChanged || (params.reputation !== undefined && params.reputation_operation) || tradePointsChanged) {
         // Use gang owner's user_id so logs are attributed to the owner even
@@ -469,7 +496,8 @@ export async function updateGang(params: UpdateGangParams): Promise<UpdateGangRe
           gang_id: params.gang_id,
           oldState,
           newState,
-          user_id: gang.user_id ?? undefined
+          user_id: gang.user_id ?? undefined,
+          ...(Object.keys(reasons).length > 0 ? { reasons } : {}),
         });
       }
     } catch (logError) {

--- a/components/gang/gang-edit-modal.tsx
+++ b/components/gang/gang-edit-modal.tsx
@@ -12,21 +12,14 @@ import { HexColorPicker } from "react-colorful";
 import { groupAlliancesByType } from "@/utils/allianceRank";
 import { gangVariantRank } from "@/utils/gangVariantRank";
 import { useQuery } from '@tanstack/react-query';
-import { ResourceUpdate } from '@/types/gang';
 import { deleteGang } from '@/app/actions/delete-gang';
-import { hasAlignment, hasTradePoints, sameEditionForDisplay } from '@/types/edition';
+import { hasAlignment, sameEditionForDisplay } from '@/types/edition';
 
 interface GangUpdates {
   name?: string;
-  credits?: number;
-  credits_operation?: 'add' | 'subtract';
   alignment?: string;
   alliance_id?: string | null;
   alliance_name?: string;
-  reputation?: number;
-  reputation_operation?: 'add' | 'subtract';
-  trade_points?: number;
-  trade_points_operation?: 'add' | 'subtract';
   gang_variants?: string[];
   gang_colour?: string;
   gang_affiliation_id?: string | null;
@@ -37,15 +30,6 @@ interface GangUpdates {
   campaign_allegiance_id?: string | null;
   campaign_allegiance_is_custom?: boolean;
   campaign_id?: string;
-  // New resource updates from normalised tables
-  resourceUpdates?: ResourceUpdate[];
-}
-
-interface CampaignResource {
-  resource_id: string;
-  resource_name: string;
-  quantity: number;
-  is_custom: boolean;
 }
 
 interface Campaign {
@@ -55,8 +39,6 @@ interface Campaign {
     id: string;
     name: string;
   } | null;
-  // Normalised resources
-  resources?: CampaignResource[];
 }
 
 interface GangEditModalProps {
@@ -67,9 +49,6 @@ interface GangEditModalProps {
   // Gang data
   gangId: string;
   gangName: string;
-  credits: number;
-  reputation: number;
-  tradePoints: number;
   editionSlug?: string | null;
   alignment: string;
   allianceId: string | null;
@@ -86,7 +65,7 @@ interface GangEditModalProps {
   gangTypeHasOrigin: boolean;
   hidden: boolean;
 
-  // Campaign features (includes dynamic resources)
+  // Campaign features
   campaigns?: Campaign[];
 
   // Permissions - controls Delete button visibility
@@ -102,20 +81,17 @@ interface GangEditModalProps {
  * 
  * Extracted from gang.tsx to improve component maintainability.
  * Handles all gang editing functionality including:
- * - Basic gang info (name, credits, reputation)
+ * - Basic gang info (name, visibility)
  * - Alignment and alliance management
  * - Gang variants selection
  * - Colour picker
- * - Campaign-specific resources (meat, scavenging rolls, exploration points)
+ * - Campaign allegiance
  */
 export default function GangEditModal({
   isOpen,
   onClose,
   gangId,
   gangName,
-  credits,
-  reputation,
-  tradePoints,
   editionSlug,
   alignment,
   allianceId,
@@ -167,9 +143,6 @@ export default function GangEditModal({
   // Single form state object instead of multiple individual states
   const [formState, setFormState] = useState({
     name: gangName,
-    credits: '',  // delta inputs start empty
-    reputation: '',
-    trade_points: '',
     alignment: effectiveAlignment,
     allianceId: allianceId || '',
     gangColour: gangColour,
@@ -181,10 +154,6 @@ export default function GangEditModal({
     campaignAllegianceId: effectiveCurrentAllegianceId
   });
   
-  // Dynamic resource deltas state - tracks changes for each normalised resource
-  // Key: resource_id, Value: delta string (for input field)
-  const [resourceDeltas, setResourceDeltas] = useState<Record<string, string>>({});
-
   // Alliance management state
   const [allianceList, setAllianceList] = useState<Array<{
     id: string;
@@ -252,9 +221,6 @@ export default function GangEditModal({
       setFormState(prev => ({
         ...prev,
         name: gangName,
-        credits: '',
-        reputation: '',
-        trade_points: '',
         alignment: effectiveAlignment,
         allianceId: allianceId || '',
         gangColour: gangColour,
@@ -265,8 +231,6 @@ export default function GangEditModal({
         hidden: hidden,
         campaignAllegianceId: effectiveCurrentAllegianceId
       }));
-
-      setResourceDeltas({});
     }
   }
 
@@ -468,53 +432,6 @@ export default function GangEditModal({
       updates.gang_variants = formState.gangVariants.map(v => v.id);
     }
 
-    // Handle resource deltas - only include if non-empty and non-zero
-    const creditsDifference = parseInt(formState.credits) || 0;
-    if (credits + creditsDifference < 0) {
-      toast.error('Insufficient credits', {
-        description: `Cannot subtract ${Math.abs(creditsDifference)} credits. Current balance: ${credits}`
-      });
-      return;
-    }
-    if (creditsDifference !== 0) {
-      updates.credits = Math.abs(creditsDifference);
-      updates.credits_operation = creditsDifference >= 0 ? 'add' : 'subtract';
-    }
-
-    const reputationDifference = parseInt(formState.reputation) || 0;
-    if (reputationDifference !== 0) {
-      updates.reputation = Math.abs(reputationDifference);
-      updates.reputation_operation = reputationDifference >= 0 ? 'add' : 'subtract';
-    }
-
-    if (hasTradePoints(editionSlug)) {
-      const tradePointsDifference = parseInt(formState.trade_points) || 0;
-      if (tradePointsDifference !== 0) {
-        updates.trade_points = Math.abs(tradePointsDifference);
-        updates.trade_points_operation = tradePointsDifference >= 0 ? 'add' : 'subtract';
-      }
-    }
-
-    // Handle dynamic resource deltas from normalised tables
-    const resourceUpdatesList: ResourceUpdate[] = [];
-    const campaignResources = campaigns?.[0]?.resources || [];
-    
-    for (const resource of campaignResources) {
-      const deltaStr = resourceDeltas[resource.resource_id];
-      const delta = parseInt(deltaStr) || 0;
-      if (delta !== 0) {
-        resourceUpdatesList.push({
-          resource_id: resource.resource_id,
-          is_custom: resource.is_custom,
-          quantity_delta: delta
-        });
-      }
-    }
-    
-    if (resourceUpdatesList.length > 0) {
-      updates.resourceUpdates = resourceUpdatesList;
-    }
-
     // Close modal immediately for instant UX (optimistic update will handle UI)
     onClose();
 
@@ -603,86 +520,6 @@ export default function GangEditModal({
           />
         </div>
       )}
-
-      {/* Resources Section */}
-      <div className="space-y-4">
-        <div>
-          <p className="text-base font-medium">Resources</p>
-          <p className="text-xs text-muted-foreground mt-1">Add or remove (e.g. 5 or -5)</p>
-        </div>
-        <div className="grid grid-cols-2 gap-4">
-          <div className="space-y-2">
-            <p className="text-xs font-medium">Credits
-              <span className="text-xs text-muted-foreground"> (Current: {credits})</span>
-            </p>
-            <Input
-              type="tel"
-              inputMode="url"
-              pattern="-?[0-9]+"
-              value={formState.credits}
-              onChange={(e) => setFormState(prev => ({ ...prev, credits: e.target.value }))}
-              className="flex-1"
-              placeholder="0"
-            />
-          </div>
-
-          <div className="space-y-2">
-            <p className="text-xs font-medium">
-              Reputation
-              <span className="text-xs text-muted-foreground"> (Current: {reputation})</span>
-            </p>
-            <Input
-              type="tel"
-              inputMode="url"
-              pattern="-?[0-9]+"
-              value={formState.reputation}
-              onChange={(e) => setFormState(prev => ({ ...prev, reputation: e.target.value }))}
-              className="flex-1"
-              placeholder="0"
-            />
-          </div>
-
-          {hasTradePoints(editionSlug) && (
-            <div className="space-y-2">
-              <p className="text-xs font-medium">
-                Trade Points
-                <span className="text-xs text-muted-foreground"> (Current: {tradePoints})</span>
-              </p>
-              <Input
-                type="tel"
-                inputMode="url"
-                pattern="-?[0-9]+"
-                value={formState.trade_points}
-                onChange={(e) => setFormState(prev => ({ ...prev, trade_points: e.target.value }))}
-                className="flex-1"
-                placeholder="0"
-              />
-            </div>
-          )}
-
-          {/* Dynamic Campaign Resources */}
-          {campaigns?.[0]?.resources?.map((resource) => (
-            <div key={resource.resource_id} className="space-y-2">
-              <p className="text-xs font-medium">
-                {resource.resource_name}
-                <span className="text-xs text-muted-foreground"> (Current: {resource.quantity})</span>
-              </p>
-              <Input
-                type="tel"
-                inputMode="url"
-                pattern="-?[0-9]+"
-                value={resourceDeltas[resource.resource_id] || ''}
-                onChange={(e) => setResourceDeltas(prev => ({
-                  ...prev,
-                  [resource.resource_id]: e.target.value
-                }))}
-                className="flex-1"
-                placeholder="0"
-              />
-            </div>
-          ))}
-        </div>
-      </div>
 
       <div className="space-y-2">
         <p className="text-sm font-medium">Gang Visibility</p>

--- a/components/gang/gang-resources-modal.tsx
+++ b/components/gang/gang-resources-modal.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Input } from '../ui/input';
+import Modal from '@/components/ui/modal';
+import { toast } from 'sonner';
+import { ResourceUpdate } from '@/types/gang';
+import { hasTradePoints } from '@/types/edition';
+import {
+  RESOURCE_REASON_MAX_LENGTH,
+  sanitizeResourceReason,
+} from '@/utils/sanitize-resource-reason';
+
+interface ResourceUpdates {
+  credits?: number;
+  credits_operation?: 'add' | 'subtract';
+  credits_reason?: string;
+  reputation?: number;
+  reputation_operation?: 'add' | 'subtract';
+  reputation_reason?: string;
+  trade_points?: number;
+  trade_points_operation?: 'add' | 'subtract';
+  trade_points_reason?: string;
+  resourceUpdates?: ResourceUpdate[];
+}
+
+interface CampaignResource {
+  resource_id: string;
+  resource_name: string;
+  quantity: number;
+  is_custom: boolean;
+}
+
+interface Campaign {
+  campaign_id: string;
+  campaign_gang_id: string;
+  resources?: CampaignResource[];
+}
+
+interface GangResourcesModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  credits: number;
+  reputation: number;
+  tradePoints: number;
+  editionSlug?: string | null;
+  campaigns?: Campaign[];
+  onSave: (updates: ResourceUpdates) => Promise<boolean>;
+}
+
+function isNonZeroDelta(value: string | undefined): boolean {
+  return (parseInt(value || '') || 0) !== 0;
+}
+
+/**
+ * Dedicated modal for adjusting gang resources (credits, reputation,
+ * trade points, and campaign-specific resources).
+ */
+export default function GangResourcesModal({
+  isOpen,
+  onClose,
+  credits,
+  reputation,
+  tradePoints,
+  editionSlug,
+  campaigns,
+  onSave,
+}: GangResourcesModalProps) {
+  const [formState, setFormState] = useState({
+    credits: '',
+    reputation: '',
+    trade_points: '',
+  });
+  const [resourceDeltas, setResourceDeltas] = useState<Record<string, string>>({});
+  const [resourceReasons, setResourceReasons] = useState<Record<string, string>>({});
+
+  const resetKey = `${isOpen}-${credits}-${reputation}-${tradePoints}`;
+  const [prevResetKey, setPrevResetKey] = useState(resetKey);
+  if (resetKey !== prevResetKey) {
+    setPrevResetKey(resetKey);
+    if (isOpen) {
+      setFormState({
+        credits: '',
+        reputation: '',
+        trade_points: '',
+      });
+      setResourceDeltas({});
+      setResourceReasons({});
+    }
+  }
+
+  const setReason = (key: string, value: string) => {
+    setResourceReasons(prev => ({ ...prev, [key]: value }));
+  };
+
+  const handleSave = async (): Promise<boolean> => {
+    const updates: ResourceUpdates = {};
+
+    const creditsDifference = parseInt(formState.credits) || 0;
+    if (credits + creditsDifference < 0) {
+      toast.error('Insufficient credits', {
+        description: `Cannot subtract ${Math.abs(creditsDifference)} credits. Current balance: ${credits}`,
+      });
+      return false;
+    }
+    if (creditsDifference !== 0) {
+      updates.credits = Math.abs(creditsDifference);
+      updates.credits_operation = creditsDifference >= 0 ? 'add' : 'subtract';
+      const reason = sanitizeResourceReason(resourceReasons['credits']);
+      if (reason) updates.credits_reason = reason;
+    }
+
+    const reputationDifference = parseInt(formState.reputation) || 0;
+    if (reputationDifference !== 0) {
+      updates.reputation = Math.abs(reputationDifference);
+      updates.reputation_operation = reputationDifference >= 0 ? 'add' : 'subtract';
+      const reason = sanitizeResourceReason(resourceReasons['reputation']);
+      if (reason) updates.reputation_reason = reason;
+    }
+
+    if (hasTradePoints(editionSlug)) {
+      const tradePointsDifference = parseInt(formState.trade_points) || 0;
+      if (tradePointsDifference !== 0) {
+        updates.trade_points = Math.abs(tradePointsDifference);
+        updates.trade_points_operation = tradePointsDifference >= 0 ? 'add' : 'subtract';
+        const reason = sanitizeResourceReason(resourceReasons['trade_points']);
+        if (reason) updates.trade_points_reason = reason;
+      }
+    }
+
+    const resourceUpdatesList: ResourceUpdate[] = [];
+    const campaignResources = campaigns?.[0]?.resources || [];
+
+    for (const resource of campaignResources) {
+      const deltaStr = resourceDeltas[resource.resource_id];
+      const delta = parseInt(deltaStr) || 0;
+      if (delta !== 0) {
+        const reason = sanitizeResourceReason(resourceReasons[resource.resource_id]);
+        resourceUpdatesList.push({
+          resource_id: resource.resource_id,
+          is_custom: resource.is_custom,
+          quantity_delta: delta,
+          ...(reason ? { reason } : {}),
+        });
+      }
+    }
+
+    if (resourceUpdatesList.length > 0) {
+      updates.resourceUpdates = resourceUpdatesList;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return false;
+    }
+
+    return await onSave(updates);
+  };
+
+  const reasonInput = (key: string) => (
+    <Input
+      type="text"
+      value={resourceReasons[key] || ''}
+      onChange={(e) => setReason(key, e.target.value)}
+      placeholder="Reason (optional)"
+      maxLength={RESOURCE_REASON_MAX_LENGTH}
+      className="mt-1.5"
+    />
+  );
+
+  const modalContent = (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <p className="text-xs font-medium">Credits
+            <span className="text-xs text-muted-foreground"> (Current: {credits})</span>
+          </p>
+          <Input
+            type="tel"
+            inputMode="url"
+            pattern="-?[0-9]+"
+            value={formState.credits}
+            onChange={(e) => setFormState(prev => ({ ...prev, credits: e.target.value }))}
+            className="flex-1"
+            placeholder="0"
+          />
+          {isNonZeroDelta(formState.credits) && reasonInput('credits')}
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs font-medium">
+            Reputation
+            <span className="text-xs text-muted-foreground"> (Current: {reputation})</span>
+          </p>
+          <Input
+            type="tel"
+            inputMode="url"
+            pattern="-?[0-9]+"
+            value={formState.reputation}
+            onChange={(e) => setFormState(prev => ({ ...prev, reputation: e.target.value }))}
+            className="flex-1"
+            placeholder="0"
+          />
+          {isNonZeroDelta(formState.reputation) && reasonInput('reputation')}
+        </div>
+
+        {hasTradePoints(editionSlug) && (
+          <div className="space-y-2">
+            <p className="text-xs font-medium">
+              Trade Points
+              <span className="text-xs text-muted-foreground"> (Current: {tradePoints})</span>
+            </p>
+            <Input
+              type="tel"
+              inputMode="url"
+              pattern="-?[0-9]+"
+              value={formState.trade_points}
+              onChange={(e) => setFormState(prev => ({ ...prev, trade_points: e.target.value }))}
+              className="flex-1"
+              placeholder="0"
+            />
+            {isNonZeroDelta(formState.trade_points) && reasonInput('trade_points')}
+          </div>
+        )}
+
+        {campaigns?.[0]?.resources?.map((resource) => (
+          <div key={resource.resource_id} className="space-y-2">
+            <p className="text-xs font-medium">
+              {resource.resource_name}
+              <span className="text-xs text-muted-foreground"> (Current: {resource.quantity})</span>
+            </p>
+            <Input
+              type="tel"
+              inputMode="url"
+              pattern="-?[0-9]+"
+              value={resourceDeltas[resource.resource_id] || ''}
+              onChange={(e) => setResourceDeltas(prev => ({
+                ...prev,
+                [resource.resource_id]: e.target.value,
+              }))}
+              className="flex-1"
+              placeholder="0"
+            />
+            {isNonZeroDelta(resourceDeltas[resource.resource_id]) && reasonInput(resource.resource_id)}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      {isOpen && (
+        <Modal
+          title="Resources"
+          helper="Add or remove resources (e.g. 5 or -5)"
+          content={modalContent}
+          onClose={onClose}
+          onConfirm={handleSave}
+          confirmText="Save Changes"
+        />
+      )}
+    </>
+  );
+}

--- a/components/gang/gang-resources-modal.tsx
+++ b/components/gang/gang-resources-modal.tsx
@@ -150,6 +150,7 @@ export default function GangResourcesModal({
     }
 
     if (Object.keys(updates).length === 0) {
+      toast.message('No changes to save');
       return false;
     }
 

--- a/components/gang/gang.tsx
+++ b/components/gang/gang.tsx
@@ -21,6 +21,7 @@ import { toJpeg } from 'html-to-image';
 import LogModal from '../log-modal';
 import { ViewModeDropdown, isGangPageViewMode, type GangPageViewMode } from './ViewModeDropdown';
 import GangEditModal from './gang-edit-modal';
+import GangResourcesModal from './gang-resources-modal';
 import { UserPermissions } from '@/types/user-permissions';
 import { updateGangPositioning } from '@/app/actions/update-gang-positioning';
 import { FaRegCopy } from 'react-icons/fa';
@@ -216,6 +217,7 @@ export default function Gang({
     });
   }, [campaigns, currentAllegiance, campaignResources]);
   const [showEditModal, setShowEditModal] = useState(false);
+  const [showResourcesModal, setShowResourcesModal] = useState(false);
   const [showAddFighterModal, setShowAddFighterModal] = useState(false);
   const [showAddVehicleModal, setShowAddVehicleModal] = useState(false);
   const [positions, setPositions] = useState<Record<number, string>>(positioning);
@@ -536,6 +538,22 @@ export default function Gang({
         setGangIsVariant(newVariants.length > 0);
       }
 
+      if (Array.isArray(updates.resources) && updates.resources.length > 0) {
+        const updatedResources = campaignResources.map(resource => {
+          const update = updates.resources.find(
+            (u: { resource_id: string; quantity_delta: number }) => u.resource_id === resource.resource_id
+          );
+          if (update) {
+            return {
+              ...resource,
+              quantity: resource.quantity + update.quantity_delta
+            };
+          }
+          return resource;
+        });
+        setCampaignResources(updatedResources);
+      }
+
       return { snapshot };
     },
     onError: (error, _variables, context) => {
@@ -578,68 +596,25 @@ export default function Gang({
           setGangVariants(result.data.gang_variants);
           setGangIsVariant(result.data.gang_variants.length > 0);
         }
-      }
-
-      // Show success toast
-      toast.success("Gang updated successfully");
-    }
-  });
-
-  // TanStack Query mutation for resource updates with optimistic updates
-  const updateResourceMutation = useMutation({
-    mutationFn: async (resourceUpdates: Array<{
-      campaign_gang_id: string;
-      resource_id: string;
-      resource_name: string;
-      is_custom: boolean;
-      quantity_delta: number;
-    }>) => {
-      const { updateGang } = await import('@/app/actions/update-gang');
-      if (resourceUpdates.length === 0) return { success: true };
-      
-      const campaignGangId = resourceUpdates[0].campaign_gang_id;
-      const resources = resourceUpdates.map(r => ({
-        resource_id: r.resource_id,
-        resource_name: r.resource_name,
-        is_custom: r.is_custom,
-        quantity_delta: r.quantity_delta
-      }));
-      
-      return updateGang({
-        gang_id: id,
-        campaign_gang_id: campaignGangId,
-        resources
-      });
-    },
-    onMutate: async (resourceUpdates) => {
-      // Snapshot previous resources for rollback
-      const snapshot = { campaignResources: [...campaignResources] };
-
-      // Apply optimistic updates
-      const updatedResources = campaignResources.map(resource => {
-        const update = resourceUpdates.find(u => u.resource_id === resource.resource_id);
-        if (update) {
-          return {
-            ...resource,
-            quantity: resource.quantity + update.quantity_delta
-          };
+        if (result.data.resources && result.data.resources.length > 0) {
+          setCampaignResources(prev => prev.map(resource => {
+            const updated = result.data!.resources!.find(
+              (r: { resource_id: string; quantity: number }) => r.resource_id === resource.resource_id
+            );
+            return updated
+              ? { ...resource, quantity: updated.quantity }
+              : resource;
+          }));
         }
-        return resource;
-      });
-      setCampaignResources(updatedResources);
-
-      return { snapshot };
-    },
-    onError: (error, _variables, context) => {
-      // Rollback on error
-      if (context?.snapshot) {
-        setCampaignResources(context.snapshot.campaignResources);
       }
-      console.error('Error updating resources:', error);
-      toast.error(error instanceof Error ? error.message : 'Failed to update resources');
-    },
-    onSuccess: () => {
-      toast.success("Resources updated successfully");
+
+      const resourceOnly =
+        Array.isArray(variables.resources) &&
+        variables.resources.length > 0 &&
+        !Object.keys(variables).some(
+          (key) => !['resources', 'campaign_gang_id'].includes(key) && !key.endsWith('_reason')
+        );
+      toast.success(resourceOnly ? 'Resources updated successfully' : 'Gang updated successfully');
     }
   });
 
@@ -706,28 +681,31 @@ export default function Gang({
         }
       }
       
-      // Handle resource updates if present
-      if (updates.resourceUpdates && updates.resourceUpdates.length > 0) {
+      // Fold campaign resource updates into the same updateGang call as credits/etc.
+      if (gangUpdates.resourceUpdates && gangUpdates.resourceUpdates.length > 0) {
         const campaignGangId = campaigns?.[0]?.campaign_gang_id;
-        if (campaignGangId) {
-          const resourceUpdatesWithCampaignGang = updates.resourceUpdates.map((r: ResourceUpdate) => {
-            // Look up resource_name from campaignResources
-            const resource = campaignResources.find(cr => cr.resource_id === r.resource_id);
-            return {
-              campaign_gang_id: campaignGangId,
-              resource_id: r.resource_id,
-              resource_name: resource?.resource_name || r.resource_name || 'Unknown Resource',
-              is_custom: r.is_custom,
-              quantity_delta: r.quantity_delta
-            };
+        if (!campaignGangId) {
+          delete gangUpdates.resourceUpdates;
+          toast.error('Cannot update campaign resources', {
+            description: 'This gang is not linked to a campaign.',
           });
-          await updateResourceMutation.mutateAsync(resourceUpdatesWithCampaignGang);
+          throw new Error('Missing campaign_gang_id for resource updates');
         }
-        // Remove resourceUpdates from gangUpdates since they're handled separately
+        gangUpdates.campaign_gang_id = campaignGangId;
+        gangUpdates.resources = gangUpdates.resourceUpdates.map((r: ResourceUpdate) => {
+          const resource = campaignResources.find(cr => cr.resource_id === r.resource_id);
+          return {
+            resource_id: r.resource_id,
+            resource_name: resource?.resource_name || r.resource_name || 'Unknown Resource',
+            is_custom: r.is_custom,
+            quantity_delta: r.quantity_delta,
+            ...(r.reason ? { reason: r.reason } : {}),
+          };
+        });
         delete gangUpdates.resourceUpdates;
       }
       
-      // Update gang fields (only if there are any non-allegiance updates)
+      // Update gang fields (+ optional resources) in one server call
       if (Object.keys(gangUpdates).length > 0) {
         await updateGangMutation.mutateAsync(gangUpdates);
       }
@@ -957,6 +935,13 @@ export default function Gang({
                 <div className="flex gap-2">
                   {additionalButtons}
                   <Button
+                    onClick={() => setShowResourcesModal(true)}
+                    disabled={!userPermissions?.canEdit}
+                    className="bg-neutral-900 text-white hover:bg-gray-800 print:hidden disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    Resources
+                  </Button>
+                  <Button
                     onClick={handleEditModalOpen}
                     disabled={!userPermissions?.canEdit}
                     className="bg-neutral-900 text-white hover:bg-gray-800 print:hidden disabled:opacity-50 disabled:cursor-not-allowed"
@@ -978,6 +963,13 @@ export default function Gang({
               </div>
               <div className="flex gap-2">
                 {additionalButtons}
+                <Button
+                  onClick={() => setShowResourcesModal(true)}
+                  disabled={!userPermissions?.canEdit}
+                  className="bg-neutral-900 text-white hover:bg-gray-800 print:hidden disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  Resources
+                </Button>
                 <Button
                   onClick={handleEditModalOpen}
                   disabled={!userPermissions?.canEdit}
@@ -1268,9 +1260,6 @@ export default function Gang({
             onClose={() => setShowEditModal(false)}
             gangId={id}
             gangName={name}
-            credits={credits}
-            reputation={reputation}
-            tradePoints={tradePoints}
             editionSlug={edition_slug}
             isGangOwner={userPermissions?.isOwner}
             isAdmin={userPermissions?.isAdmin}
@@ -1288,6 +1277,17 @@ export default function Gang({
             gangOriginCategoryName={gangOriginCategoryName}
             gangTypeHasOrigin={gang_type_has_origin || false}
             hidden={hidden}
+            campaigns={campaignsWithOptimisticData}
+            onSave={handleGangUpdate}
+          />
+
+          <GangResourcesModal
+            isOpen={showResourcesModal}
+            onClose={() => setShowResourcesModal(false)}
+            credits={credits}
+            reputation={reputation}
+            tradePoints={tradePoints}
+            editionSlug={edition_slug}
             campaigns={campaignsWithOptimisticData}
             onSave={handleGangUpdate}
           />

--- a/components/gang/gang.tsx
+++ b/components/gang/gang.tsx
@@ -608,13 +608,24 @@ export default function Gang({
         }
       }
 
-      const resourceOnly =
-        Array.isArray(variables.resources) &&
-        variables.resources.length > 0 &&
-        !Object.keys(variables).some(
-          (key) => !['resources', 'campaign_gang_id'].includes(key) && !key.endsWith('_reason')
-        );
-      toast.success(resourceOnly ? 'Resources updated successfully' : 'Gang updated successfully');
+      const resourceUpdateKeys = new Set([
+        'resources',
+        'campaign_gang_id',
+        'credits',
+        'credits_operation',
+        'credits_reason',
+        'reputation',
+        'reputation_operation',
+        'reputation_reason',
+        'trade_points',
+        'trade_points_operation',
+        'trade_points_reason',
+      ]);
+      const variableKeys = Object.keys(variables);
+      const isResourceUpdate =
+        variableKeys.length > 0 &&
+        variableKeys.every((key) => resourceUpdateKeys.has(key));
+      toast.success(isResourceUpdate ? 'Resources updated successfully' : 'Gang updated successfully');
     }
   });
 

--- a/types/gang.ts
+++ b/types/gang.ts
@@ -72,4 +72,5 @@ export interface ResourceUpdate {
   resource_name?: string;  // Optional - can be looked up
   is_custom: boolean;
   quantity_delta: number;
-} 
+  reason?: string;
+}

--- a/utils/sanitize-resource-reason.ts
+++ b/utils/sanitize-resource-reason.ts
@@ -1,0 +1,12 @@
+/** Max length for optional resource-change reasons stored in gang logs. */
+export const RESOURCE_REASON_MAX_LENGTH = 100;
+
+/**
+ * Collapse whitespace/newlines and cap length so log first-line / second-line
+ * splitting in the log modal stays intact.
+ */
+export function sanitizeResourceReason(reason: string | undefined | null): string | undefined {
+  if (!reason) return undefined;
+  const cleaned = reason.replace(/\s+/g, ' ').trim().slice(0, RESOURCE_REASON_MAX_LENGTH);
+  return cleaned || undefined;
+}


### PR DESCRIPTION
Move credits/reputation/trade points/campaign resources out of Edit Gang into their own modal, and append optional per-resource reasons to gang logs.