### PR TITLE
Remove the runaway campaign catalog cache purge

### DIFF
--- a/app/actions/campaigns/[id]/campaign-territories.ts
+++ b/app/actions/campaigns/[id]/campaign-territories.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { invalidateCampaign, invalidateGangCampaignMembership, purgePreEditionCampaignCatalogCachesOnce } from '@/utils/cache-tags';
+import { invalidateCampaign, invalidateGangCampaignMembership } from '@/utils/cache-tags';
 import { createClient } from "@/utils/supabase/server";
 import { logTerritoryLost, logTerritoryClaimed } from "../../logs/gang-campaign-logs";
 import { getAuthenticatedUser } from '@/utils/auth';
@@ -310,7 +310,6 @@ export async function addTerritoryToCampaign(params: AddTerritoryParams) {
     if (error) throw error;
 
     invalidateCampaign(campaignId);
-    purgePreEditionCampaignCatalogCachesOnce();
 
     return { success: true };
   } catch (error) {

--- a/app/actions/create-campaign.ts
+++ b/app/actions/create-campaign.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { invalidateUser, invalidateCampaignCount, purgePreEditionCampaignCatalogCachesOnce } from '@/utils/cache-tags';
+import { invalidateUser, invalidateCampaignCount } from '@/utils/cache-tags';
 import { createClient } from "@/utils/supabase/server";
 import { getAuthenticatedUser } from "@/utils/auth";
 
@@ -53,9 +53,6 @@ export async function createCampaign({ name, campaignTypeId, trading_posts }: Cr
 
     // Invalidate global campaign count
     invalidateCampaignCount();
-
-    // Drop pre-rename catalog cache keys that share campaign-types / territories tags
-    purgePreEditionCampaignCatalogCachesOnce();
 
     // Invalidate user's campaigns list so the new campaign appears immediately
     invalidateUser(user.id);

--- a/app/api/admin/campaign-types/route.ts
+++ b/app/api/admin/campaign-types/route.ts
@@ -1,8 +1,6 @@
-import { TAGS } from '@/utils/cache-tags';
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 import { checkAdmin } from "@/utils/auth";
-import { revalidateTag } from "next/cache";
 import { invalidateCampaignCatalogLists } from "@/utils/cache-tags";
 
 export async function GET() {
@@ -30,7 +28,7 @@ export async function GET() {
   }
 }
 
-async function _POST(request: Request) {
+export async function POST(request: Request) {
   const supabase = await createClient();
   
   try {
@@ -123,7 +121,7 @@ async function _POST(request: Request) {
   }
 }
 
-async function _PATCH(request: Request) {
+export async function PATCH(request: Request) {
   const supabase = await createClient();
   
   try {
@@ -254,21 +252,3 @@ async function _PATCH(request: Request) {
     );
   }
 }
-
-// Admin edits change global reference data that is cached app-wide; fire the
-// matching tags once per successful mutation (previously nothing was fired,
-// so admin edits never showed up until caches expired).
-function withReferenceInvalidation(
-  handler: (...args: any[]) => Promise<Response>
-) {
-  return async (...args: any[]) => {
-    const response = await handler(...args);
-    if (response.ok) {
-      revalidateTag(TAGS.campaignTypes(), { expire: 0 });
-    }
-    return response;
-  };
-}
-
-export const POST = withReferenceInvalidation(_POST);
-export const PATCH = withReferenceInvalidation(_PATCH);

--- a/app/api/admin/territories/route.ts
+++ b/app/api/admin/territories/route.ts
@@ -1,8 +1,6 @@
-import { TAGS } from '@/utils/cache-tags';
 import { createClient } from "@/utils/supabase/server";
 import { NextResponse } from "next/server";
 import { checkAdmin } from "@/utils/auth";
-import { revalidateTag } from "next/cache";
 import { invalidateCampaignCatalogLists } from "@/utils/cache-tags";
 
 export async function GET(request: Request) {
@@ -39,7 +37,7 @@ export async function GET(request: Request) {
   }
 }
 
-async function _POST(request: Request) {
+export async function POST(request: Request) {
   const supabase = await createClient();
   
   try {
@@ -89,7 +87,7 @@ async function _POST(request: Request) {
   }
 }
 
-async function _PATCH(request: Request) {
+export async function PATCH(request: Request) {
   const supabase = await createClient();
   
   try {
@@ -154,21 +152,3 @@ async function _PATCH(request: Request) {
     );
   }
 }
-
-// Admin edits change global reference data that is cached app-wide; fire the
-// matching tags once per successful mutation (previously nothing was fired,
-// so admin edits never showed up until caches expired).
-function withReferenceInvalidation(
-  handler: (...args: any[]) => Promise<Response>
-) {
-  return async (...args: any[]) => {
-    const response = await handler(...args);
-    if (response.ok) {
-      revalidateTag(TAGS.globalTerritories(), { expire: 0 });
-    }
-    return response;
-  };
-}
-
-export const POST = withReferenceInvalidation(_POST);
-export const PATCH = withReferenceInvalidation(_PATCH);

--- a/app/api/campaigns/[campaignId]/route.ts
+++ b/app/api/campaigns/[campaignId]/route.ts
@@ -6,7 +6,7 @@ import {
   getCampaignBattles,
   getCampaignCaptives
 } from "@/app/lib/campaigns/[id]/get-campaign-data";
-import { invalidateCampaign, purgePreEditionCampaignCatalogCachesOnce } from '@/utils/cache-tags';
+import { invalidateCampaign } from '@/utils/cache-tags';
 
 export async function GET(request: Request, props: { params: Promise<{ campaignId: string }> }) {
   const params = await props.params;
@@ -23,7 +23,6 @@ export async function GET(request: Request, props: { params: Promise<{ campaignI
     // Force-refresh endpoint: bust the campaign cache before re-reading so the
     // client gets fresh data (all campaign entries share the campaign-{id} tag)
     invalidateCampaign(campaignId);
-    purgePreEditionCampaignCatalogCachesOnce();
     // Use the same cached functions as the page
     const [
       campaignBasic,

--- a/app/api/discord/callback/route.ts
+++ b/app/api/discord/callback/route.ts
@@ -83,7 +83,9 @@ export async function GET(request: NextRequest) {
     console.log('[Discord Callback] DB update success — guildId:', guildId, 'campaignId:', campaignId)
 
     // Invalidate campaign cache
-    invalidateCampaign(campaignId);invalidateCampaign(campaignId);// Return self-closing HTML that notifies the opener window via postMessage
+    invalidateCampaign(campaignId);
+
+    // Return self-closing HTML that notifies the opener window via postMessage
     const origin = new URL(request.url).origin
     const html = `<!DOCTYPE html>
 <html><head><title>Discord Connected</title></head>

--- a/app/campaigns/[id]/page.tsx
+++ b/app/campaigns/[id]/page.tsx
@@ -1,12 +1,10 @@
 import { createClient } from "@/utils/supabase/server";
 import { notFound } from "next/navigation";
-import { after } from "next/server";
 import CampaignPageContent from "@/components/campaigns/[id]/campaign-page-content";
 import { CampaignErrorBoundary } from "@/components/campaigns/campaign-error-boundary";
 import { checkCampaignPermissions } from "@/utils/user-permissions";
 import type { CampaignPermissions } from "@/types/user-permissions";
 import { getAuthenticatedUser } from "@/utils/auth";
-import { purgePreEditionCampaignCatalogCachesOnce } from "@/utils/cache-tags";
 import {
   getTradingPostTypesCached,
   getCampaignTriumphs,
@@ -31,11 +29,6 @@ import {
 export default async function CampaignPage(props: { params: Promise<{ id: string }> }) {
   const params = await props.params;
   const supabase = await createClient();
-
-  // Expire pre-rename catalog cache keys after the response (shared tags).
-  after(() => {
-    purgePreEditionCampaignCatalogCachesOnce();
-  });
 
   // Get the user data once at the page level via claims
   let userId: string | undefined = undefined;

--- a/app/lib/reference-data.ts
+++ b/app/lib/reference-data.ts
@@ -23,7 +23,7 @@ export const getScenariosCached = async (supabase: any): Promise<Scenario[]> => 
       if (error) throw error;
       return (data || []).map(withEditionSlug);
     },
-    ['global-scenarios-with-edition'],
+    ['global-scenarios'],
     {
       tags: [TAGS.globalScenarios()],
       revalidate: 3600
@@ -48,7 +48,7 @@ export const getTradingPostTypesCached = async (supabase: any): Promise<TradingP
       if (error) throw error;
       return (data || []).map(withEditionSlug);
     },
-    ['global-trading-post-types-with-edition'],
+    ['global-trading-post-types'],
     {
       tags: [TAGS.globalTradingPostTypes()],
       revalidate: 3600
@@ -71,7 +71,7 @@ export const getCampaignTypes = async () => {
       if (error) throw error;
       return (data || []).map(withEditionSlug);
     },
-    ['campaign-types-with-edition'],
+    ['campaign-types'],
     {
       tags: [TAGS.campaignTypes()],
       revalidate: false
@@ -101,7 +101,7 @@ export const getAllTerritories = async () => {
         };
       });
     },
-    ['territories-list-with-edition'],
+    ['territories-list'],
     {
       tags: [TAGS.globalTerritories()],
       revalidate: false

--- a/utils/cache-tags.ts
+++ b/utils/cache-tags.ts
@@ -166,25 +166,11 @@ export const invalidateBattleSessions = (gangId: string) => {
 
 /**
  * Global campaign catalog lists (campaign types + territory templates).
- * Call after admin edits, or to drop every unstable_cache entry that shares
- * these tags (including older key names after a key rename).
+ * Call after admin edits.
  */
 export function invalidateCampaignCatalogLists() {
   bust(TAGS.campaignTypes());
   bust(TAGS.globalTerritories());
-}
-
-let didPurgePreEditionCampaignCatalogCaches = false;
-
-/**
- * One-shot per process: expire pre-rename catalog cache keys that still share
- * the campaign-types / territories tags (e.g. `campaign-types` entries from
- * before the move to `campaign-types-with-edition`).
- */
-export function purgePreEditionCampaignCatalogCachesOnce() {
-  if (didPurgePreEditionCampaignCatalogCaches) return;
-  didPurgePreEditionCampaignCatalogCaches = true;
-  invalidateCampaignCatalogLists();
 }
 
 // Global reference data


### PR DESCRIPTION
purgePreEditionCampaignCatalogCachesOnce was a one-time cleanup for the PR #1973 cache-key rename, but its guard flag is module scope, so "once" meant once per JS instance. On Vercel Fluid instances cycle constantly and tag expiry is persisted to a shared store, so it re-fired indefinitely and evicted two revalidate: false catalogs fleet-wide. The campaign page read both caches and then evicted them in after() during the same render, so they were never warm and every miss put a Supabase round trip on the render critical path.

Removes the purge and all five call sites, and reverts the four -with-edition keys in reference-data.ts now that nothing depends on the rename. Safe because those tags have been expired continuously since Aug 13; still worth running vercel cache purge --type data at deploy.

Also drops two redundancies found nearby: a duplicated invalidateCampaign call in the Discord callback, and the withReferenceInvalidation wrappers in the campaign-types and territories admin routes, whose handlers already call the broader invalidateCampaignCatalogLists on every ok-returning path. The same wrapper in five other admin routes is the only invalidation there and is left untouched.