### PR TITLE
fix(promotion): show fighter variant in the type picker

### DIFF
--- a/components/fighter/edit-fighter/fighter-promotion-modal.tsx
+++ b/components/fighter/edit-fighter/fighter-promotion-modal.tsx
@@ -52,6 +52,10 @@ function promotionSourceSubtype(subtypes: string[], fallback: string): string {
 
 type PromotionFighterType = FighterPromotionModalProps['fighterTypes'][number];
 
+/** What splits a family into sibling rows. No row carries both. */
+const variantOrSpecialisation = (ft: PromotionFighterType): string =>
+  ft.fighter_variant || ft.specialisation?.specialisation_name || '';
+
 function sortPromotionFighterTypes(
   types: PromotionFighterType[],
   editionSlug?: string | null
@@ -64,13 +68,16 @@ function sortPromotionFighterTypes(
     const typeCompare = a.fighter_type.localeCompare(b.fighter_type);
     if (typeCompare !== 0) return typeCompare;
 
-    return (a.specialisation?.specialisation_name || '').localeCompare(b.specialisation?.specialisation_name || '');
+    return variantOrSpecialisation(a).localeCompare(variantOrSpecialisation(b));
   });
 }
 
 function formatPromotionFighterTypeLabel(ft: PromotionFighterType): string {
-  const base = `${ft.fighter_type} (${ft.fighter_subtypes.join(', ')})`;
-  return ft.specialisation?.specialisation_name ? `${base}, ${ft.specialisation.specialisation_name}` : base;
+  return [
+    `${ft.fighter_type} (${ft.fighter_subtypes.join(', ')})`,
+    ft.fighter_variant,
+    ft.specialisation?.specialisation_name,
+  ].filter(Boolean).join(', ');
 }
 
 export type FighterPromotionResult = {
@@ -108,6 +115,7 @@ interface FighterPromotionModalProps {
     fighter_subtypes: string[];
     total_cost: number;
     specialisation?: { id: string; specialisation_name: string } | null;
+    fighter_variant?: string | null;
   }>;
   editionSlug?: string | null;
   isOpen: boolean;


### PR DESCRIPTION
The picker labelled rows by specialisation only. Since 20260823120000_narrow_fighter_specialisation_id nulled fighter_specialisation_id on every variant row, sibling rows render identically — a Goliath Champion sees "Forge Tyrant (Leader)" three times with no way to tell Natborn from Unborn from Vatborn, despite different stats and cost.

The label now shows the same three-part line the fighter card already uses: type (subtypes), variant, specialisation. Sort tie-breaks on variant-or-specialisation so siblings order alphabetically rather than by catalog order.

fighter_variant was already supplied by /api/fighter-types via withVariantGroups; it was only undeclared on the prop.

Checked against the live catalog: promotion-target families rendering as indistinguishable duplicates go 22 -> 0. Label and sort order only — nothing about what a promotion writes changes.