### PR TITLE
fix(fighters): keep the variant when a retype changes fighter_type_id

### DIFF
--- a/app/actions/edit-fighter.ts
+++ b/app/actions/edit-fighter.ts
@@ -122,6 +122,7 @@ export interface UpdateFighterDetailsParams {
   custom_fighter_type_id?: string | null;
   fighter_specialisation?: string | null;
   fighter_specialisation_id?: string | null;
+  fighter_variant?: string | null;
   note?: string;
   note_backstory?: string;
   fighter_gang_legacy_id?: string | null;
@@ -1452,7 +1453,12 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
             .maybeSingle()
         : { data: null };
 
-      updateData.fighter_variant = typeRow?.fighter_variant ?? null;
+      // Adopt the new row's variant, but never clear one just because the type changed.
+      if (params.fighter_variant !== undefined) {
+        updateData.fighter_variant = params.fighter_variant;
+      } else if (typeRow?.fighter_variant) {
+        updateData.fighter_variant = typeRow.fighter_variant;
+      }
       if (params.fighter_specialisation_id === undefined) {
         updateData.fighter_specialisation_id = typeRow?.fighter_specialisation_id ?? null;
       }

--- a/components/fighter/edit-fighter/fighter-edit-modal.tsx
+++ b/components/fighter/edit-fighter/fighter-edit-modal.tsx
@@ -488,6 +488,7 @@ export function EditFighterModal({
       special_rules?: string[];
       fighter_specialisation?: string | null;
       fighter_specialisation_id?: string | null;
+      fighter_variant?: string | null;
       fighter_gang_legacy_id?: string | null;
       selected_archetype_id?: string | null;
     }) => {
@@ -505,6 +506,7 @@ export function EditFighterModal({
         custom_fighter_type_id: submit.custom_fighter_type_id,
         fighter_specialisation: submit.fighter_specialisation,
         fighter_specialisation_id: submit.fighter_specialisation_id,
+        fighter_variant: submit.fighter_variant,
         fighter_gang_legacy_id: submit.fighter_gang_legacy_id,
         selected_archetype_id: submit.selected_archetype_id,
         stat_adjustments: Object.keys(pendingStatAdjustments).length > 0 ? pendingStatAdjustments : undefined
@@ -938,6 +940,7 @@ export function EditFighterModal({
         } else {
           submitData.fighter_type_id = fighterTypeToUse.id;
           submitData.custom_fighter_type_id = null;
+          submitData.fighter_variant = fighterTypeToUse.fighter_variant ?? null;
           // client-only: used by the optimistic fighter_type overlay, not forwarded to the server
           submitData.gang_type_id = fighterTypeToUse.gang_type_id ?? null;
           submitData.custom_gang_type_id = null;


### PR DESCRIPTION
updateFighterDetails rewrote fighters.fighter_variant from the submitted type row on every retype, so moving a fighter to a row with no variant cleared it. A Champion->Leader promotion does exactly that: the fighter is still a Natborn, but the label was dropped because the Leader row carries none.

Live rows this hits: 1,629 Genestealer Cults Early Generation Hybrid Champions, whose gang has no Leader row with that variant at all, plus any Goliath (8,251), Delaque (1,292) or Palanite (518) Champion promoted into a plain row.

The new row's variant is still adopted when it has one; it just never clears. Edit Fighter now sends fighter_variant explicitly so its Variant dropdown keeps working in both directions - picking "Default" clears, as the user asked for - following the same explicit-wins-over-derived rule already used two lines below for the specialisation.