### PR TITLE
feat(fighters): keep N26 subtypes and specialisation independent of n…

### DIFF
--- a/app/actions/add-fighter.ts
+++ b/app/actions/add-fighter.ts
@@ -12,6 +12,7 @@ import { logFighterAction } from '@/app/actions/logs/fighter-logs';
 import { mapArchetypeSkillAccessToOverrides } from '@/utils/archetypeEligibility';
 import { assertArchetypeAssignable } from '@/utils/assertArchetypeAssignable';
 import { editionSlugFromJoin, gangEditionSlug, type EditionJoin } from '@/types/edition';
+import { shouldClearSpecialisationForSubtypes } from '@/utils/keepTypePromotionN26';
 
 interface SelectedEquipment {
   equipment_id: string;
@@ -415,6 +416,10 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
       throw new Error('Gang not found');
     }
 
+    const fighterSource = effectiveFighterData as FighterTypeSource;
+    const editionSlug =
+      editionSlugFromJoin(fighterSource.editions) ?? gangEditionSlug(gangData);
+
     // Note: Authorization is enforced by RLS policies on fighters table
 
     // Check for adjusted cost based on gang type (only for regular fighters)
@@ -455,14 +460,9 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
     // Server-side archetype eligibility (UI check is not sufficient)
     let archetypeIdToPersist: string | null = null;
     if (params.selected_archetype_id) {
-      const fighterSource = effectiveFighterData as FighterTypeSource;
       const fighterSubtypes = fighterSource.fighter_subtypes?.length
         ? fighterSource.fighter_subtypes
         : ['Custom'];
-
-      // Prefer fighter-type edition; fall back to gang edition for legacy custom types with null edition_id
-      const editionSlug =
-        editionSlugFromJoin(fighterSource.editions) ?? gangEditionSlug(gangData);
 
       const assignable = await assertArchetypeAssignable(supabase, {
         gangTypeId: gangData.gang_type_id,
@@ -526,6 +526,11 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
       fighterInsertData.fighter_type_id = params.fighter_type_id;
       fighterInsertData.fighter_specialisation_id = fighterTypeData.fighter_specialisation_id;
       fighterInsertData.custom_fighter_type_id = null;
+    }
+
+    if (shouldClearSpecialisationForSubtypes(editionSlug, fighterInsertData.fighter_subtypes)) {
+      fighterInsertData.fighter_specialisation = null;
+      fighterInsertData.fighter_specialisation_id = null;
     }
 
     // Insert fighter

--- a/app/actions/copy-fighter.ts
+++ b/app/actions/copy-fighter.ts
@@ -7,6 +7,8 @@ import {checkAdmin, getAuthenticatedUser} from "@/utils/auth";
 import {updateGangFinancials} from '@/utils/gang-rating-and-wealth';
 import {logFighterAction} from '@/app/actions/logs/fighter-logs';
 import {revalidateTag} from 'next/cache';
+import { resolveFighterEditionSlug } from '@/utils/fighter-subtype-grants';
+import { shouldClearSpecialisationForSubtypes } from '@/utils/keepTypePromotionN26';
 
 interface CopyFighterParams {
   fighter_id: string;
@@ -242,6 +244,8 @@ export async function copyFighter(params: CopyFighterParams): Promise<CopyFighte
       return { success: false, error: `Fighter not found: ${fetchError?.message || 'Unknown error'}` };
     }
 
+    const editionSlug = await resolveFighterEditionSlug(supabase, params.fighter_id);
+
     // Fetch vehicle equipment separately (linked via vehicle_id, not fighter_id)
     let vehicleEquipment: any[] = [];
     if (sourceFighter.vehicles?.length > 0) {
@@ -321,6 +325,15 @@ export async function copyFighter(params: CopyFighterParams): Promise<CopyFighte
 
     const nextPosition = (maxPositionData?.position ?? -1) + 1;
     const newFighterName = params.new_name || sourceFighter.fighter_name;
+    const copySpecialisation = shouldClearSpecialisationForSubtypes(
+      editionSlug,
+      sourceFighter.fighter_subtypes
+    )
+      ? { fighter_specialisation: null, fighter_specialisation_id: null }
+      : {
+          fighter_specialisation: sourceFighter.fighter_specialisation,
+          fighter_specialisation_id: sourceFighter.fighter_specialisation_id,
+        };
 
     const fighterData: any = {
       gang_id: params.target_gang_id,
@@ -328,8 +341,8 @@ export async function copyFighter(params: CopyFighterParams): Promise<CopyFighte
       fighter_type: sourceFighter.fighter_type,
       fighter_type_id: sourceFighter.fighter_type_id,
       fighter_subtypes: sourceFighter.fighter_subtypes || [],
-      fighter_specialisation: sourceFighter.fighter_specialisation,
-      fighter_specialisation_id: sourceFighter.fighter_specialisation_id,
+      fighter_specialisation: copySpecialisation.fighter_specialisation,
+      fighter_specialisation_id: copySpecialisation.fighter_specialisation_id,
       fighter_variant: sourceFighter.fighter_variant,
       custom_fighter_type_id: sourceFighter.custom_fighter_type_id,
       fighter_gang_legacy_id: sourceFighter.fighter_gang_legacy_id,
@@ -732,6 +745,16 @@ export async function copyFighter(params: CopyFighterParams): Promise<CopyFighte
         }
 
         // Insert new beast fighter (fighter_pet_id set to null initially, linked after ownership record)
+        const beastSpecialisation = shouldClearSpecialisationForSubtypes(
+          editionSlug,
+          beastFighter.fighter_subtypes
+        )
+          ? { fighter_specialisation: null, fighter_specialisation_id: null }
+          : {
+              fighter_specialisation: beastFighter.fighter_specialisation,
+              fighter_specialisation_id: beastFighter.fighter_specialisation_id,
+            };
+
         const { data: newBeastFighter, error: beastInsertError } = await supabase
           .from('fighters')
           .insert({
@@ -740,8 +763,8 @@ export async function copyFighter(params: CopyFighterParams): Promise<CopyFighte
             fighter_type: beastFighter.fighter_type,
             fighter_type_id: beastFighter.fighter_type_id,
             fighter_subtypes: beastFighter.fighter_subtypes || [],
-            fighter_specialisation: beastFighter.fighter_specialisation,
-            fighter_specialisation_id: beastFighter.fighter_specialisation_id,
+            fighter_specialisation: beastSpecialisation.fighter_specialisation,
+            fighter_specialisation_id: beastSpecialisation.fighter_specialisation_id,
             fighter_variant: beastFighter.fighter_variant,
             custom_fighter_type_id: beastFighter.custom_fighter_type_id,
             fighter_gang_legacy_id: beastFighter.fighter_gang_legacy_id,

--- a/app/actions/edit-fighter.ts
+++ b/app/actions/edit-fighter.ts
@@ -11,8 +11,9 @@ import { logFighterAction } from './logs/fighter-logs';
 import { countsTowardRating, hasKilledStatusFlag } from '@/utils/fighter-status';
 import { updateGangFinancials, updateGangRatingSimple, GangFinancialUpdateResult } from '@/utils/gang-rating-and-wealth';
 import { insertFighterOoaRecords } from './fighter-ooa-records';
-import { allowsMultipleSubtypes } from '@/types/edition';
+import { allowsMultipleSubtypes, namedTypeKeepsSubtypes } from '@/types/edition';
 import { resolveFighterEditionSlug } from '@/utils/fighter-subtype-grants';
+import { shouldClearSpecialisationForSubtypes } from '@/utils/keepTypePromotionN26';
 import { assertArchetypeAssignable } from '@/utils/assertArchetypeAssignable';
 import { mapArchetypeSkillAccessToOverrides } from '@/utils/archetypeEligibility';
 
@@ -1444,7 +1445,12 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
     if (params.fighter_specialisation_id !== undefined) updateData.fighter_specialisation_id = params.fighter_specialisation_id;
 
     // An explicit specialisation from the caller wins over the type row's.
+    // N26 named type does not own specialisation, so a retype must not copy it.
     if (params.fighter_type_id !== undefined || params.custom_fighter_type_id !== undefined) {
+      if (resolvedEditionSlug === undefined) {
+        resolvedEditionSlug = await resolveFighterEditionSlug(supabase, params.fighter_id);
+      }
+
       const { data: typeRow } = params.fighter_type_id
         ? await supabase
             .from('fighter_types')
@@ -1459,8 +1465,34 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
       } else if (typeRow?.fighter_variant) {
         updateData.fighter_variant = typeRow.fighter_variant;
       }
-      if (params.fighter_specialisation_id === undefined) {
+      if (
+        params.fighter_specialisation_id === undefined &&
+        !namedTypeKeepsSubtypes(resolvedEditionSlug)
+      ) {
         updateData.fighter_specialisation_id = typeRow?.fighter_specialisation_id ?? null;
+      }
+    }
+
+    // Specialisation is only valid with the Specialist subtype. Skip rename-only
+    // (and other unrelated) saves so we do not resolve edition or rewrite nulls
+    // unless this payload actually touches type, subtypes, or specialisation.
+    const touchesSpecialisationScope =
+      params.fighter_subtypes !== undefined ||
+      params.fighter_type !== undefined ||
+      params.fighter_type_id !== undefined ||
+      params.custom_fighter_type_id !== undefined ||
+      params.fighter_specialisation !== undefined ||
+      params.fighter_specialisation_id !== undefined;
+
+    if (touchesSpecialisationScope) {
+      if (resolvedEditionSlug === undefined) {
+        resolvedEditionSlug = await resolveFighterEditionSlug(supabase, params.fighter_id);
+      }
+      const effectiveSubtypes: string[] =
+        updateData.fighter_subtypes ?? fighter.fighter_subtypes ?? [];
+      if (shouldClearSpecialisationForSubtypes(resolvedEditionSlug, effectiveSubtypes)) {
+        updateData.fighter_specialisation = null;
+        updateData.fighter_specialisation_id = null;
       }
     }
     if (params.note !== undefined) updateData.note = params.note;

--- a/components/fighter/edit-fighter/fighter-edit-modal.tsx
+++ b/components/fighter/edit-fighter/fighter-edit-modal.tsx
@@ -10,8 +10,8 @@ import { HiX } from "react-icons/hi";
 import { toast } from 'sonner';
 import { applySpecialRulesModifiers, subtypeGrantsFromEffects } from '@/utils/effect-modifiers';
 import { getFighterSubtypeSortRank } from '@/utils/fighterSubtypeRank';
-import { N26_PROSPECT_SPECIALISATIONS } from '@/utils/keepTypePromotionN26';
-import { allowsMultipleSubtypes, hasFighterSpecialisations } from '@/types/edition';
+import { N26_PROSPECT_SPECIALISATIONS, hasN26SpecialistSubtype } from '@/utils/keepTypePromotionN26';
+import { allowsMultipleSubtypes, hasFighterSpecialisations, namedTypeKeepsSubtypes, omitsNamedTypeSubtypeSuffix } from '@/types/edition';
 import {
   getArchetypeCatalogSubtype,
   isArchetypeEligible,
@@ -307,6 +307,12 @@ export function EditFighterModal({
     return new Set(add.map(id => nameFor.get(id)).filter((name): name is string => !!name));
   }, [fighter.effects, allFighterSubtypes]);
 
+  const hasSpecialistSubtype = hasN26SpecialistSubtype(selectedFighterSubtypes, allFighterSubtypes);
+  const canHaveSpecialisation =
+    hasFighterSpecialisations(fighter.edition_slug) &&
+    !isVehicleFighter &&
+    hasSpecialistSubtype;
+
   // Subtypes not yet selected — for the N26 add Combobox
   const availableSubtypeComboboxOptions = useMemo(() => {
     const selected = new Set(selectedFighterSubtypes);
@@ -427,7 +433,9 @@ export function EditFighterModal({
         return a.cost - b.cost;
       })
       .map(({ fighter: ft }) => {
-        const displayName = `${ft.fighter_type} (${ft.fighter_subtypes.join(', ')})`;
+        const displayName = omitsNamedTypeSubtypeSuffix(fighter.edition_slug)
+          ? ft.fighter_type
+          : `${ft.fighter_type} (${ft.fighter_subtypes.join(', ')})`;
         const gangVariantSuffix = (ft as any).is_gang_variant ? ` - ${(ft as any).gang_variant_name}` : '';
         return {
           value: ft.id,
@@ -562,12 +570,14 @@ export function EditFighterModal({
                 fighterTypes.find(ft => ft.id === submit.fighter_type_id)?.fighter_variant ?? null,
             }
           : {}),
-        ...(submit.fighter_specialisation && submit.fighter_specialisation_id
+        ...(submit.fighter_specialisation_id !== undefined
           ? {
-              fighter_specialisation: {
-                fighter_specialisation: submit.fighter_specialisation,
-                fighter_specialisation_id: submit.fighter_specialisation_id,
-              } as any,
+              fighter_specialisation: submit.fighter_specialisation_id
+                ? {
+                    fighter_specialisation: submit.fighter_specialisation ?? '',
+                    fighter_specialisation_id: submit.fighter_specialisation_id,
+                  }
+                : null,
             }
           : {}),
         ...(submit.fighter_gang_legacy_id !== undefined
@@ -624,7 +634,9 @@ export function EditFighterModal({
       (fighter.fighter_type as any)?.fighter_type_id || (fighter as any).fighter_type_id || '';
     setSelectedFighterTypeId(initialFighterTypeId);
     setSelectedVariantTypeId(initialFighterTypeId);
-    setSelectedFighterSpecialisationId(fighter.fighter_specialisation?.fighter_specialisation_id || '');
+    setSelectedFighterSpecialisationId(
+      fighter.fighter_specialisation?.fighter_specialisation_id || ''
+    );
     setSelectedGangLegacyId((fighter as any).fighter_gang_legacy_id || '');
     setSelectedArchetypeId(fighter.selected_archetype_id || '');
     setHasExplicitlySelectedType(false);
@@ -710,18 +722,22 @@ export function EditFighterModal({
     const selectedType = fighterTypes.find((ft: any) => ft.id === fighterTypeId);
 
     if (selectedType) {
+      const keepSubtypes = namedTypeKeepsSubtypes(fighter.edition_slug);
+
       // Update form values with selected type
       setFormValues(prev => ({
         ...prev,
         fighter_type: selectedType.fighter_type,
-        fighter_subtypes: selectedType.fighter_subtypes
+        ...(keepSubtypes ? {} : { fighter_subtypes: selectedType.fighter_subtypes }),
       }));
-      const typeSubtypes = selectedType.fighter_subtypes ?? [];
-      setSelectedFighterSubtypes(
-        allowMultipleSubtypes ? typeSubtypes : typeSubtypes.slice(0, 1)
-      );
+      if (!keepSubtypes) {
+        const typeSubtypes = selectedType.fighter_subtypes ?? [];
+        setSelectedFighterSubtypes(
+          allowMultipleSubtypes ? typeSubtypes : typeSubtypes.slice(0, 1)
+        );
+        setSelectedArchetypeId('');
+      }
       setPendingSubtypeToAdd('');
-      setSelectedArchetypeId('');
 
       // Update available legacies for the selected fighter type
       const nextLegacies = selectedType.available_legacies || [];
@@ -744,8 +760,11 @@ export function EditFighterModal({
     setSelectedSpecialRuleOption('');
     setCustomSpecialRule('');
 
-    // A variant can carry subtypes the base row does not, so the selection follows the
-    // chosen row. Subtypes no row in the family owns were granted or hand-added; keep them.
+    // N26 keeps subtypes independent of named type and variant. N23 still follows
+    // the chosen row: a variant can carry subtypes the base row does not, while
+    // subtypes no row in the family owns were granted or hand-added and are kept.
+    if (namedTypeKeepsSubtypes(fighter.edition_slug)) return;
+
     const variantType = fighterTypes.find(ft => ft.id === specialisationId);
     if (!variantType) return;
 
@@ -926,7 +945,9 @@ export function EditFighterModal({
 
       // Only include fighter type fields if we're actually updating the fighter type
       if (shouldUpdateFighterType && fighterTypeToUse) {
-        submitData.fighter_subtypes = fighterTypeToUse.fighter_subtypes;
+        if (!namedTypeKeepsSubtypes(fighter.edition_slug)) {
+          submitData.fighter_subtypes = fighterTypeToUse.fighter_subtypes;
+        }
         submitData.fighter_type = fighterTypeToUse.fighter_type;
         if (fighterTypeToUse.is_custom_fighter) {
           // Custom type IDs live in custom_fighter_types, not fighter_types — must not write to fighter_type_id
@@ -949,17 +970,19 @@ export function EditFighterModal({
 
       // The server derives the specialisation from any submitted type row, so send the
       // fighter's own whenever the type moves as well — a retype must not rewrite it.
+      // Without Specialist, specialisation is not valid and must be cleared.
       if (
         hasFighterSpecialisations(fighter.edition_slug) &&
         !isVehicleFighter &&
         !submitData.custom_fighter_type_id
       ) {
         const currentSpecialisationId = fighter.fighter_specialisation?.fighter_specialisation_id || '';
-        if (selectedFighterSpecialisationId !== currentSpecialisationId || submitData.fighter_type_id) {
+        const nextSpecialisationId = canHaveSpecialisation ? selectedFighterSpecialisationId : '';
+        if (nextSpecialisationId !== currentSpecialisationId || submitData.fighter_type_id) {
           const specialisation = N26_PROSPECT_SPECIALISATIONS.find(
-            s => s.id === selectedFighterSpecialisationId
+            s => s.id === nextSpecialisationId
           );
-          submitData.fighter_specialisation_id = selectedFighterSpecialisationId || null;
+          submitData.fighter_specialisation_id = nextSpecialisationId || null;
           submitData.fighter_specialisation = specialisation?.name ?? null;
         }
       }
@@ -1004,13 +1027,13 @@ export function EditFighterModal({
   return (
     <>
       <Modal
-        title="Edit Fighter"
+        title={isVehicleFighter ? "Edit Vehicle" : "Edit Fighter"}
         content={
           <div className="space-y-4">
             {/* Fighter Name */}
             <div>
               <label htmlFor="name" className="block text-sm font-medium mb-1">
-                Fighter Name
+                Name
               </label>
               <Input
                 id="name"
@@ -1081,7 +1104,7 @@ export function EditFighterModal({
             {/* Fighter Type Dropdown */}
             <div>
               <label htmlFor="fighter_type_id" className="block text-sm font-medium mb-1">
-                Change Fighter Type
+                Named Type
               </label>
               <Combobox
                 id="fighter_type_id"
@@ -1096,8 +1119,12 @@ export function EditFighterModal({
                   Current: {typeof (fighter as any).fighter_type === 'object' 
                     ? (fighter as any).fighter_type.fighter_type 
                     : fighter.fighter_type}
-                  {` `}
-                  {`(${fighter.fighter_subtypes?.join(', ') || 'Unknown Subtype'})`}
+                  {!omitsNamedTypeSubtypeSuffix(fighter.edition_slug) && (
+                    <>
+                      {` `}
+                      {`(${fighter.fighter_subtypes?.join(', ') || 'Unknown Subtype'})`}
+                    </>
+                  )}
                 </div>
               )}
             </div>
@@ -1122,34 +1149,10 @@ export function EditFighterModal({
               </div>
             )}
 
-            {/* Specialisation - the fighter's own, never its type's */}
-            {hasFighterSpecialisations(fighter.edition_slug) && !isVehicleFighter && (
-              <div>
-                <label htmlFor="fighter_specialisation_id" className="block text-sm font-medium mb-1">
-                  Fighter Specialisation
-                </label>
-                <Combobox
-                  id="fighter_specialisation_id"
-                  value={selectedFighterSpecialisationId}
-                  onValueChange={setSelectedFighterSpecialisationId}
-                  placeholder="None"
-                  clearable
-                  options={[
-                    { value: '', label: 'None' },
-                    ...N26_PROSPECT_SPECIALISATIONS.map(s => ({ value: s.id, label: s.name })),
-                  ]}
-                  dropdownPlacement="down"
-                />
-                <div className="mt-1 text-sm text-muted-foreground">
-                  Current: {fighter.fighter_specialisation?.fighter_specialisation || 'None'}
-                </div>
-              </div>
-            )}
-
             {/* Fighter Subtype — multi add/chips on N26, single Combobox on N23 */}
             <div>
               <label className="block text-sm font-medium mb-1">
-                Fighter Subtype
+                Subtypes
               </label>
               {allowMultipleSubtypes ? (
                 <>
@@ -1159,7 +1162,7 @@ export function EditFighterModal({
                         options={availableSubtypeComboboxOptions}
                         value={pendingSubtypeToAdd}
                         onValueChange={setPendingSubtypeToAdd}
-                        placeholder="Add a Fighter Subtype"
+                        placeholder="Add a Subtype"
                         dropdownPlacement="down"
                       />
                     </div>
@@ -1215,6 +1218,30 @@ export function EditFighterModal({
                 Current: {fighter.fighter_subtypes?.join(', ') || 'Unknown'}
               </div>
             </div>
+
+            {/* Specialisation - the fighter's own, never its type's */}
+            {canHaveSpecialisation && (
+              <div>
+                <label htmlFor="fighter_specialisation_id" className="block text-sm font-medium mb-1">
+                  Fighter Specialisation
+                </label>
+                <Combobox
+                  id="fighter_specialisation_id"
+                  value={selectedFighterSpecialisationId}
+                  onValueChange={setSelectedFighterSpecialisationId}
+                  placeholder="None"
+                  clearable
+                  options={[
+                    { value: '', label: 'None' },
+                    ...N26_PROSPECT_SPECIALISATIONS.map(s => ({ value: s.id, label: s.name })),
+                  ]}
+                  dropdownPlacement="down"
+                />
+                <div className="mt-1 text-sm text-muted-foreground">
+                  Current: {fighter.fighter_specialisation?.fighter_specialisation || 'None'}
+                </div>
+              </div>
+            )}
 
             {/* Gang Legacy Dropdown */}
             {availableLegacies.length > 0 && (

--- a/components/fighter/fighter-page.tsx
+++ b/components/fighter/fighter-page.tsx
@@ -1448,7 +1448,9 @@ export default function FighterPage({
                     ...optimistic,
                     // Ensure type shape matches `Fighter` interface
                     fighter_type: optimistic?.fighter_type ? (optimistic.fighter_type as any) : prev.fighter.fighter_type,
-                    fighter_specialisation: optimistic?.fighter_specialisation ? (optimistic.fighter_specialisation as any) : prev.fighter.fighter_specialisation,
+                    fighter_specialisation: optimistic && 'fighter_specialisation' in optimistic
+                      ? (optimistic.fighter_specialisation as any)
+                      : prev.fighter.fighter_specialisation,
                     // Optimistically adjust credits if cost_adjustment changes
                     credits: (() => {
                       const newAdj = (optimistic as any)?.cost_adjustment;

--- a/types/edition.ts
+++ b/types/edition.ts
@@ -107,6 +107,18 @@ const EDITION_CAPABILITIES = {
   /** A fighter may hold several subtypes at once */
   multipleFighterSubtypes:  { n23: false, n26: true  },
   /**
+   * Named-type picker options omit the parenthetical subtype list. N26 lists
+   * subtypes on their own control, so "Ganger (Ganger, Specialist)" is redundant
+   * there. When false, each option is "Type (Subtypes)".
+   */
+  omitNamedTypeSubtypeSuffix: { n23: false, n26: true },
+  /**
+   * Picking a named type leaves fighter_subtypes in place. N26 treats named type
+   * and subtype as independent fields. When false, the catalog row's subtypes
+   * replace the fighter's.
+   */
+  namedTypeKeepsSubtypes: { n23: false, n26: true },
+  /**
    * Custom fighter authoring offers a curated shortlist of subtypes rather than
    * every row the edition defines. The N23 table mixes real subtypes with
    * placeholders ('*', 'Others', 'Special Terrain') and alliance-only entries, so
@@ -262,6 +274,12 @@ export const initiativeAndMentalCharacteristicSuffix = (
 
 export const allowsMultipleSubtypes = (editionSlug?: string | null): boolean =>
   can('multipleFighterSubtypes', editionSlug);
+
+export const omitsNamedTypeSubtypeSuffix = (editionSlug?: string | null): boolean =>
+  can('omitNamedTypeSubtypeSuffix', editionSlug);
+
+export const namedTypeKeepsSubtypes = (editionSlug?: string | null): boolean =>
+  can('namedTypeKeepsSubtypes', editionSlug);
 
 export const hasCuratedFighterSubtypes = (editionSlug?: string | null): boolean =>
   can('curatedFighterSubtypes', editionSlug);

--- a/utils/keepTypePromotionN26.ts
+++ b/utils/keepTypePromotionN26.ts
@@ -12,7 +12,37 @@
  * (fighter_specialisations / fighter_defaults) if these ever drift.
  */
 
+import { hasFighterSpecialisations } from '@/types/edition';
+
 export const N26_PROSPECT_PROMOTION_CREDITS = 15;
+
+/** N26 fighter_subtypes row. Specialisation is only valid with this subtype. */
+export const N26_SPECIALIST_SUBTYPE_ID = '12d6cc2c-21ed-4b5a-b552-6c72d2e96042';
+export const N26_SPECIALIST_SUBTYPE_NAME = 'Specialist';
+
+export type N26SpecialistSubtypeCatalog = Array<{ id: string; subtype_name: string }>;
+
+function n26SpecialistSubtypeName(
+  catalog?: N26SpecialistSubtypeCatalog | null
+): string {
+  return catalog?.find(row => row.id === N26_SPECIALIST_SUBTYPE_ID)?.subtype_name
+    ?? N26_SPECIALIST_SUBTYPE_NAME;
+}
+
+export function hasN26SpecialistSubtype(
+  subtypes?: string[] | null,
+  catalog?: N26SpecialistSubtypeCatalog | null
+): boolean {
+  return (subtypes ?? []).includes(n26SpecialistSubtypeName(catalog));
+}
+
+/** True when this edition uses specialisations but the fighter is not a Specialist. */
+export function shouldClearSpecialisationForSubtypes(
+  editionSlug?: string | null,
+  subtypes?: string[] | null
+): boolean {
+  return hasFighterSpecialisations(editionSlug) && !hasN26SpecialistSubtype(subtypes);
+}
 
 /** Catalog ids for the eight houseless specialisations offered on Prospect promotion. */
 export const N26_PROSPECT_SPECIALISATIONS = [


### PR DESCRIPTION
…amed type

Named type and variant no longer rewrite subtypes; specialisation is Specialist-only and is stripped on add, copy, and edit when that subtype is missing.