### PR TITLE
Improve Venator Skill Set ranking UX with drag-to-rank and partial ra…

### DIFF
--- a/app/actions/gang/save-venator-skill-ranks.ts
+++ b/app/actions/gang/save-venator-skill-ranks.ts
@@ -17,16 +17,17 @@ export async function saveVenatorSkillRanks(
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const { gangId, ranks } = params;
 
-  if (ranks.length !== 0 && ranks.length !== 4) {
-    return { ok: false, error: 'All four ranks must be set, or none.' };
+  if (ranks.length > 4) {
+    return { ok: false, error: 'At most four Skill Sets can be ranked.' };
   }
-  if (ranks.length === 4) {
+  if (ranks.length > 0) {
     const rankValues = ranks.map((r) => r.rank).sort((a, b) => a - b);
-    if (rankValues.join(',') !== '1,2,3,4') {
-      return { ok: false, error: 'Ranks must be exactly 1, 2, 3, 4.' };
+    const expected = Array.from({ length: ranks.length }, (_, i) => i + 1).join(',');
+    if (rankValues.join(',') !== expected) {
+      return { ok: false, error: 'Ranks must be consecutive starting from 1.' };
     }
     const skillIds = ranks.map((r) => r.skill_type_id);
-    if (new Set(skillIds).size !== 4) {
+    if (skillIds.some((id) => !id) || new Set(skillIds).size !== ranks.length) {
       return { ok: false, error: 'The same Skill Set cannot occupy two ranks.' };
     }
   }

--- a/app/fighter/[id]/page.tsx
+++ b/app/fighter/[id]/page.tsx
@@ -253,7 +253,7 @@ export default async function FighterPageServer({ params }: FighterPageProps) {
         gang_type: gangBasic.gang_type,
         gang_type_id: gangBasic.gang_type_id,
         custom_gang_type_id: gangBasic.custom_gang_type_id,
-        venator_no_ranks: gangBasic.venator_no_ranks ?? false,
+        venator_ranks_incomplete: gangBasic.venator_ranks_incomplete ?? false,
         gang_affiliation_id: gangBasic.gang_affiliation_id,
         gang_affiliation_name: gangBasic.gang_affiliation?.name,
         positioning: gangPositioning,

--- a/app/lib/shared/gang-data.ts
+++ b/app/lib/shared/gang-data.ts
@@ -70,7 +70,7 @@ export interface GangBasic {
   image_url?: string;
   default_gang_image?: number | null;
   hidden: boolean;
-  venator_no_ranks?: boolean;
+  venator_ranks_incomplete?: boolean;
 }
 
 export interface GangType {
@@ -282,14 +282,13 @@ export const getGangCore = async (gangId: string, supabase: any): Promise<GangCo
       }
       if (!data) return null;
       const editionSlug = gangEditionSlug(data);
-      let venatorNoRanks: boolean | undefined;
+      let venatorRanksIncomplete: boolean | undefined;
       if (isVenatorGang(editionSlug, data.gang_type, Boolean(data.custom_gang_type_id))) {
         const { data: ranksProbe } = await supabase
           .from('gang_skill_set_ranks')
           .select('rank')
-          .eq('gang_id', gangId)
-          .limit(1);
-        venatorNoRanks = (ranksProbe ?? []).length === 0;
+          .eq('gang_id', gangId);
+        venatorRanksIncomplete = (ranksProbe ?? []).length < 4;
       }
       return {
         ...data,
@@ -297,10 +296,10 @@ export const getGangCore = async (gangId: string, supabase: any): Promise<GangCo
         rating: (data.rating ?? 0) as number,
         wealth: (data.wealth ?? 0) as number,
         alliance: data.alliance ?? null,
-        venator_no_ranks: venatorNoRanks,
+        venator_ranks_incomplete: venatorRanksIncomplete,
       };
     },
-    [`gang-core-v4-${gangId}`],
+    [`gang-core-v5-${gangId}`],
     {
       tags: [TAGS.gang(gangId)],
       revalidate: false

--- a/components/fighter/edit-fighter/skill-access-modal.tsx
+++ b/components/fighter/edit-fighter/skill-access-modal.tsx
@@ -9,7 +9,7 @@ import {
   saveFighterSkillAccessOverrides,
   type SkillAccessOverride
 } from '@/app/actions/fighter-skill-access';
-import { getSkillSetRank } from "@/utils/skillSetRank";
+import { getSkillSetGroupLabel, getSkillSetRank } from "@/utils/skillSetRank";
 
 interface SkillAccessModalProps {
   fighterId: string;
@@ -84,16 +84,7 @@ export function SkillAccessModal({
   }, [skillTypesError, skillAccessError]);
 
   // Helper to get the group label for a skill set based on its rank
-  const getGroupLabel = (rank: number): string => {
-    if (rank <= 19) return 'Universal Skill Sets';
-    if (rank <= 39) return 'Gang-specific Skill Sets';
-    if (rank <= 59) return 'Wyrd Powers';
-    if (rank <= 69) return 'Cult Wyrd Powers';
-    if (rank <= 79) return 'Psychoteric Whispers';
-    if (rank <= 89) return 'Legendary Names';
-    if (rank <= 99) return 'Ironhead Squat Mining Clans';
-    return 'Misc.';
-  };
+  const getGroupLabel = getSkillSetGroupLabel;
 
   // Reset initialization state when modal closes
   const [prevIsOpen, setPrevIsOpen] = useState(isOpen);

--- a/components/fighter/fighter-advancement-list.tsx
+++ b/components/fighter/fighter-advancement-list.tsx
@@ -7,7 +7,7 @@ import Modal from "@/components/ui/modal";
 import { Skill, FighterSkills, FighterEffect as FighterEffectType } from '@/types/fighter';
 import { TypeSpecificData } from '@/types/fighter-effect';
 import { createClient } from '@/utils/supabase/client';
-import { getSkillSetRank } from "@/utils/skillSetRank";
+import { buildGroupedSkillSetComboboxOptions } from '@/utils/skillSetComboboxOptions';
 import { characteristicRank } from "@/utils/characteristicRank";
 import { countAdvancementsTaken, openAdvancementsFor } from "@/utils/advancementRanks";
 import { List } from "@/components/ui/list";
@@ -41,7 +41,7 @@ import {
   type N26AdvancementEntry
 } from '@/utils/dice';
 import { hasCumulativeXp } from '@/types/edition';
-import { skillAccessDeniedMessage } from '@/utils/venatorSkillAccess';
+import { VENATOR_RANKS_INCOMPLETE_MESSAGE } from '@/utils/venatorSkillAccess';
 import {
   N26_CHAMPION_PROMOTION_SKILL_NAME,
   N26_PROSPECT_PROMOTION_CREDITS,
@@ -65,7 +65,7 @@ interface AdvancementModalProps {
   onCharacteristicUpdate?: (characteristicName: string, changeAmount: number) => void;
   userPermissions?: UserPermissions;
   gangId?: string;
-  venatorNoRanks?: boolean;
+  venatorRanksIncomplete?: boolean;
   gangTypeId?: string;
   customGangTypeId?: string;
   fighterSpecialRules?: string[];
@@ -196,7 +196,7 @@ interface AdvancementsListProps {
   onXpCreditsUpdate?: (xpChange: number, creditsChange: number) => void;
   onCharacteristicUpdate?: (characteristicName: string, changeAmount: number) => void;
   gangId?: string;
-  venatorNoRanks?: boolean;
+  venatorRanksIncomplete?: boolean;
   gangTypeId?: string;
   customGangTypeId?: string;
   fighterSpecialRules?: string[];
@@ -308,13 +308,6 @@ function getAllowedAcquisitionTypeIds(
   return getAcquisitionTypeIdsForAccess(accessLevel);
 }
 
-type SkillSetComboboxOption = {
-  value: string;
-  label: React.ReactNode;
-  displayValue: string;
-  disabled?: boolean;
-};
-
 /**
  * Builds grouped Skill Set combobox options with access annotations.
  * When `highlightPrimaryOnly` is true, only Primary sets use normal styling; all others are grey/italic.
@@ -324,97 +317,33 @@ function buildSkillSetComboboxOptions(
   skillAccess: SkillAccess[],
   highlightPrimaryOnly: boolean,
   editionSlug?: string | null
-): SkillSetComboboxOption[] {
-  const skillSetRank = getSkillSetRank(editionSlug);
+) {
   const skillAccessMap = new Map<string, SkillAccess>();
   skillAccess.forEach((a) => skillAccessMap.set(a.skill_type_id, a));
 
-  const customCategories = categories.filter((c) => c.is_custom);
-  const standardCategories = categories.filter((c) => !c.is_custom);
-
-  const groupByLabel: Record<string, SkillType[]> = {};
-  standardCategories.forEach((category) => {
-    const rank = skillSetRank[category.name.toLowerCase()] ?? Infinity;
-    let groupLabel = 'Misc.';
-    if (rank <= 19) groupLabel = 'Universal Skill Sets';
-    else if (rank <= 39) groupLabel = 'Gang-specific Skill Sets';
-    else if (rank <= 59) groupLabel = 'Wyrd Powers';
-    else if (rank <= 69) groupLabel = 'Cult Wyrd Powers';
-    else if (rank <= 79) groupLabel = 'Psychoteric Whispers';
-    else if (rank <= 89) groupLabel = 'Legendary Names';
-    else if (rank <= 99) groupLabel = 'Ironhead Squat Mining Clans';
-    if (!groupByLabel[groupLabel]) groupByLabel[groupLabel] = [];
-    groupByLabel[groupLabel].push(category);
+  return buildGroupedSkillSetComboboxOptions(categories, editionSlug, {
+    formatItem: (category) => {
+      const access = skillAccessMap.get(category.id);
+      const effectiveLevel = access ? effectiveSkillAccess(access) : null;
+      let accessLabel = '';
+      if (effectiveLevel === 'primary') accessLabel = '(Primary)';
+      else if (effectiveLevel === 'secondary') accessLabel = '(Secondary)';
+      else if (effectiveLevel === 'allowed') accessLabel = '(Allowed)';
+      const labelText = accessLabel ? `${category.name} ${accessLabel}` : category.name;
+      const useNormalLabelStyle = highlightPrimaryOnly
+        ? effectiveLevel === 'primary'
+        : !!effectiveLevel;
+      return {
+        label: useNormalLabelStyle ? (
+          <span className="pl-4">{labelText}</span>
+        ) : (
+          <span className="pl-4 italic text-neutral-400">{labelText}</span>
+        ),
+        displayValue: labelText,
+        ...(highlightPrimaryOnly && effectiveLevel !== 'primary' ? { disabled: true } : {}),
+      };
+    },
   });
-
-  const sortedGroupLabels = Object.keys(groupByLabel).sort((a, b) => {
-    const aRank = Math.min(
-      ...groupByLabel[a].map((cat) => skillSetRank[cat.name.toLowerCase()] ?? Infinity)
-    );
-    const bRank = Math.min(
-      ...groupByLabel[b].map((cat) => skillSetRank[cat.name.toLowerCase()] ?? Infinity)
-    );
-    return aRank - bRank;
-  });
-
-  const options: SkillSetComboboxOption[] = [];
-
-  const pushCategory = (category: SkillType) => {
-    const access = skillAccessMap.get(category.id);
-    const effectiveLevel = access ? effectiveSkillAccess(access) : null;
-    let accessLabel = '';
-    if (effectiveLevel === 'primary') accessLabel = '(Primary)';
-    else if (effectiveLevel === 'secondary') accessLabel = '(Secondary)';
-    else if (effectiveLevel === 'allowed') accessLabel = '(Allowed)';
-    const labelText = accessLabel ? `${category.name} ${accessLabel}` : category.name;
-    const useNormalLabelStyle = highlightPrimaryOnly
-      ? effectiveLevel === 'primary'
-      : !!effectiveLevel;
-    options.push({
-      value: category.id,
-      label: useNormalLabelStyle ? (
-        <span className="pl-4">{labelText}</span>
-      ) : (
-        <span className="pl-4 italic text-neutral-400">{labelText}</span>
-      ),
-      displayValue: labelText,
-      ...(highlightPrimaryOnly && effectiveLevel !== 'primary' ? { disabled: true } : {})
-    });
-  };
-
-  if (customCategories.length > 0) {
-    options.push({
-      value: '__group__custom',
-      label: (
-        <span className="text-xs font-bold uppercase tracking-wide">Custom Skill Sets</span>
-      ),
-      displayValue: 'Custom Skill Sets',
-      disabled: true
-    });
-    customCategories
-      .slice()
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .forEach(pushCategory);
-  }
-
-  sortedGroupLabels.forEach((groupLabel) => {
-    options.push({
-      value: `__group__${groupLabel}`,
-      label: (
-        <span className="text-xs font-bold uppercase tracking-wide">{groupLabel}</span>
-      ),
-      displayValue: groupLabel,
-      disabled: true
-    });
-    const groupCategories = groupByLabel[groupLabel].slice().sort((a, b) => {
-      const rankA = skillSetRank[a.name.toLowerCase()] ?? Infinity;
-      const rankB = skillSetRank[b.name.toLowerCase()] ?? Infinity;
-      return rankA - rankB;
-    });
-    groupCategories.forEach(pushCategory);
-  });
-
-  return options;
 }
 
 const GANGER_ADVANCEMENT_TABLE_LABEL = 'Ganger / Exotic Beast Advancement';
@@ -494,7 +423,7 @@ export function AdvancementModal({
   onCharacteristicUpdate,
   userPermissions,
   gangId = '',
-  venatorNoRanks,
+  venatorRanksIncomplete,
   gangTypeId = '',
   customGangTypeId = '',
   fighterSpecialRules = [],
@@ -2807,9 +2736,15 @@ export function AdvancementModal({
                     options={skillSetComboboxOptions}
                     dropdownPlacement="down"
                   />
+                  {venatorRanksIncomplete && (
+                    <p className="text-sm text-amber-500">
+                      {VENATOR_RANKS_INCOMPLETE_MESSAGE}
+                    </p>
+                  )}
                   {selectedCategory && selectedSkillSetLacksAccess && (
                     <p className="text-sm text-amber-500">
-                      {skillAccessDeniedMessage(!!venatorNoRanks)}
+                      This Skill Set is not accessible to this fighter. Change their Skill Set
+                      access in: Edit Fighter &gt; Customise Skill Set Access.
                     </p>
                   )}
                 </div>
@@ -2966,7 +2901,7 @@ export function AdvancementsList({
   onXpCreditsUpdate,
   onCharacteristicUpdate,
   gangId = '',
-  venatorNoRanks,
+  venatorRanksIncomplete,
   gangTypeId = '',
   customGangTypeId = '',
   fighterSpecialRules = [],
@@ -3511,7 +3446,7 @@ export function AdvancementsList({
           onCharacteristicUpdate={onCharacteristicUpdate}
           userPermissions={userPermissions}
           gangId={gangId}
-          venatorNoRanks={venatorNoRanks}
+          venatorRanksIncomplete={venatorRanksIncomplete}
           gangTypeId={gangTypeId}
           customGangTypeId={customGangTypeId}
           fighterSpecialRules={fighterSpecialRules}

--- a/components/fighter/fighter-page.tsx
+++ b/components/fighter/fighter-page.tsx
@@ -151,7 +151,7 @@ interface Gang {
   gang_type?: string | null;
   gang_type_id?: string | null;
   custom_gang_type_id?: string | null;
-  venator_no_ranks?: boolean;
+  venator_ranks_incomplete?: boolean;
   gang_affiliation_id?: string | null;
   gang_affiliation_name?: string;
   rating?: number;
@@ -369,7 +369,7 @@ const transformFighterData = (fighterData: any, gangFighters: any[]): FighterPag
       gang_type: fighterData.gang.gang_type,
       gang_type_id: fighterData.gang.gang_type_id,
       custom_gang_type_id: fighterData.gang.custom_gang_type_id,
-      venator_no_ranks: fighterData.gang.venator_no_ranks,
+      venator_ranks_incomplete: fighterData.gang.venator_ranks_incomplete,
       gang_affiliation_id: fighterData.gang.gang_affiliation_id,
       gang_affiliation_name: fighterData.gang.gang_affiliation_name,
       positioning: fighterData.gang.positioning
@@ -869,7 +869,7 @@ export default function FighterPage({
             free_skill={fighterData.fighter?.free_skill}
             userPermissions={userPermissions}
             gangCredits={fighterData.gang?.credits}
-            venatorNoRanks={fighterData.gang?.venator_no_ranks}
+            venatorRanksIncomplete={fighterData.gang?.venator_ranks_incomplete}
             editionSlug={editionSlug}
             fighterSpecialisationId={fighterData.fighter?.fighter_specialisation?.fighter_specialisation_id || null}
             fighterSpecialisationName={fighterData.fighter?.fighter_specialisation?.fighter_specialisation || null}
@@ -947,7 +947,7 @@ export default function FighterPage({
             skills={fighterData.fighter?.skills || {}}
             userPermissions={userPermissions}
             gangId={fighterData.gang?.id || ''}
-            venatorNoRanks={fighterData.gang?.venator_no_ranks}
+            venatorRanksIncomplete={fighterData.gang?.venator_ranks_incomplete}
             gangTypeId={fighterData.fighter?.fighter_type?.gang_type_id || ''}
             customGangTypeId={fighterData.fighter?.fighter_type?.custom_gang_type_id || ''}
             fighterSpecialRules={fighterData.fighter?.special_rules || []}

--- a/components/fighter/fighter-skills-list.tsx
+++ b/components/fighter/fighter-skills-list.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import Modal from "@/components/ui/modal";
 import { toast } from 'sonner';
-import { getSkillSetRank } from "@/utils/skillSetRank";
+import { buildGroupedSkillSetComboboxOptions } from '@/utils/skillSetComboboxOptions';
 import { FighterSkills } from '@/types/fighter';
 import { FighterLoadout } from '@/types/equipment';
 import { isEquipmentInActiveLoadout } from '@/components/fighter/fighter-equipment-list';
@@ -10,7 +10,7 @@ import { List } from "@/components/ui/list";
 import { Combobox } from '@/components/ui/combobox';
 import { UserPermissions } from '@/types/user-permissions';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { skillAccessDeniedMessage } from '@/utils/venatorSkillAccess';
+import { VENATOR_RANKS_INCOMPLETE_MESSAGE } from '@/utils/venatorSkillAccess';
 import { 
   addSkillAdvancement, 
   deleteAdvancement 
@@ -56,7 +56,7 @@ interface SkillsListProps {
   free_skill?: boolean;
   userPermissions: UserPermissions;
   gangCredits?: number;
-  venatorNoRanks?: boolean;
+  venatorRanksIncomplete?: boolean;
   editionSlug?: string | null;
   /** Used to detect N26 Prospect / Ganger→Champion keep-type skill grants on delete. */
   fighterSpecialisationId?: string | null;
@@ -83,7 +83,7 @@ interface SkillModalProps {
   fighterId: string;
   userId: string;
   gangCredits?: number;
-  venatorNoRanks?: boolean;
+  venatorRanksIncomplete?: boolean;
   editionSlug?: string | null;
   onClose: () => void;
   onSkillAdded: (skillId: string, skillName: string, creditsIncrease: number, isAdvance: boolean) => void;
@@ -121,7 +121,7 @@ interface SkillAccess {
 }
 
 // SkillModal Component
-export function SkillModal({ fighterId, userId, gangCredits, venatorNoRanks, editionSlug, onClose, onSkillAdded, onSkillRollback, isSubmitting, onSelectSkill, onGangCreditsUpdate }: SkillModalProps) {
+export function SkillModal({ fighterId, userId, gangCredits, venatorRanksIncomplete, editionSlug, onClose, onSkillAdded, onSkillRollback, isSubmitting, onSelectSkill, onGangCreditsUpdate }: SkillModalProps) {
   const [categories, setCategories] = useState<Category[]>([]);
   const [selectedCategory, setSelectedCategory] = useState<string>('');
   const [skillsData, setSkillsData] = useState<SkillResponse | null>(null);
@@ -254,103 +254,30 @@ export function SkillModal({ fighterId, userId, gangCredits, venatorNoRanks, edi
    * Group headers are rendered as disabled rows so the Combobox treats them as section headers.
    */
   const skillSetComboboxOptions = useMemo(() => {
-    const skillSetRank = getSkillSetRank(editionSlug);
     const skillAccessMap = new Map<string, SkillAccess>();
     skillAccess.forEach((a) => skillAccessMap.set(a.skill_type_id, a));
 
-    const customCategories = categories.filter((c) => c.is_custom);
-    const standardCategories = categories.filter((c) => !c.is_custom);
-
-    const groupByLabel: Record<string, Category[]> = {};
-    standardCategories.forEach((category) => {
-      const rank = skillSetRank[category.name.toLowerCase()] ?? Infinity;
-      let groupLabel = 'Misc.';
-      if (rank <= 19) groupLabel = 'Universal Skill Sets';
-      else if (rank <= 39) groupLabel = 'Gang-specific Skill Sets';
-      else if (rank <= 59) groupLabel = 'Wyrd Powers';
-      else if (rank <= 69) groupLabel = 'Cult Wyrd Powers';
-      else if (rank <= 79) groupLabel = 'Psychoteric Whispers';
-      else if (rank <= 89) groupLabel = 'Legendary Names';
-      else if (rank <= 99) groupLabel = 'Ironhead Squat Mining Clans';
-      if (!groupByLabel[groupLabel]) groupByLabel[groupLabel] = [];
-      groupByLabel[groupLabel].push(category);
+    return buildGroupedSkillSetComboboxOptions(categories, editionSlug, {
+      formatItem: (category) => {
+        const access = skillAccessMap.get(category.id);
+        const rawLevel = access?.override_access_level ?? access?.access_level;
+        // Treat 'denied' the same as no access for display purposes
+        const effectiveLevel = rawLevel && rawLevel !== 'denied' ? rawLevel : null;
+        let accessLabel = '';
+        if (effectiveLevel === 'primary') accessLabel = '(Primary)';
+        else if (effectiveLevel === 'secondary') accessLabel = '(Secondary)';
+        else if (effectiveLevel === 'allowed') accessLabel = '(Allowed)';
+        const labelText = accessLabel ? `${category.name} ${accessLabel}` : category.name;
+        return {
+          label: effectiveLevel ? (
+            <span className="pl-3">{labelText}</span>
+          ) : (
+            <span className="pl-3 italic text-neutral-400">{labelText}</span>
+          ),
+          displayValue: labelText,
+        };
+      },
     });
-
-    const sortedGroupLabels = Object.keys(groupByLabel).sort((a, b) => {
-      const aRank = Math.min(
-        ...groupByLabel[a].map((cat) => skillSetRank[cat.name.toLowerCase()] ?? Infinity)
-      );
-      const bRank = Math.min(
-        ...groupByLabel[b].map((cat) => skillSetRank[cat.name.toLowerCase()] ?? Infinity)
-      );
-      return aRank - bRank;
-    });
-
-    const options: Array<{
-      value: string;
-      label: React.ReactNode;
-      displayValue: string;
-      disabled?: boolean;
-    }> = [];
-
-    const pushCategory = (category: Category) => {
-      const access = skillAccessMap.get(category.id);
-      const rawLevel = access?.override_access_level ?? access?.access_level;
-      // Treat 'denied' the same as no access for display purposes
-      const effectiveLevel = rawLevel && rawLevel !== 'denied' ? rawLevel : null;
-      let accessLabel = '';
-      if (effectiveLevel === 'primary') accessLabel = '(Primary)';
-      else if (effectiveLevel === 'secondary') accessLabel = '(Secondary)';
-      else if (effectiveLevel === 'allowed') accessLabel = '(Allowed)';
-      const labelText = accessLabel ? `${category.name} ${accessLabel}` : category.name;
-      options.push({
-        value: category.id,
-        label: effectiveLevel ? (
-          <span className="pl-3">{labelText}</span>
-        ) : (
-          <span className="pl-3 italic text-neutral-400">{labelText}</span>
-        ),
-        displayValue: labelText
-      });
-    };
-
-    if (customCategories.length > 0) {
-      options.push({
-        value: '__group__custom',
-        label: (
-          <span className="text-xs font-bold uppercase tracking-wide">
-            Custom Skill Sets
-          </span>
-        ),
-        displayValue: 'Custom Skill Sets',
-        disabled: true
-      });
-      customCategories
-        .slice()
-        .sort((a, b) => a.name.localeCompare(b.name))
-        .forEach(pushCategory);
-    }
-
-    sortedGroupLabels.forEach((groupLabel) => {
-      options.push({
-        value: `__group__${groupLabel}`,
-        label: (
-          <span className="text-xs font-bold uppercase tracking-wide">
-            {groupLabel}
-          </span>
-        ),
-        displayValue: groupLabel,
-        disabled: true
-      });
-      const groupCategories = groupByLabel[groupLabel].slice().sort((a, b) => {
-        const rankA = skillSetRank[a.name.toLowerCase()] ?? Infinity;
-        const rankB = skillSetRank[b.name.toLowerCase()] ?? Infinity;
-        return rankA - rankB;
-      });
-      groupCategories.forEach(pushCategory);
-    });
-
-    return options;
   }, [categories, skillAccess, editionSlug]);
 
   // Whether the fighter has no meaningful access to the currently selected skill set.
@@ -424,9 +351,15 @@ export function SkillModal({ fighterId, userId, gangCredits, venatorNoRanks, edi
           options={skillSetComboboxOptions}
           dropdownPlacement="down"
         />
+        {venatorRanksIncomplete && (
+          <p className="text-sm text-amber-500">
+            {VENATOR_RANKS_INCOMPLETE_MESSAGE}
+          </p>
+        )}
         {selectedSkillSetLacksAccess && (
           <p className="text-sm text-amber-500">
-            {skillAccessDeniedMessage(!!venatorNoRanks)}
+            This Skill Set is not accessible to this fighter. Change their Skill Set
+            access in: Edit Fighter &gt; Customise Skill Set Access.
           </p>
         )}
       </div>
@@ -477,6 +410,7 @@ export function SkillModal({ fighterId, userId, gangCredits, venatorNoRanks, edi
   return (
     <Modal
       title="Skills"
+      helper="Add a skill to your fighter that is not part of a Promotion or an Advancement."
       content={modalContent}
       onClose={onClose}
       onConfirm={handleSubmit}
@@ -494,7 +428,7 @@ export function SkillsList({
   free_skill,
   userPermissions,
   gangCredits,
-  venatorNoRanks,
+  venatorRanksIncomplete,
   editionSlug,
   fighterSpecialisationId = null,
   fighterSpecialisationName = null,
@@ -911,7 +845,7 @@ export function SkillsList({
           fighterId={fighterId}
           userId={userPermissions.userId}
           gangCredits={gangCredits}
-          venatorNoRanks={venatorNoRanks}
+          venatorRanksIncomplete={venatorRanksIncomplete}
           editionSlug={editionSlug}
           onClose={() => setIsAddSkillModalOpen(false)}
           onSkillAdded={handleSkillAdded}

--- a/components/gang/gang-edit-modal.tsx
+++ b/components/gang/gang-edit-modal.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { Input } from '../ui/input';
 import { Switch } from "@/components/ui/switch";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Combobox } from "@/components/ui/combobox";
+import { Button } from "@/components/ui/button";
 import Modal from '@/components/ui/modal';
 import { toast } from 'sonner';
 import { HexColorPicker } from "react-colorful";
@@ -17,6 +18,13 @@ import { hasAlignment, sameEditionForDisplay } from '@/types/edition';
 import { isVenatorGang } from '@/utils/venatorSkillAccess';
 import { saveVenatorSkillRanks } from '@/app/actions/gang/save-venator-skill-ranks';
 import { createClient } from '@/utils/supabase/client';
+import { DndContext, closestCenter, type DragEndEvent } from '@dnd-kit/core';
+import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { restrictToParentElement, restrictToVerticalAxis } from '@dnd-kit/modifiers';
+import { CSS } from '@dnd-kit/utilities';
+import { useDndSensorsConfig, dragSurfaceProps } from '@/hooks/use-dnd-sensors';
+import { buildGroupedSkillSetComboboxOptions } from '@/utils/skillSetComboboxOptions';
+import { LuGripVertical, LuX } from 'react-icons/lu';
 
 interface GangUpdates {
   name?: string;
@@ -81,6 +89,72 @@ interface GangEditModalProps {
   onSave: (updates: GangUpdates) => Promise<boolean>;
 }
 
+function SortableSkillSetRankRow({
+  id,
+  rank,
+  name,
+  onRemove,
+}: {
+  id: string;
+  rank: number;
+  name: string;
+  onRemove: () => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+
+  const surface = dragSurfaceProps(true);
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Translate.toString(transform),
+        transition,
+        zIndex: isDragging ? 50 : 'auto',
+        position: 'relative',
+        // Prefer none over dragSurfaceProps' "manipulation" so vertical drags
+        // reorder rows instead of scrolling the modal underneath.
+        WebkitUserSelect: 'none',
+        userSelect: 'none',
+        WebkitTouchCallout: 'none',
+        WebkitTapHighlightColor: 'transparent',
+        touchAction: 'none',
+      }}
+      className={`flex items-center gap-2 rounded-md border border-border bg-card px-2 py-1.5 cursor-grab ${
+        isDragging ? 'shadow-md border-rose-700 cursor-grabbing' : ''
+      }`}
+      aria-label={`Drag to reorder ${name}`}
+      onContextMenu={surface.onContextMenu}
+      {...attributes}
+      {...listeners}
+    >
+      <span className="inline-flex w-5 shrink-0 items-center justify-center text-sm text-muted-foreground">{rank}</span>
+      <span className="shrink-0 p-1 text-muted-foreground" aria-hidden="true">
+        <LuGripVertical className="h-4 w-4" />
+      </span>
+      <span className="min-w-0 flex-1 truncate text-sm">{name}</span>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="h-8 w-8 shrink-0 cursor-pointer touch-auto p-0"
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={onRemove}
+        aria-label={`Remove ${name}`}
+      >
+        <LuX className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}
+
 /**
  * Gang Edit Modal Component
  * 
@@ -131,7 +205,7 @@ export default function GangEditModal({
 
   const isVenator = isVenatorGang(editionSlug, gangType, Boolean(customGangTypeId));
 
-  const { data: skillTypes = [], isSuccess: skillTypesLoaded } = useQuery<Array<{ id: string; name: string }>>({
+  const { data: skillTypes = [] } = useQuery<Array<{ id: string; name: string }>>({
     queryKey: ['skill-types', editionSlug, 'strict'],
     enabled: isVenator && !!editionSlug,
     queryFn: async () => {
@@ -160,22 +234,82 @@ export default function GangEditModal({
     },
   });
 
-  const [ranks, setRanks] = useState<string[]>(['', '', '', '']);
-  const setRank = (i: number, value: string) =>
-    setRanks((prev) => prev.map((v, idx) => (idx === i ? value : v)));
+  const [ranks, setRanks] = useState<string[]>([]);
+  const rankSensors = useDndSensorsConfig('distance');
+  const rankListRef = useRef<HTMLDivElement | null>(null);
+  const lockedScrollParentRef = useRef<{
+    el: HTMLElement;
+    overflowY: string;
+    overscrollBehavior: string;
+  } | null>(null);
+
+  const unlockRankModalScroll = useCallback(() => {
+    const locked = lockedScrollParentRef.current;
+    if (!locked) return;
+    locked.el.style.overflowY = locked.overflowY;
+    locked.el.style.overscrollBehavior = locked.overscrollBehavior;
+    lockedScrollParentRef.current = null;
+  }, []);
+
+  const lockRankModalScroll = useCallback(() => {
+    unlockRankModalScroll();
+    let el = rankListRef.current?.parentElement ?? null;
+    while (el) {
+      const { overflowY } = window.getComputedStyle(el);
+      if (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay') {
+        lockedScrollParentRef.current = {
+          el,
+          overflowY: el.style.overflowY,
+          overscrollBehavior: el.style.overscrollBehavior,
+        };
+        el.style.overflowY = 'hidden';
+        el.style.overscrollBehavior = 'none';
+        break;
+      }
+      el = el.parentElement;
+    }
+  }, [unlockRankModalScroll]);
+
+  const addRank = useCallback((skillTypeId: string) => {
+    if (!skillTypeId) return;
+    setRanks((prev) => {
+      if (prev.length >= 4 || prev.includes(skillTypeId)) return prev;
+      return [...prev, skillTypeId];
+    });
+  }, []);
+
+  const removeRank = useCallback((skillTypeId: string) => {
+    setRanks((prev) => prev.filter((id) => id !== skillTypeId));
+  }, []);
+
+  const handleRankDragEnd = useCallback((event: DragEndEvent) => {
+    unlockRankModalScroll();
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    setRanks((prev) => {
+      const oldIndex = prev.findIndex((id) => id === active.id);
+      const newIndex = prev.findIndex((id) => id === over.id);
+      if (oldIndex === -1 || newIndex === -1) return prev;
+      return arrayMove(prev, oldIndex, newIndex);
+    });
+  }, [unlockRankModalScroll]);
 
   const ranksInitializedRef = useRef(false);
   useEffect(() => {
     if (!isOpen) {
       ranksInitializedRef.current = false;
+      unlockRankModalScroll();
       return;
     }
     if (ranksInitializedRef.current) return;
     if (!existingRanksLoaded) return;
-    const byRank = new Map(existingRanks.map((r) => [r.rank, r.skill_type_id]));
-    setRanks([1, 2, 3, 4].map((n) => byRank.get(n) ?? ''));
+    setRanks(
+      [...existingRanks]
+        .sort((a, b) => a.rank - b.rank)
+        .map((r) => r.skill_type_id),
+    );
     ranksInitializedRef.current = true;
-  }, [isOpen, existingRanks, existingRanksLoaded]);
+  }, [isOpen, existingRanks, existingRanksLoaded, unlockRankModalScroll]);
 
   // Get campaign ID and current allegiance if gang is in a campaign
   const campaignId = campaigns?.[0]?.campaign_id;
@@ -490,47 +624,38 @@ export default function GangEditModal({
     if (isVenator) {
       const filled = ranks.filter(Boolean);
       const hadPreviousRanks = existingRanks.length > 0;
-      if (filled.length !== 0 && filled.length !== 4) {
-        toast.error('Please set all four Skill Sets, or leave them all blank.');
-        return;
-      }
-      if (filled.length === 4) {
-        const byRank = new Map(existingRanks.map((r) => [r.rank, r.skill_type_id]));
-        const ranksUnchanged =
-          hadPreviousRanks && ranks.every((v, i) => byRank.get(i + 1) === v);
-        if (!ranksUnchanged) {
-          if (hadPreviousRanks) {
-            const proceed = window.confirm(
-              "Changing your gang's ranked Skill Sets will reset any custom Skill Set Access you've configured on individual Venator fighters. Continue?",
-            );
-            if (!proceed) return;
-          }
+      const previousOrdered = [...existingRanks]
+        .sort((a, b) => a.rank - b.rank)
+        .map((r) => r.skill_type_id);
+      const ranksUnchanged =
+        filled.length === previousOrdered.length &&
+        filled.every((id, i) => id === previousOrdered[i]);
+
+      if (!ranksUnchanged) {
+        if (filled.length > 0) {
+          const payload = filled.map((skill_type_id, i) => ({
+            rank: i + 1,
+            skill_type_id,
+          }));
           const result = await saveVenatorSkillRanks({
             gangId,
-            ranks: ranks.map((skill_type_id, i) => ({ rank: i + 1, skill_type_id })),
+            ranks: payload,
           });
           if (!result.ok) {
             toast.error(result.error);
             return;
           }
-          queryClient.setQueryData(
-            ['gang-skill-set-ranks', gangId],
-            ranks.map((skill_type_id, i) => ({ rank: i + 1, skill_type_id })),
-          );
+          queryClient.setQueryData(['gang-skill-set-ranks', gangId], payload);
+          queryClient.invalidateQueries({ queryKey: ['fighter-skill-access'] });
+        } else if (hadPreviousRanks) {
+          const result = await saveVenatorSkillRanks({ gangId, ranks: [] });
+          if (!result.ok) {
+            toast.error(result.error);
+            return;
+          }
+          queryClient.setQueryData(['gang-skill-set-ranks', gangId], []);
           queryClient.invalidateQueries({ queryKey: ['fighter-skill-access'] });
         }
-      } else if (hadPreviousRanks) {
-        const proceed = window.confirm(
-          "Clear your gang's ranked Skill Sets? Any Venator fighter's rank-derived skill access will be removed.",
-        );
-        if (!proceed) return;
-        const result = await saveVenatorSkillRanks({ gangId, ranks: [] });
-        if (!result.ok) {
-          toast.error(result.error);
-          return;
-        }
-        queryClient.setQueryData(['gang-skill-set-ranks', gangId], []);
-        queryClient.invalidateQueries({ queryKey: ['fighter-skill-access'] });
       }
     }
 
@@ -625,32 +750,53 @@ export default function GangEditModal({
 
       {isVenator && (
         <div className="space-y-2">
-          <p className="text-sm font-medium">Skill Access</p>
+          <p className="text-sm font-medium">Venator Skill Access</p>
           <p className="text-sm text-muted-foreground">
-            Pick and rank the four Skill Sets your gang has access to. Rank 1 is
-            the Skill Set that most embodies your gang.
+            Add four Skill Sets, then drag to rank them. Rank order
+            determines skill access for each fighter.
           </p>
-          {skillTypesLoaded && skillTypes.length === 0 ? (
-            <p className="text-sm text-destructive">
-              No Skill Sets are available for this edition yet. Please contact an admin.
-            </p>
-          ) : (
-            ranks.map((value, i) => {
-              const taken = new Set(ranks.filter((v, idx) => v && idx !== i));
-              const options = skillTypes.filter((s) => !taken.has(s.id));
-              return (
-                <div key={i} className="flex items-center gap-2">
-                  <span className="w-6 text-sm text-muted-foreground">{i + 1}</span>
-                  <Combobox
-                    value={value || undefined}
-                    onValueChange={(v) => setRank(i, v ?? '')}
-                    options={options.map((o) => ({ value: o.id, label: o.name }))}
-                    placeholder="Select a Skill Set"
-                    clearable
-                  />
+          {ranks.length > 0 && (
+            <DndContext
+              sensors={rankSensors}
+              collisionDetection={closestCenter}
+              modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+              onDragStart={lockRankModalScroll}
+              onDragEnd={handleRankDragEnd}
+              onDragCancel={unlockRankModalScroll}
+            >
+              <SortableContext items={ranks} strategy={verticalListSortingStrategy}>
+                <div ref={rankListRef} className="space-y-2" style={{ touchAction: 'none' }}>
+                  {ranks.map((skillTypeId, i) => {
+                    const skillType = skillTypes.find((s) => s.id === skillTypeId);
+                    return (
+                      <SortableSkillSetRankRow
+                        key={skillTypeId}
+                        id={skillTypeId}
+                        rank={i + 1}
+                        name={skillType?.name ?? 'Unknown Skill Set'}
+                        onRemove={() => removeRank(skillTypeId)}
+                      />
+                    );
+                  })}
                 </div>
-              );
-            })
+              </SortableContext>
+            </DndContext>
+          )}
+          {ranks.length < 4 && (
+            <Combobox
+              key={ranks.join(',')}
+              value={undefined}
+              onValueChange={(v) => {
+                if (v) addRank(v);
+              }}
+              options={buildGroupedSkillSetComboboxOptions(
+                skillTypes,
+                editionSlug,
+                { excludeIds: new Set(ranks) },
+              )}
+              placeholder="Add a Skill Set"
+              dropdownPlacement="down"
+            />
           )}
         </div>
       )}

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -335,8 +335,8 @@ export function Combobox({
               : "placeholder:text-muted-foreground",
             "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-black focus-visible:ring-offset-2",
             "disabled:cursor-not-allowed disabled:opacity-50",
-            // Reserve space for chevron (~48px) and optional clear (~48px) so text does not sit under icons
-            clearable && value ? "pr-[5.5rem]" : "pr-12",
+            // Always reserve chevron space; when clearable, also reserve the X so empty/filled sizes match
+            clearable ? "pr-[5.5rem]" : "pr-12",
             selectedOption && !open && inputValue === "" && "truncate",
             selectedOption && typeof selectedOption.label !== 'string' && !open && "text-transparent placeholder:text-transparent"
           )}
@@ -362,7 +362,7 @@ export function Combobox({
           <div
             className={cn(
               "absolute inset-y-0 left-3 flex items-center pointer-events-none overflow-hidden",
-              clearable && value ? "right-[5.5rem]" : "right-12"
+              clearable ? "right-[5.5rem]" : "right-12"
             )}
           >
             <span className="min-w-0 flex-1 truncate text-sm text-foreground">

--- a/hooks/use-dnd-sensors.ts
+++ b/hooks/use-dnd-sensors.ts
@@ -4,13 +4,23 @@ import { useCallback, type MouseEvent as ReactMouseEvent } from 'react'
 import { MouseSensor, TouchSensor, KeyboardSensor, useSensor, useSensors } from '@dnd-kit/core'
 import { sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 
-export function useDndSensorsConfig() {
+/**
+ * Default `delay` touch activation suits pages where a long-press must not steal
+ * scroll or link taps (fighter cards, home favourites). Use `distance` for compact
+ * reorder lists (e.g. modal rank lists) where waiting feels like lag.
+ */
+export function useDndSensorsConfig(
+  touchActivation: 'delay' | 'distance' = 'delay',
+) {
   return useSensors(
     useSensor(MouseSensor, {
       activationConstraint: { distance: 8 },
     }),
     useSensor(TouchSensor, {
-      activationConstraint: { delay: 600, tolerance: 10 },
+      activationConstraint:
+        touchActivation === 'distance'
+          ? { distance: 8 }
+          : { delay: 600, tolerance: 10 },
     }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^7.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@floating-ui/react-dom": "^2.1.8",
@@ -349,6 +350,20 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-7.0.0.tgz",
+      "integrity": "sha512-BG/ETy3eBjFap7+zIti53f0PCLGDzNXyTmn6fSdrudORf+OH04MxrW4p5+mPu4mgMk9kM41iYONjc3DOUWTcfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dnd-kit/sortable": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@floating-ui/react-dom": "^2.1.8",

--- a/utils/skillSetComboboxOptions.tsx
+++ b/utils/skillSetComboboxOptions.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { getSkillSetGroupLabel, getSkillSetRank } from '@/utils/skillSetRank';
+
+export type SkillSetComboboxOption = {
+  value: string;
+  label: React.ReactNode;
+  displayValue: string;
+  disabled?: boolean;
+};
+
+type SkillSetItem = {
+  id: string;
+  name: string;
+  is_custom?: boolean;
+};
+
+type FormatItemResult = {
+  label: React.ReactNode;
+  displayValue: string;
+  disabled?: boolean;
+};
+
+/**
+ * Grouped Skill Set combobox options (Custom first, then edition rank bands).
+ * Group headers are disabled rows so Combobox treats them as section headers.
+ */
+export function buildGroupedSkillSetComboboxOptions(
+  skillTypes: readonly SkillSetItem[],
+  editionSlug?: string | null,
+  opts?: {
+    excludeIds?: ReadonlySet<string>;
+    formatItem?: (item: SkillSetItem) => FormatItemResult;
+  },
+): SkillSetComboboxOption[] {
+  const skillSetRank = getSkillSetRank(editionSlug);
+  const excludeIds = opts?.excludeIds;
+  const formatItem =
+    opts?.formatItem ??
+    ((item: SkillSetItem): FormatItemResult => ({
+      label: <span className="pl-3">{item.name}</span>,
+      displayValue: item.name,
+    }));
+
+  const available = excludeIds
+    ? skillTypes.filter((s) => !excludeIds.has(s.id))
+    : [...skillTypes];
+
+  const customCategories = available.filter((c) => c.is_custom);
+  const standardCategories = available.filter((c) => !c.is_custom);
+
+  const groupByLabel: Record<string, SkillSetItem[]> = {};
+  standardCategories.forEach((category) => {
+    const rank = skillSetRank[category.name.toLowerCase()] ?? Infinity;
+    const groupLabel = getSkillSetGroupLabel(rank);
+    if (!groupByLabel[groupLabel]) groupByLabel[groupLabel] = [];
+    groupByLabel[groupLabel].push(category);
+  });
+
+  const sortedGroupLabels = Object.keys(groupByLabel).sort((a, b) => {
+    const aRank = Math.min(
+      ...groupByLabel[a].map((cat) => skillSetRank[cat.name.toLowerCase()] ?? Infinity),
+    );
+    const bRank = Math.min(
+      ...groupByLabel[b].map((cat) => skillSetRank[cat.name.toLowerCase()] ?? Infinity),
+    );
+    return aRank - bRank;
+  });
+
+  const options: SkillSetComboboxOption[] = [];
+
+  const pushCategory = (category: SkillSetItem) => {
+    const formatted = formatItem(category);
+    options.push({
+      value: category.id,
+      label: formatted.label,
+      displayValue: formatted.displayValue,
+      ...(formatted.disabled ? { disabled: true } : {}),
+    });
+  };
+
+  if (customCategories.length > 0) {
+    options.push({
+      value: '__group__custom',
+      label: (
+        <span className="text-xs font-bold uppercase tracking-wide">
+          Custom Skill Sets
+        </span>
+      ),
+      displayValue: 'Custom Skill Sets',
+      disabled: true,
+    });
+    customCategories
+      .slice()
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .forEach(pushCategory);
+  }
+
+  sortedGroupLabels.forEach((groupLabel) => {
+    options.push({
+      value: `__group__${groupLabel}`,
+      label: (
+        <span className="text-xs font-bold uppercase tracking-wide">
+          {groupLabel}
+        </span>
+      ),
+      displayValue: groupLabel,
+      disabled: true,
+    });
+    const groupCategories = groupByLabel[groupLabel].slice().sort((a, b) => {
+      const rankA = skillSetRank[a.name.toLowerCase()] ?? Infinity;
+      const rankB = skillSetRank[b.name.toLowerCase()] ?? Infinity;
+      return rankA - rankB;
+    });
+    groupCategories.forEach(pushCategory);
+  });
+
+  return options;
+}

--- a/utils/skillSetRank.ts
+++ b/utils/skillSetRank.ts
@@ -27,3 +27,15 @@ export function getSkillSetRank(
   if (!editionSlug) return {};
   return SKILL_SET_RANK_BY_EDITION[editionSlug as EditionSlug] ?? {};
 }
+
+/** Band label used when grouping Skill Sets in comboboxes and skill-access UIs. */
+export function getSkillSetGroupLabel(rank: number): string {
+  if (rank <= 19) return 'Universal Skill Sets';
+  if (rank <= 39) return 'Gang-specific Skill Sets';
+  if (rank <= 59) return 'Wyrd Powers';
+  if (rank <= 69) return 'Cult Wyrd Powers';
+  if (rank <= 79) return 'Psychoteric Whispers';
+  if (rank <= 89) return 'Legendary Names';
+  if (rank <= 99) return 'Ironhead Squat Mining Clans';
+  return 'Misc.';
+}

--- a/utils/venatorSkillAccess.ts
+++ b/utils/venatorSkillAccess.ts
@@ -29,11 +29,8 @@ export function isVenatorGang(
     && (gangType ?? '').toLowerCase() === VENATOR_GANG_TYPE_NAME.toLowerCase();
 }
 
-export function skillAccessDeniedMessage(venatorNoRanks: boolean): string {
-  return venatorNoRanks
-    ? "Your gang hasn't ranked its Skill Sets yet. Set them in Edit Gang → Skill Access."
-    : "This Skill Set is not accessible to this fighter. Change their Skill Set access in: Edit Fighter > Customise Skill Set Access.";
-}
+export const VENATOR_RANKS_INCOMPLETE_MESSAGE =
+  "Venator Skill Sets aren't fully ranked. Finish this in Edit Gang.";
 
 export function deriveOverrides(
   ranks: readonly { rank: number; skill_type_id: string }[],


### PR DESCRIPTION
…nks.

Allow 0–4 consecutive ranks, share Skill Set combobox grouping, and warn when ranking is incomplete in Skills/Advancement modals.

## Summary

- Replace the four fixed Venator Skill Set comboboxes in Edit Gang with an add-then-drag ranked list (0–4 Skill Sets), including mobile-friendly drag constraints.
- Allow saving partial rankings (consecutive ranks `1..n`) on both client and server; warn in Skills and Advancement modals when ranking is incomplete (`< 4`).
- Share Skill Set combobox grouping via `buildGroupedSkillSetComboboxOptions` / `getSkillSetGroupLabel`, and reserve Combobox clear-button space so empty/filled controls stay the same size.
- Keep the generic “This Skill Set is not accessible…” copy inlined in the Skills and Advancement modals (not in `venatorSkillAccess`). That message is not Venator-specific, so this restores the pre–Venator-ranking approach instead of housing it in a Venator util.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Docs
- [ ] Schema / migration

## How I tested

- [x] Edit a Venator gang → add/remove/reorder Skill Sets (desktop drag + mobile touch) → save with 2 ranks and confirm they persist as ranks 1 and 2
- [x] Save with 0 / 4 ranks; confirm clearing ranks works; confirm incomplete-rank warning appears under Skill Set comboboxes in Skills and Advancement modals until all four are set
- [x] With a Skill Set selected that the fighter cannot access, confirm the “not accessible…” message still shows (including when ranking is incomplete)

## Risk / rollout

- Low — no migration; behavior change is Venator-specific ranking UX plus shared Skill Set option grouping. Deploy includes new `@dnd-kit/modifiers` dependency. Existing gangs with 0 or 4 ranks behave as before; gangs can now also store 1–3 ranks for house ruling purposes.
