### PR TITLE
Make Venator Skill Set rank saves atomic and surface sync failures.

### DIFF
--- a/app/actions/add-fighter.ts
+++ b/app/actions/add-fighter.ts
@@ -1231,7 +1231,6 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
               : [],
           },
           supabase,
-          user.id,
         );
       } catch (err) {
         console.error('syncFighter failed after add-fighter', err);

--- a/app/actions/add-fighter.ts
+++ b/app/actions/add-fighter.ts
@@ -1235,6 +1235,8 @@ export async function addFighterToGang(params: AddFighterParams): Promise<AddFig
         );
       } catch (err) {
         console.error('syncFighter failed after add-fighter', err);
+        archetypeSkillAccessWarning =
+          'Fighter added but skill access save failed. Please try again via Customise Skill Set Access.';
       }
     }
 

--- a/app/actions/copy-fighter.ts
+++ b/app/actions/copy-fighter.ts
@@ -431,6 +431,18 @@ export async function copyFighter(params: CopyFighterParams): Promise<CopyFighte
         );
       } catch (err) {
         console.error('syncFighter failed after copy-fighter', err);
+        const { error: deleteErr } = await supabase.from('fighters').delete().eq('id', newFighterId);
+        if (deleteErr) {
+          console.error('Failed to roll back copied fighter after syncFighter failure', deleteErr);
+          return {
+            success: false,
+            error: 'Failed to copy fighter skill access, and the incomplete copy could not be removed. Please delete it and try again.',
+          };
+        }
+        return {
+          success: false,
+          error: 'Failed to copy fighter skill access. Please try again.',
+        };
       }
     }
 

--- a/app/actions/copy-fighter.ts
+++ b/app/actions/copy-fighter.ts
@@ -427,7 +427,6 @@ export async function copyFighter(params: CopyFighterParams): Promise<CopyFighte
               : [],
           },
           supabase,
-          user.id,
         );
       } catch (err) {
         console.error('syncFighter failed after copy-fighter', err);

--- a/app/actions/edit-fighter.ts
+++ b/app/actions/edit-fighter.ts
@@ -1817,6 +1817,7 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
           );
         } catch (err) {
           console.error('syncFighter failed after edit-fighter', err);
+          archetypeSkillAccessWarning = ARCHETYPE_SKILL_ACCESS_WARNING;
         }
       }
     }

--- a/app/actions/edit-fighter.ts
+++ b/app/actions/edit-fighter.ts
@@ -1813,7 +1813,6 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
               subtypes: effectiveSubtypes,
             },
             supabase,
-            user.id,
           );
         } catch (err) {
           console.error('syncFighter failed after edit-fighter', err);

--- a/app/actions/gang/save-venator-skill-ranks.ts
+++ b/app/actions/gang/save-venator-skill-ranks.ts
@@ -2,7 +2,7 @@
 
 import { createClient } from '@/utils/supabase/server';
 import { getAuthenticatedUser } from '@/utils/auth';
-import { syncGang } from '@/utils/syncVenatorSkillOverrides';
+import { replaceGangRanks } from '@/utils/syncVenatorSkillOverrides';
 import { invalidateGang } from '@/utils/cache-tags';
 import { isVenatorGang } from '@/utils/venatorSkillAccess';
 import { gangEditionSlug } from '@/types/edition';
@@ -52,53 +52,18 @@ export async function saveVenatorSkillRanks(
 
   const FAILED_TO_SAVE = "Failed to save your gang's Skill Set ranks. Please try again.";
 
-  const { data: previousRanks, error: previousRanksErr } = await supabase
-    .from('gang_skill_set_ranks')
-    .select('skill_type_id')
-    .eq('gang_id', gangId);
-  if (previousRanksErr) {
-    console.error('saveVenatorSkillRanks: previous-ranks read failed', previousRanksErr);
-    return { ok: false, error: FAILED_TO_SAVE };
-  }
-  const previouslyOwnedSkillTypeIds = (previousRanks ?? []).map((r) => r.skill_type_id as string);
-
-  const { error: deleteErr } = await supabase
-    .from('gang_skill_set_ranks')
-    .delete()
-    .eq('gang_id', gangId);
-  if (deleteErr) {
-    console.error('saveVenatorSkillRanks: rank delete failed', deleteErr);
-    return { ok: false, error: FAILED_TO_SAVE };
-  }
-
-  if (ranks.length > 0) {
-    const { error: insertErr } = await supabase
-      .from('gang_skill_set_ranks')
-      .insert(
-        ranks.map((r) => ({
-          gang_id: gangId,
-          rank: r.rank,
-          skill_type_id: r.skill_type_id,
-        })),
-      );
-    if (insertErr) {
-      console.error('saveVenatorSkillRanks: rank insert failed', insertErr);
-      return { ok: false, error: FAILED_TO_SAVE };
-    }
-  }
-
   try {
-    await syncGang(
+    await replaceGangRanks(
       gangId,
+      ranks,
       gang.gang_type,
       gangEditionSlug(gang),
       Boolean(gang.custom_gang_type_id),
       supabase,
       user.id,
-      previouslyOwnedSkillTypeIds,
     );
   } catch (err) {
-    console.error('saveVenatorSkillRanks: syncGang failed', err);
+    console.error('saveVenatorSkillRanks: replaceGangRanks failed', err);
     return { ok: false, error: FAILED_TO_SAVE };
   }
 

--- a/app/actions/gang/save-venator-skill-ranks.ts
+++ b/app/actions/gang/save-venator-skill-ranks.ts
@@ -33,7 +33,7 @@ export async function saveVenatorSkillRanks(
   }
 
   const supabase = await createClient();
-  const user = await getAuthenticatedUser(supabase);
+  await getAuthenticatedUser(supabase);
 
   const { data: gang, error: gangErr } = await supabase
     .from('gangs')
@@ -60,7 +60,6 @@ export async function saveVenatorSkillRanks(
       gangEditionSlug(gang),
       Boolean(gang.custom_gang_type_id),
       supabase,
-      user.id,
     );
   } catch (err) {
     console.error('saveVenatorSkillRanks: replaceGangRanks failed', err);

--- a/components/gang/gang-edit-modal.tsx
+++ b/components/gang/gang-edit-modal.tsx
@@ -235,6 +235,7 @@ export default function GangEditModal({
   });
 
   const [ranks, setRanks] = useState<string[]>([]);
+  const [showRankChangeConfirm, setShowRankChangeConfirm] = useState(false);
   const rankSensors = useDndSensorsConfig('distance');
   const rankListRef = useRef<HTMLDivElement | null>(null);
   const lockedScrollParentRef = useRef<{
@@ -298,6 +299,7 @@ export default function GangEditModal({
   useEffect(() => {
     if (!isOpen) {
       ranksInitializedRef.current = false;
+      setShowRankChangeConfirm(false);
       unlockRankModalScroll();
       return;
     }
@@ -549,7 +551,19 @@ export default function GangEditModal({
     }
   };
 
-  const handleSave = async () => {
+  const getVenatorRankSaveState = () => {
+    const filled = ranks.filter(Boolean);
+    const hadPreviousRanks = existingRanks.length > 0;
+    const previousOrdered = [...existingRanks]
+      .sort((a, b) => a.rank - b.rank)
+      .map((r) => r.skill_type_id);
+    const ranksUnchanged =
+      filled.length === previousOrdered.length &&
+      filled.every((id, i) => id === previousOrdered[i]);
+    return { filled, hadPreviousRanks, ranksUnchanged };
+  };
+
+  const handleSave = async (options?: { skipRankConfirm?: boolean }) => {
     const updates: GangUpdates = {};
     const initial = initialValues;
 
@@ -622,16 +636,13 @@ export default function GangEditModal({
     }
 
     if (isVenator) {
-      const filled = ranks.filter(Boolean);
-      const hadPreviousRanks = existingRanks.length > 0;
-      const previousOrdered = [...existingRanks]
-        .sort((a, b) => a.rank - b.rank)
-        .map((r) => r.skill_type_id);
-      const ranksUnchanged =
-        filled.length === previousOrdered.length &&
-        filled.every((id, i) => id === previousOrdered[i]);
+      const { filled, hadPreviousRanks, ranksUnchanged } = getVenatorRankSaveState();
 
       if (!ranksUnchanged) {
+        if (hadPreviousRanks && !options?.skipRankConfirm) {
+          setShowRankChangeConfirm(true);
+          return false;
+        }
         if (filled.length > 0) {
           const payload = filled.map((skill_type_id, i) => ({
             rank: i + 1,
@@ -643,7 +654,7 @@ export default function GangEditModal({
           });
           if (!result.ok) {
             toast.error(result.error);
-            return;
+            return false;
           }
           queryClient.setQueryData(['gang-skill-set-ranks', gangId], payload);
           queryClient.invalidateQueries({ queryKey: ['fighter-skill-access'] });
@@ -651,7 +662,7 @@ export default function GangEditModal({
           const result = await saveVenatorSkillRanks({ gangId, ranks: [] });
           if (!result.ok) {
             toast.error(result.error);
-            return;
+            return false;
           }
           queryClient.setQueryData(['gang-skill-set-ranks', gangId], []);
           queryClient.invalidateQueries({ queryKey: ['fighter-skill-access'] });
@@ -1117,6 +1128,29 @@ export default function GangEditModal({
               </div>
             </div>
           }
+        />
+      )}
+
+      {showRankChangeConfirm && (
+        <Modal
+          title={ranks.length === 0
+            ? 'Clear Skill Set ranks?'
+            : 'Update Skill Set ranks?'}
+          content={
+            <p>
+              {ranks.length === 0
+                ? 'This will remove rank-derived skill access from Venator fighters and reset any custom Skill Set Access on those Skill Sets.'
+                : 'This will reset any custom Skill Set Access on individual Venator fighters to match the new ranking.'}
+            </p>
+          }
+          onClose={() => setShowRankChangeConfirm(false)}
+          onConfirm={async () => {
+            const saved = await handleSave({ skipRankConfirm: true });
+            if (saved === false) return false;
+            setShowRankChangeConfirm(false);
+            return true;
+          }}
+          confirmText="Continue"
         />
       )}
 

--- a/components/gang/gang-edit-modal.tsx
+++ b/components/gang/gang-edit-modal.tsx
@@ -551,18 +551,6 @@ export default function GangEditModal({
     }
   };
 
-  const getVenatorRankSaveState = () => {
-    const filled = ranks.filter(Boolean);
-    const hadPreviousRanks = existingRanks.length > 0;
-    const previousOrdered = [...existingRanks]
-      .sort((a, b) => a.rank - b.rank)
-      .map((r) => r.skill_type_id);
-    const ranksUnchanged =
-      filled.length === previousOrdered.length &&
-      filled.every((id, i) => id === previousOrdered[i]);
-    return { filled, hadPreviousRanks, ranksUnchanged };
-  };
-
   const handleSave = async (options?: { skipRankConfirm?: boolean }) => {
     const updates: GangUpdates = {};
     const initial = initialValues;
@@ -636,7 +624,14 @@ export default function GangEditModal({
     }
 
     if (isVenator) {
-      const { filled, hadPreviousRanks, ranksUnchanged } = getVenatorRankSaveState();
+      const filled = ranks.filter(Boolean);
+      const hadPreviousRanks = existingRanks.length > 0;
+      const previousOrdered = [...existingRanks]
+        .sort((a, b) => a.rank - b.rank)
+        .map((r) => r.skill_type_id);
+      const ranksUnchanged =
+        filled.length === previousOrdered.length &&
+        filled.every((id, i) => id === previousOrdered[i]);
 
       if (!ranksUnchanged) {
         if (hadPreviousRanks && !options?.skipRankConfirm) {

--- a/supabase/functions/replace_fighter_skill_access_overrides.sql
+++ b/supabase/functions/replace_fighter_skill_access_overrides.sql
@@ -1,0 +1,50 @@
+-- Single-fighter counterpart of replace_gang_skill_set_ranks: delete+insert of
+-- that fighter's rank-owned override rows in one transaction.
+-- SECURITY INVOKER: table RLS still decides who may write. auth.uid() is required
+-- and is stamped as override user_id; payload fighter_id is ignored in favour of
+-- p_fighter_id so a caller cannot attach rows to a different fighter in this call.
+
+CREATE OR REPLACE FUNCTION public.replace_fighter_skill_access_overrides(
+  p_fighter_id uuid,
+  p_owned_skill_type_ids uuid[],
+  p_overrides jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user uuid := auth.uid();
+BEGIN
+  IF v_user IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+  IF p_fighter_id IS NULL THEN
+    RAISE EXCEPTION 'fighter_id is required';
+  END IF;
+
+  IF p_owned_skill_type_ids IS NOT NULL AND cardinality(p_owned_skill_type_ids) > 0 THEN
+    DELETE FROM public.fighter_skill_access_override
+    WHERE fighter_id = p_fighter_id
+      AND skill_type_id = ANY (p_owned_skill_type_ids);
+  END IF;
+
+  INSERT INTO public.fighter_skill_access_override (
+    fighter_id, skill_type_id, access_level, user_id
+  )
+  SELECT p_fighter_id, o.skill_type_id, o.access_level, v_user
+  FROM jsonb_to_recordset(COALESCE(p_overrides, '[]'::jsonb))
+    AS o(skill_type_id uuid, access_level text)
+  WHERE o.skill_type_id IS NOT NULL
+    AND o.access_level IS NOT NULL;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.replace_fighter_skill_access_overrides(uuid, uuid[], jsonb) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.replace_fighter_skill_access_overrides(uuid, uuid[], jsonb) FROM anon;
+GRANT EXECUTE ON FUNCTION public.replace_fighter_skill_access_overrides(uuid, uuid[], jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.replace_fighter_skill_access_overrides(uuid, uuid[], jsonb) TO service_role;
+
+COMMENT ON FUNCTION public.replace_fighter_skill_access_overrides(uuid, uuid[], jsonb) IS
+  'Atomically rewrites fighter_skill_access_override rows for one fighter and the given skill types. SECURITY INVOKER: RLS of the caller still applies.';

--- a/supabase/functions/replace_gang_skill_set_ranks.sql
+++ b/supabase/functions/replace_gang_skill_set_ranks.sql
@@ -1,0 +1,68 @@
+-- Replace a gang's ranked Skill Sets and the rank-derived fighter skill-access
+-- overrides in one transaction. App-level delete-then-insert left an empty
+-- rank table if the insert failed, and a failed override rewrite after a
+-- successful rank write reported an error while the new ranks were already
+-- persisted.
+--
+-- SECURITY INVOKER (same model as copy_custom_collection): writes still go
+-- through table RLS. We only assert auth.uid() so anon/EXECUTE cannot slip
+-- through, stamp override user_id from the session, and ignore override rows
+-- whose fighter is not in p_gang_id. Rank shape (0–4 consecutive) stays in
+-- the server action; table CHECKs already reject rank outside 1–4.
+
+CREATE OR REPLACE FUNCTION public.replace_gang_skill_set_ranks(
+  p_gang_id uuid,
+  p_ranks jsonb,
+  p_owned_skill_type_ids uuid[],
+  p_overrides jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user uuid := auth.uid();
+BEGIN
+  IF v_user IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+  IF p_gang_id IS NULL THEN
+    RAISE EXCEPTION 'gang_id is required';
+  END IF;
+
+  DELETE FROM public.gang_skill_set_ranks
+  WHERE gang_id = p_gang_id;
+
+  INSERT INTO public.gang_skill_set_ranks (gang_id, rank, skill_type_id)
+  SELECT p_gang_id, r.rank, r.skill_type_id
+  FROM jsonb_to_recordset(COALESCE(p_ranks, '[]'::jsonb))
+    AS r(rank int, skill_type_id uuid)
+  WHERE r.rank IS NOT NULL AND r.skill_type_id IS NOT NULL;
+
+  IF p_owned_skill_type_ids IS NOT NULL AND cardinality(p_owned_skill_type_ids) > 0 THEN
+    DELETE FROM public.fighter_skill_access_override
+    WHERE fighter_id IN (SELECT id FROM public.fighters WHERE gang_id = p_gang_id)
+      AND skill_type_id = ANY (p_owned_skill_type_ids);
+  END IF;
+
+  INSERT INTO public.fighter_skill_access_override (
+    fighter_id, skill_type_id, access_level, user_id
+  )
+  SELECT o.fighter_id, o.skill_type_id, o.access_level, v_user
+  FROM jsonb_to_recordset(COALESCE(p_overrides, '[]'::jsonb))
+    AS o(fighter_id uuid, skill_type_id uuid, access_level text, user_id uuid)
+  WHERE o.fighter_id IS NOT NULL
+    AND o.skill_type_id IS NOT NULL
+    AND o.access_level IS NOT NULL
+    AND o.fighter_id IN (SELECT id FROM public.fighters WHERE gang_id = p_gang_id);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.replace_gang_skill_set_ranks(uuid, jsonb, uuid[], jsonb) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.replace_gang_skill_set_ranks(uuid, jsonb, uuid[], jsonb) FROM anon;
+GRANT EXECUTE ON FUNCTION public.replace_gang_skill_set_ranks(uuid, jsonb, uuid[], jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.replace_gang_skill_set_ranks(uuid, jsonb, uuid[], jsonb) TO service_role;
+
+COMMENT ON FUNCTION public.replace_gang_skill_set_ranks(uuid, jsonb, uuid[], jsonb) IS
+  'Atomically replaces gang_skill_set_ranks for a gang and rewrites fighter_skill_access_override rows for the owned skill types. SECURITY INVOKER: RLS of the caller still applies.';

--- a/supabase/migrations/20260901072836_replace_gang_skill_set_ranks.sql
+++ b/supabase/migrations/20260901072836_replace_gang_skill_set_ranks.sql
@@ -1,0 +1,116 @@
+-- Replace a gang's ranked Skill Sets and the rank-derived fighter skill-access
+-- overrides in one transaction. App-level delete-then-insert left an empty
+-- rank table if the insert failed, and a failed override rewrite after a
+-- successful rank write reported an error while the new ranks were already
+-- persisted.
+--
+-- SECURITY INVOKER (same model as copy_custom_collection): writes still go
+-- through table RLS. We only assert auth.uid() so anon/EXECUTE cannot slip
+-- through, stamp override user_id from the session, and ignore override rows
+-- whose fighter is not in p_gang_id. Rank shape (0–4 consecutive) stays in
+-- the server action; table CHECKs already reject rank outside 1–4.
+
+CREATE OR REPLACE FUNCTION public.replace_gang_skill_set_ranks(
+  p_gang_id uuid,
+  p_ranks jsonb,
+  p_owned_skill_type_ids uuid[],
+  p_overrides jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user uuid := auth.uid();
+BEGIN
+  IF v_user IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+  IF p_gang_id IS NULL THEN
+    RAISE EXCEPTION 'gang_id is required';
+  END IF;
+
+  DELETE FROM public.gang_skill_set_ranks
+  WHERE gang_id = p_gang_id;
+
+  INSERT INTO public.gang_skill_set_ranks (gang_id, rank, skill_type_id)
+  SELECT p_gang_id, r.rank, r.skill_type_id
+  FROM jsonb_to_recordset(COALESCE(p_ranks, '[]'::jsonb))
+    AS r(rank int, skill_type_id uuid)
+  WHERE r.rank IS NOT NULL AND r.skill_type_id IS NOT NULL;
+
+  IF p_owned_skill_type_ids IS NOT NULL AND cardinality(p_owned_skill_type_ids) > 0 THEN
+    DELETE FROM public.fighter_skill_access_override
+    WHERE fighter_id IN (SELECT id FROM public.fighters WHERE gang_id = p_gang_id)
+      AND skill_type_id = ANY (p_owned_skill_type_ids);
+  END IF;
+
+  INSERT INTO public.fighter_skill_access_override (
+    fighter_id, skill_type_id, access_level, user_id
+  )
+  SELECT o.fighter_id, o.skill_type_id, o.access_level, v_user
+  FROM jsonb_to_recordset(COALESCE(p_overrides, '[]'::jsonb))
+    AS o(fighter_id uuid, skill_type_id uuid, access_level text, user_id uuid)
+  WHERE o.fighter_id IS NOT NULL
+    AND o.skill_type_id IS NOT NULL
+    AND o.access_level IS NOT NULL
+    AND o.fighter_id IN (SELECT id FROM public.fighters WHERE gang_id = p_gang_id);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.replace_gang_skill_set_ranks(uuid, jsonb, uuid[], jsonb) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.replace_gang_skill_set_ranks(uuid, jsonb, uuid[], jsonb) FROM anon;
+GRANT EXECUTE ON FUNCTION public.replace_gang_skill_set_ranks(uuid, jsonb, uuid[], jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.replace_gang_skill_set_ranks(uuid, jsonb, uuid[], jsonb) TO service_role;
+
+COMMENT ON FUNCTION public.replace_gang_skill_set_ranks(uuid, jsonb, uuid[], jsonb) IS
+  'Atomically replaces gang_skill_set_ranks for a gang and rewrites fighter_skill_access_override rows for the owned skill types. SECURITY INVOKER: RLS of the caller still applies.';
+
+-- Single-fighter counterpart for add/copy/edit sync: delete+insert of that
+-- fighter's rank-owned override rows in one transaction.
+
+CREATE OR REPLACE FUNCTION public.replace_fighter_skill_access_overrides(
+  p_fighter_id uuid,
+  p_owned_skill_type_ids uuid[],
+  p_overrides jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_user uuid := auth.uid();
+BEGIN
+  IF v_user IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+  IF p_fighter_id IS NULL THEN
+    RAISE EXCEPTION 'fighter_id is required';
+  END IF;
+
+  IF p_owned_skill_type_ids IS NOT NULL AND cardinality(p_owned_skill_type_ids) > 0 THEN
+    DELETE FROM public.fighter_skill_access_override
+    WHERE fighter_id = p_fighter_id
+      AND skill_type_id = ANY (p_owned_skill_type_ids);
+  END IF;
+
+  INSERT INTO public.fighter_skill_access_override (
+    fighter_id, skill_type_id, access_level, user_id
+  )
+  SELECT p_fighter_id, o.skill_type_id, o.access_level, v_user
+  FROM jsonb_to_recordset(COALESCE(p_overrides, '[]'::jsonb))
+    AS o(skill_type_id uuid, access_level text)
+  WHERE o.skill_type_id IS NOT NULL
+    AND o.access_level IS NOT NULL;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.replace_fighter_skill_access_overrides(uuid, uuid[], jsonb) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.replace_fighter_skill_access_overrides(uuid, uuid[], jsonb) FROM anon;
+GRANT EXECUTE ON FUNCTION public.replace_fighter_skill_access_overrides(uuid, uuid[], jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.replace_fighter_skill_access_overrides(uuid, uuid[], jsonb) TO service_role;
+
+COMMENT ON FUNCTION public.replace_fighter_skill_access_overrides(uuid, uuid[], jsonb) IS
+  'Atomically rewrites fighter_skill_access_override rows for one fighter and the given skill types. SECURITY INVOKER: RLS of the caller still applies.';

--- a/utils/syncVenatorSkillOverrides.ts
+++ b/utils/syncVenatorSkillOverrides.ts
@@ -23,7 +23,6 @@ export interface SyncFighterInput {
 export async function syncFighter(
   input: SyncFighterInput,
   supabase: SupabaseClient,
-  _actingUserId: string,
 ): Promise<void> {
   if (!isVenatorGang(input.editionSlug, input.gangType, input.isCustomGangType)) return;
 
@@ -51,7 +50,6 @@ export async function replaceGangRanks(
   editionSlug: string | null | undefined,
   isCustomGangType: boolean,
   supabase: SupabaseClient,
-  _actingUserId: string,
 ): Promise<void> {
   if (!isVenatorGang(editionSlug, gangType, isCustomGangType)) return;
 

--- a/utils/syncVenatorSkillOverrides.ts
+++ b/utils/syncVenatorSkillOverrides.ts
@@ -11,37 +11,6 @@ async function readGangRanks(gangId: string, supabase: SupabaseClient) {
   return data ?? [];
 }
 
-async function rewriteFighterOverrides(
-  fighterId: string,
-  supabase: SupabaseClient,
-  actingUserId: string,
-  ownedSkillTypeIds: readonly string[],
-  overrides: Array<{ skill_type_id: string; access_level: 'primary' | 'secondary' }>,
-): Promise<void> {
-  if (ownedSkillTypeIds.length > 0) {
-    const { error: deleteErr } = await supabase
-      .from('fighter_skill_access_override')
-      .delete()
-      .eq('fighter_id', fighterId)
-      .in('skill_type_id', ownedSkillTypeIds as string[]);
-    if (deleteErr) throw deleteErr;
-  }
-
-  if (overrides.length === 0) return;
-
-  const rows = overrides.map((o) => ({
-    fighter_id: fighterId,
-    skill_type_id: o.skill_type_id,
-    access_level: o.access_level,
-    user_id: actingUserId,
-  }));
-
-  const { error: insertErr } = await supabase
-    .from('fighter_skill_access_override')
-    .insert(rows);
-  if (insertErr) throw insertErr;
-}
-
 export interface SyncFighterInput {
   fighterId: string;
   gangId: string;
@@ -54,7 +23,7 @@ export interface SyncFighterInput {
 export async function syncFighter(
   input: SyncFighterInput,
   supabase: SupabaseClient,
-  actingUserId: string,
+  _actingUserId: string,
 ): Promise<void> {
   if (!isVenatorGang(input.editionSlug, input.gangType, input.isCustomGangType)) return;
 
@@ -64,24 +33,40 @@ export async function syncFighter(
   const overrides = deriveOverrides(ranks, input.subtypes);
   const ownedSkillTypeIds = ranks.map((r) => r.skill_type_id);
 
-  await rewriteFighterOverrides(input.fighterId, supabase, actingUserId, ownedSkillTypeIds, overrides);
+  const { error } = await supabase.rpc('replace_fighter_skill_access_overrides', {
+    p_fighter_id: input.fighterId,
+    p_owned_skill_type_ids: ownedSkillTypeIds.length > 0 ? ownedSkillTypeIds : null,
+    p_overrides: overrides.map((o) => ({
+      skill_type_id: o.skill_type_id,
+      access_level: o.access_level,
+    })),
+  });
+  if (error) throw error;
 }
 
-export async function syncGang(
+export async function replaceGangRanks(
   gangId: string,
+  ranks: Array<{ rank: number; skill_type_id: string }>,
   gangType: string | null | undefined,
   editionSlug: string | null | undefined,
   isCustomGangType: boolean,
   supabase: SupabaseClient,
-  actingUserId: string,
-  previouslyOwnedSkillTypeIds: readonly string[] = [],
+  _actingUserId: string,
 ): Promise<void> {
   if (!isVenatorGang(editionSlug, gangType, isCustomGangType)) return;
 
-  const ranks = await readGangRanks(gangId, supabase);
+  const { data: previousRanks, error: previousRanksErr } = await supabase
+    .from('gang_skill_set_ranks')
+    .select('skill_type_id')
+    .eq('gang_id', gangId);
+  if (previousRanksErr) throw previousRanksErr;
+
   const currentSkillTypeIds = ranks.map((r) => r.skill_type_id);
   const ownedSkillTypeIds = Array.from(
-    new Set<string>([...previouslyOwnedSkillTypeIds, ...currentSkillTypeIds]),
+    new Set<string>([
+      ...(previousRanks ?? []).map((r) => r.skill_type_id as string),
+      ...currentSkillTypeIds,
+    ]),
   );
 
   const { data: fighters, error: fightersErr } = await supabase
@@ -90,33 +75,20 @@ export async function syncGang(
     .eq('gang_id', gangId);
   if (fightersErr) throw fightersErr;
 
-  const targetIds = (fighters ?? []).map((f) => f.id as string);
-  if (targetIds.length === 0 || ownedSkillTypeIds.length === 0) return;
+  const overrides = (fighters ?? []).flatMap((f) => {
+    const subs: string[] = Array.isArray(f.fighter_subtypes) ? f.fighter_subtypes : [];
+    return deriveOverrides(ranks, subs).map((o) => ({
+      fighter_id: f.id as string,
+      skill_type_id: o.skill_type_id,
+      access_level: o.access_level,
+    }));
+  });
 
-  const { error: deleteErr } = await supabase
-    .from('fighter_skill_access_override')
-    .delete()
-    .in('fighter_id', targetIds)
-    .in('skill_type_id', ownedSkillTypeIds);
-  if (deleteErr) throw deleteErr;
-
-  if (ranks.length === 0) return;
-
-  const rows = (fighters ?? [])
-    .flatMap((f) => {
-      const subs: string[] = Array.isArray(f.fighter_subtypes) ? f.fighter_subtypes : [];
-      return deriveOverrides(ranks, subs).map((o) => ({
-        fighter_id: f.id as string,
-        skill_type_id: o.skill_type_id,
-        access_level: o.access_level,
-        user_id: actingUserId,
-      }));
-    });
-
-  if (rows.length === 0) return;
-
-  const { error: insertErr } = await supabase
-    .from('fighter_skill_access_override')
-    .insert(rows);
-  if (insertErr) throw insertErr;
+  const { error } = await supabase.rpc('replace_gang_skill_set_ranks', {
+    p_gang_id: gangId,
+    p_ranks: ranks,
+    p_owned_skill_type_ids: ownedSkillTypeIds.length > 0 ? ownedSkillTypeIds : null,
+    p_overrides: overrides,
+  });
+  if (error) throw error;
 }


### PR DESCRIPTION
## Summary

- Make saving Venator Skill Set ranks atomic: one RPC replaces `gang_skill_set_ranks` and rewrites rank-derived `fighter_skill_access_override` rows in a single transaction, so a failed insert can no longer leave an empty rank table.
- Same for per-fighter sync on add/copy/edit (`replace_fighter_skill_access_overrides`). Add/edit now surface a skill-access warning toast; copy rolls back the new fighter if sync fails (and reports if that rollback fails).
- Restore a warning before changing or clearing existing ranks as an in-app modal (not `window.confirm`), because that rewrite resets custom Customise Skill Set Access on affected Skill Sets.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Schema / migration

## How I tested

- [x] Edit a Venator gang with existing ranks → change or clear ranks → in-app confirm appears → Cancel leaves ranks unchanged; Continue saves and fighter access matches the new ranking
- [x] First-time ranking (no previous ranks) saves without the confirm
- [x] Failed rank save (e.g. before the migration is applied) shows an error and leaves Edit Gang open
- [x] Add / edit a Venator fighter when sync would fail: fighter save succeeds, skill-access warning toast is shown
- [x] Copy a Venator fighter: success copies access; if sync fails, copy is rolled back (or the error says the incomplete copy could not be removed)

## Database

- [x] Migration added under `supabase/migrations/`
  - `supabase/migrations/20260901072836_replace_gang_skill_set_ranks.sql` (defines both RPCs below)
- [x] RPC/SQL function changed: updated both `supabase/migrations/` and the matching file under `supabase/functions/`

**`replace_gang_skill_set_ranks`** (`supabase/functions/replace_gang_skill_set_ranks.sql`)  
Called when saving Edit Gang → Venator Skill Access. In one transaction it deletes the gang's rows in `gang_skill_set_ranks`, inserts the new 0–4 ranked Skill Sets, then deletes and re-inserts `fighter_skill_access_override` rows for those Skill Sets on every fighter in the gang (derived Primary/Secondary from rank + subtype).

**`replace_fighter_skill_access_overrides`** (`supabase/functions/replace_fighter_skill_access_overrides.sql`)  
Called when adding, copying, or editing a Venator fighter. In one transaction it deletes that fighter's override rows for the gang's ranked Skill Sets, then inserts the derived overrides for that fighter only.

Both are `SECURITY INVOKER` (table RLS still applies). Canonical copies live under `supabase/functions/`; the migration applies them to the database.

### Migration status

- [x] Needs maintainer to apply the migration before merge
- [ ] Migration already applied

## Risk / rollout

Medium — **do not merge until the migration is applied.** After deploy, rank save calls `replace_gang_skill_set_ranks` and fighter add/copy/edit sync calls `replace_fighter_skill_access_overrides`. Without those functions, those paths will fail. No env vars or feature flags.