### PR TITLE
feat(battle-session): hide Blaze and Flesh Wounds in N26

### DIFF
--- a/components/battle-session/participant-card.tsx
+++ b/components/battle-session/participant-card.tsx
@@ -52,7 +52,7 @@ import { createGangLog } from '@/app/actions/logs/gang-logs';
 import { updateFighterXp } from '@/app/actions/edit-fighter';
 import FighterCard from '@/components/gang/fighter-card';
 import type { BattleSessionFull, BattleSessionParticipant, BattleSessionFighter, SessionCondition, SessionInjuryRecord } from '@/types/battle-session';
-import { beastSubtypeName } from '@/types/edition';
+import { beastSubtypeName, hasBlazeCondition, hasFleshWounds } from '@/types/edition';
 
 interface ConditionDefinition {
   key: string;
@@ -187,6 +187,17 @@ function FighterActionModal({
     fighter.session_record?.conditions ?? []
   );
 
+  // Conditions the edition doesn't use aren't offered. CONDITION_BY_KEY keeps every
+  // definition, so a value another edition already recorded still renders its badge.
+  const sessionConditions = useMemo(
+    () => SESSION_CONDITIONS.filter((c) => c.key !== 'blaze' || hasBlazeCondition(editionSlug)),
+    [editionSlug]
+  );
+  const numericConditions = useMemo(
+    () => NUMERIC_CONDITIONS.filter((c) => c.key !== 'flesh_wound' || hasFleshWounds(editionSlug)),
+    [editionSlug]
+  );
+
   const openXpModal = async () => {
     setLoadingXp(true);
     try {
@@ -271,9 +282,11 @@ function FighterActionModal({
             </Button>
           </div>
           <div className="space-y-2 border-t pt-3 text-left">
-            <h4 className="text-sm font-medium text-neutral-500">Wounds & Flesh Wounds</h4>
+            <h4 className="text-sm font-medium text-neutral-500">
+              {hasFleshWounds(editionSlug) ? 'Wounds & Flesh Wounds' : 'Wounds'}
+            </h4>
             <div className="flex flex-col gap-2">
-              {NUMERIC_CONDITIONS.map((nc) => {
+              {numericConditions.map((nc) => {
                 const current = draftConditions.find((c) => c.key === nc.key)?.value ?? 0;
                 return (
                   <div key={nc.key} className="flex items-center justify-between">
@@ -309,7 +322,7 @@ function FighterActionModal({
           <div className="space-y-2 border-t pt-3 text-left">
             <h4 className="text-sm font-medium text-neutral-500">Conditions</h4>
             <div className="flex flex-wrap gap-2">
-              {SESSION_CONDITIONS.map((condition) => {
+              {sessionConditions.map((condition) => {
                 const isActive = draftConditions.some((c) => c.key === condition.key);
                 return (
                   <Button

--- a/components/battle-session/participant-card.tsx
+++ b/components/battle-session/participant-card.tsx
@@ -52,7 +52,7 @@ import { createGangLog } from '@/app/actions/logs/gang-logs';
 import { updateFighterXp } from '@/app/actions/edit-fighter';
 import FighterCard from '@/components/gang/fighter-card';
 import type { BattleSessionFull, BattleSessionParticipant, BattleSessionFighter, SessionCondition, SessionInjuryRecord } from '@/types/battle-session';
-import { beastSubtypeName, hasBlazeCondition, hasFleshWoundCondition } from '@/types/edition';
+import { beastSubtypeName, hasBlazeCondition, hasFleshWoundCondition, hasIntoxicatedCondition } from '@/types/edition';
 
 interface ConditionDefinition {
   key: string;
@@ -189,10 +189,14 @@ function FighterActionModal({
 
   // Conditions the edition doesn't use aren't offered. CONDITION_BY_KEY keeps every
   // definition, so a value another edition already recorded still renders its badge.
-  const showBlaze = hasBlazeCondition(editionSlug);
   const showFleshWounds = hasFleshWoundCondition(editionSlug);
-  const sessionConditions = SESSION_CONDITIONS.filter((c) => showBlaze || c.key !== 'blaze');
-  const numericConditions = NUMERIC_CONDITIONS.filter((c) => showFleshWounds || c.key !== 'flesh_wound');
+  const hiddenConditionKeys = new Set<string>();
+  if (!hasBlazeCondition(editionSlug)) hiddenConditionKeys.add('blaze');
+  if (!hasIntoxicatedCondition(editionSlug)) hiddenConditionKeys.add('intoxicated');
+  if (!showFleshWounds) hiddenConditionKeys.add('flesh_wound');
+
+  const sessionConditions = SESSION_CONDITIONS.filter((c) => !hiddenConditionKeys.has(c.key));
+  const numericConditions = NUMERIC_CONDITIONS.filter((c) => !hiddenConditionKeys.has(c.key));
 
   const openXpModal = async () => {
     setLoadingXp(true);

--- a/components/battle-session/participant-card.tsx
+++ b/components/battle-session/participant-card.tsx
@@ -52,7 +52,7 @@ import { createGangLog } from '@/app/actions/logs/gang-logs';
 import { updateFighterXp } from '@/app/actions/edit-fighter';
 import FighterCard from '@/components/gang/fighter-card';
 import type { BattleSessionFull, BattleSessionParticipant, BattleSessionFighter, SessionCondition, SessionInjuryRecord } from '@/types/battle-session';
-import { beastSubtypeName, hasBlazeCondition, hasFleshWounds } from '@/types/edition';
+import { beastSubtypeName, hasBlazeCondition, hasFleshWoundCondition } from '@/types/edition';
 
 interface ConditionDefinition {
   key: string;
@@ -189,14 +189,10 @@ function FighterActionModal({
 
   // Conditions the edition doesn't use aren't offered. CONDITION_BY_KEY keeps every
   // definition, so a value another edition already recorded still renders its badge.
-  const sessionConditions = useMemo(
-    () => SESSION_CONDITIONS.filter((c) => c.key !== 'blaze' || hasBlazeCondition(editionSlug)),
-    [editionSlug]
-  );
-  const numericConditions = useMemo(
-    () => NUMERIC_CONDITIONS.filter((c) => c.key !== 'flesh_wound' || hasFleshWounds(editionSlug)),
-    [editionSlug]
-  );
+  const showBlaze = hasBlazeCondition(editionSlug);
+  const showFleshWounds = hasFleshWoundCondition(editionSlug);
+  const sessionConditions = SESSION_CONDITIONS.filter((c) => showBlaze || c.key !== 'blaze');
+  const numericConditions = NUMERIC_CONDITIONS.filter((c) => showFleshWounds || c.key !== 'flesh_wound');
 
   const openXpModal = async () => {
     setLoadingXp(true);
@@ -283,7 +279,7 @@ function FighterActionModal({
           </div>
           <div className="space-y-2 border-t pt-3 text-left">
             <h4 className="text-sm font-medium text-neutral-500">
-              {hasFleshWounds(editionSlug) ? 'Wounds & Flesh Wounds' : 'Wounds'}
+              {showFleshWounds ? 'Wounds & Flesh Wounds' : 'Wounds'}
             </h4>
             <div className="flex flex-col gap-2">
               {numericConditions.map((nc) => {

--- a/types/edition.ts
+++ b/types/edition.ts
@@ -213,6 +213,8 @@ const EDITION_CAPABILITIES = {
   scenarioD6Roll: { n23: false, n26: true },
   /** Fighters can catch fire — the Blaze condition token in a battle session. */
   blazeCondition:           { n23: true,  n26: false },
+  /** Fighters can be intoxicated — the Intoxicated condition token in a battle session. */
+  intoxicatedCondition:     { n23: true,  n26: false },
   /** Damage short of a lost wound leaves a Flesh Wound, counted per fighter. */
   fleshWoundCondition:      { n23: true,  n26: false },
   venatorSkillAccess:       { n23: false, n26: true  },
@@ -365,6 +367,9 @@ export const hasScenarioD6Roll = (editionSlug?: string | null): boolean =>
 
 export const hasBlazeCondition = (editionSlug?: string | null): boolean =>
   can('blazeCondition', editionSlug);
+
+export const hasIntoxicatedCondition = (editionSlug?: string | null): boolean =>
+  can('intoxicatedCondition', editionSlug);
 
 export const hasFleshWoundCondition = (editionSlug?: string | null): boolean =>
   can('fleshWoundCondition', editionSlug);

--- a/types/edition.ts
+++ b/types/edition.ts
@@ -214,7 +214,7 @@ const EDITION_CAPABILITIES = {
   /** Fighters can catch fire — the Blaze condition token in a battle session. */
   blazeCondition:           { n23: true,  n26: false },
   /** Damage short of a lost wound leaves a Flesh Wound, counted per fighter. */
-  fleshWounds:              { n23: true,  n26: false },
+  fleshWoundCondition:      { n23: true,  n26: false },
   venatorSkillAccess:       { n23: false, n26: true  },
 } as const satisfies Record<string, Record<EditionSlug, unknown>>;
 
@@ -366,8 +366,8 @@ export const hasScenarioD6Roll = (editionSlug?: string | null): boolean =>
 export const hasBlazeCondition = (editionSlug?: string | null): boolean =>
   can('blazeCondition', editionSlug);
 
-export const hasFleshWounds = (editionSlug?: string | null): boolean =>
-  can('fleshWounds', editionSlug);
+export const hasFleshWoundCondition = (editionSlug?: string | null): boolean =>
+  can('fleshWoundCondition', editionSlug);
 
 export const hasVenatorSkillAccess = (editionSlug: string | null | undefined): boolean =>
   can('venatorSkillAccess', editionSlug);

--- a/types/edition.ts
+++ b/types/edition.ts
@@ -211,6 +211,10 @@ const EDITION_CAPABILITIES = {
   championLeaderTypePromotion: { n23: false, n26: true },
   /** The battle's scenario is rolled for on a D6 against the edition's numbered scenarios. */
   scenarioD6Roll: { n23: false, n26: true },
+  /** Fighters can catch fire — the Blaze condition token in a battle session. */
+  blazeCondition:           { n23: true,  n26: false },
+  /** Damage short of a lost wound leaves a Flesh Wound, counted per fighter. */
+  fleshWounds:              { n23: true,  n26: false },
   venatorSkillAccess:       { n23: false, n26: true  },
 } as const satisfies Record<string, Record<EditionSlug, unknown>>;
 
@@ -358,6 +362,12 @@ export const hasChampionLeaderTypePromotion = (
 
 export const hasScenarioD6Roll = (editionSlug?: string | null): boolean =>
   can('scenarioD6Roll', editionSlug);
+
+export const hasBlazeCondition = (editionSlug?: string | null): boolean =>
+  can('blazeCondition', editionSlug);
+
+export const hasFleshWounds = (editionSlug?: string | null): boolean =>
+  can('fleshWounds', editionSlug);
 
 export const hasVenatorSkillAccess = (editionSlug: string | null | undefined): boolean =>
   can('venatorSkillAccess', editionSlug);


### PR DESCRIPTION
The fighter action modal offered every condition token to every edition.
Blaze and Flesh Wounds are N23 rules that N26 does not have, so N26
players were offered conditions their edition doesn't use.

Add blazeCondition and fleshWounds to EDITION_CAPABILITIES with the
matching hasBlazeCondition / hasFleshWounds accessors, and filter both
pickers on the session's edition_slug, which FighterActionModal already
receives. The counters heading drops "Flesh Wounds" when it isn't shown.

CONDITION_BY_KEY keeps every definition so a value another edition
already recorded still renders its badge.