### PR TITLE
Move Claude PR review from a Routine to GitHub Actions

### DIFF
--- a/.github/review-prompt.md
+++ b/.github/review-prompt.md
@@ -1,0 +1,20 @@
+You are a senior engineer reviewing a change against the full codebase.
+
+1. Examine the change under review: the pull request diff, title, and description when
+   reviewing a pull request, otherwise the locally modified files (stashed or not).
+2. Check against these criteria:
+   - Correctness: bugs, logic errors, regressions
+   - Edge cases and null/undefined handling
+   - Security issues (auth, injection, data leaks). This app uses Supabase with row level
+     security, so flag any query not scoped to the calling user.
+   - Performance concerns (N+1 queries, unnecessary re-renders, large allocations)
+   - Readability and maintainability
+   - Adherence to project conventions in CONTRIBUTING.md and README.md. In particular:
+     schema changes belong in `supabase/migrations/`, `supabase/schema/schema.public.sql`
+     is generated and must never be hand-edited, and an RPC or SQL change must update both
+     the migration and the matching `supabase/functions/*.sql` file.
+   - DRY and YAGNI: duplicated logic, unnecessary parameters, prop threading bloat
+3. Focus on high-signal issues. Do not nitpick style unless it impacts clarity.
+4. Report each finding with file + line, the issue, a suggested fix, and a severity
+   (high/medium/low).
+5. End with a verdict: approve, or changes requested (with a summary of blockers).

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,142 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, labeled]
+
+# one review per PR; a newer trigger supersedes an in-flight one
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  claude-review:
+    runs-on: ubuntu-latest
+    # Forks get no secrets and a read-only token, so a fork PR would fail on auth
+    # rather than on merit. Skip it; a maintainer applies the claude-review label
+    # after checking the diff. See CONTRIBUTING.md.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'labeled' || github.event.label.name == 'claude-review')
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          # Subscription auth: shares the hourly/weekly budget with interactive use,
+          # so the review can still be skipped when that budget is spent. The point
+          # of this workflow is that it now fails visibly when that happens.
+          # Swap this one line to `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`
+          # to decouple the reviewer from subscription rate limits entirely.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true # posts a live "in progress" comment
+          use_sticky_comment: true # re-runs update one comment instead of piling up
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            You are a senior engineer reviewing a pull request against the full codebase.
+            The PR branch is already checked out in the working directory.
+
+            1. Examine the PR diff, title, and description.
+            2. Check against these criteria:
+               - Correctness: bugs, logic errors, regressions
+               - Edge cases and null/undefined handling
+               - Security issues (auth, injection, data leaks). This app uses Supabase
+                 with row level security, so flag any query not scoped to the calling user.
+               - Performance concerns (N+1 queries, unnecessary re-renders, large allocations)
+               - Readability and maintainability
+               - Adherence to project conventions in CONTRIBUTING.md and README.md.
+                 In particular: schema changes belong in supabase/migrations/,
+                 supabase/schema/schema.public.sql is generated and must never be
+                 hand-edited, and an RPC or SQL change must update both the migration
+                 and the matching supabase/functions/*.sql file.
+               - DRY and YAGNI: duplicated logic, unnecessary parameters, prop threading bloat
+            3. Focus on high-signal issues. Do not nitpick style unless it impacts clarity.
+            4. Report each finding with file + line, the issue, a suggested fix, and a
+               severity (high/medium/low).
+            5. End with a verdict: approve, or changes requested (with a summary of blockers).
+
+            Post specific findings with `mcp__github_inline_comment__create_inline_comment`
+            (with `confirmed: true`). Post the summary and verdict with `gh pr comment`,
+            tagging the PR author.
+            Only post via GitHub - do not return the review as a chat message.
+            You are a reviewer: do not modify any files.
+          claude_args: |
+            --model claude-sonnet-5
+            --effort high
+            --max-turns 40
+            --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+
+      # The point of this workflow. Runs whether the step above succeeded, failed,
+      # or died mid-run, so a review that does not happen is never silent.
+      - name: Report review status on the PR
+        if: always()
+        uses: actions/github-script@v7
+        env:
+          CONCLUSION: ${{ steps.claude.outputs.conclusion }}
+          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+        with:
+          script: |
+            const fs = require('fs');
+            const MARKER = '<!-- claude-review-status -->';
+            const ok = process.env.CONCLUSION === 'success';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}`
+              + `/actions/runs/${context.runId}`;
+
+            // Best-effort: name the cause so nobody has to read the log to know
+            // whether this was a rate limit or a real error.
+            let reason = 'The review job failed. See the run log for details.';
+            const file = process.env.EXECUTION_FILE;
+            if (!ok && file && fs.existsSync(file)) {
+              const log = fs.readFileSync(file, 'utf8').toLowerCase();
+              if (/rate.?limit|usage limit|quota|\b429\b/.test(log)) {
+                reason = 'The Claude subscription usage limit (hourly or weekly cap) was '
+                  + 'reached, so no review was produced. **This is not a problem with your '
+                  + 'PR.** Reviews resume once the limit resets.';
+              } else if (/authentication|unauthorized|invalid.*token|expired|\b401\b/.test(log)) {
+                reason = 'Claude authentication failed. The `CLAUDE_CODE_OAUTH_TOKEN` '
+                  + 'repository secret is likely expired or invalid, and a maintainer needs '
+                  + 'to regenerate it with `claude setup-token`.';
+              }
+            }
+
+            const body = ok
+              ? `${MARKER}\n✅ Automated Claude review completed. [Run log](${runUrl})`
+              : `${MARKER}\n### ⚠️ Automated Claude review did not complete\n\n`
+                + `${reason}\n\n`
+                + `**This PR has not been machine-reviewed, so treat human review as `
+                + `required.**\n\n`
+                + `To retry: remove and re-add the \`claude-review\` label, or re-run the `
+                + `failed job from the [run page](${runUrl}).`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else if (!ok) {
+              // Only create a comment on failure; on success the green check is signal enough.
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.payload.pull_request.number,
+                body,
+              });
+            }

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -49,13 +49,28 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
-          gh api -H "Accept: application/vnd.github.raw" \
-            "repos/${GITHUB_REPOSITORY}/contents/.github/review-prompt.md?ref=${BASE_SHA}" \
-            > "${RUNNER_TEMP}/review-prompt.md"
+          prompt="${RUNNER_TEMP}/review-prompt.md"
+          if ! gh api -H "Accept: application/vnd.github.raw" \
+                 "repos/${GITHUB_REPOSITORY}/contents/.github/review-prompt.md?ref=${BASE_SHA}" \
+                 > "$prompt" 2> "${RUNNER_TEMP}/gh-err"; then
+            # 404 means the prompt is not on the base branch yet, which happens only while
+            # this workflow is being introduced - the PR adding it is its own base's future.
+            # Fall back to the checked-out copy there; once merged, the file always exists
+            # on base and this branch is unreachable, so it cannot be used to bypass the
+            # base-branch rule. Any other failure is real and must stop the job.
+            if grep -q 'HTTP 404' "${RUNNER_TEMP}/gh-err"; then
+              echo "::warning::.github/review-prompt.md is not on the base branch yet;" \
+                "using the copy from this PR. Expected only while adding this workflow."
+              cp .github/review-prompt.md "$prompt"
+            else
+              cat "${RUNNER_TEMP}/gh-err" >&2
+              exit 1
+            fi
+          fi
           delimiter="REVIEW_PROMPT_$(openssl rand -hex 8)"
           {
             printf 'text<<%s\n' "$delimiter"
-            cat "${RUNNER_TEMP}/review-prompt.md"
+            cat "$prompt"
             printf '\n%s\n' "$delimiter"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -91,18 +91,43 @@ jobs:
 
             // Best-effort: name the cause so nobody has to read the log to know
             // whether this was a rate limit or a real error.
+            //
+            // Match ONLY the final result message, never the file as a whole: the
+            // execution file is the entire session transcript, including every file
+            // Claude read. This workflow is one of them, and it contains the strings
+            // "usage limit" and "401" - so grepping the transcript reports a usage
+            // limit for any failure on a PR that touches this file. A generic message
+            // is better than a confidently wrong one.
             let reason = 'The review job failed. See the run log for details.';
             const file = process.env.EXECUTION_FILE;
             if (!ok && file && fs.existsSync(file)) {
-              const log = fs.readFileSync(file, 'utf8').toLowerCase();
-              if (/rate.?limit|usage limit|quota|\b429\b/.test(log)) {
+              let result = null;
+              try {
+                const messages = JSON.parse(fs.readFileSync(file, 'utf8'));
+                if (Array.isArray(messages)) {
+                  result = messages.reverse().find((m) => m && m.type === 'result');
+                }
+              } catch (err) {
+                core.warning(`Could not parse ${file}: ${err.message}`);
+              }
+
+              // `errors` and `result` are the only fields carrying failure text.
+              const detail = result
+                ? [].concat(result.errors || [], result.result || '').join('\n').toLowerCase()
+                : '';
+
+              if (/rate.?limit|usage limit|quota|\b429\b/.test(detail)) {
                 reason = 'The Claude subscription usage limit (hourly or weekly cap) was '
                   + 'reached, so no review was produced. **This is not a problem with your '
                   + 'PR.** Reviews resume once the limit resets.';
-              } else if (/authentication|unauthorized|invalid.*token|expired|\b401\b/.test(log)) {
+              } else if (/authentication|unauthorized|invalid.*token|expired|\b401\b/.test(detail)) {
                 reason = 'Claude authentication failed. The `CLAUDE_CODE_OAUTH_TOKEN` '
                   + 'repository secret is likely expired or invalid, and a maintainer needs '
                   + 'to regenerate it with `claude setup-token`.';
+              } else if (result && result.subtype === 'error_max_turns') {
+                reason = 'The review ran out of turns (`--max-turns`) before it finished, so '
+                  + 'its findings may be incomplete or missing. **This is not a problem with '
+                  + 'your PR.**';
               }
             }
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,8 +18,9 @@ jobs:
   claude-review:
     runs-on: ubuntu-latest
     # Forks get no secrets and a read-only token, so a fork PR would fail on auth
-    # rather than on merit. Skip it; a maintainer applies the claude-review label
-    # after checking the diff. See CONTRIBUTING.md.
+    # rather than on merit. Skip it — no label can rescue it, because this guard is
+    # evaluated for the `labeled` event too. Fork PRs get a human review instead.
+    # See CONTRIBUTING.md.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.draft == false &&
@@ -28,6 +29,17 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 1
+
+      # The review criteria live in one file so the local pre-PR review documented in
+      # CONTRIBUTING.md and this workflow cannot drift apart.
+      - name: Load the shared review prompt
+        id: review-prompt
+        run: |
+          {
+            echo 'text<<CLAUDE_REVIEW_PROMPT_EOF'
+            cat .github/review-prompt.md
+            echo 'CLAUDE_REVIEW_PROMPT_EOF'
+          } >> "$GITHUB_OUTPUT"
 
       - id: claude
         uses: anthropics/claude-code-action@v1
@@ -44,27 +56,9 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            You are a senior engineer reviewing a pull request against the full codebase.
             The PR branch is already checked out in the working directory.
 
-            1. Examine the PR diff, title, and description.
-            2. Check against these criteria:
-               - Correctness: bugs, logic errors, regressions
-               - Edge cases and null/undefined handling
-               - Security issues (auth, injection, data leaks). This app uses Supabase
-                 with row level security, so flag any query not scoped to the calling user.
-               - Performance concerns (N+1 queries, unnecessary re-renders, large allocations)
-               - Readability and maintainability
-               - Adherence to project conventions in CONTRIBUTING.md and README.md.
-                 In particular: schema changes belong in supabase/migrations/,
-                 supabase/schema/schema.public.sql is generated and must never be
-                 hand-edited, and an RPC or SQL change must update both the migration
-                 and the matching supabase/functions/*.sql file.
-               - DRY and YAGNI: duplicated logic, unnecessary parameters, prop threading bloat
-            3. Focus on high-signal issues. Do not nitpick style unless it impacts clarity.
-            4. Report each finding with file + line, the issue, a suggested fix, and a
-               severity (high/medium/low).
-            5. End with a verdict: approve, or changes requested (with a summary of blockers).
+            ${{ steps.review-prompt.outputs.text }}
 
             Post specific findings with `mcp__github_inline_comment__create_inline_comment`
             (with `confirmed: true`). Post the summary and verdict with `gh pr comment`,
@@ -77,11 +71,13 @@ jobs:
             --max-turns 40
             --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
 
-      # The point of this workflow. Runs whether the step above succeeded, failed,
-      # or died mid-run, so a review that does not happen is never silent.
+      # The point of this workflow. Runs whether the step above succeeded, failed, or
+      # died mid-run, so a review that does not happen is never silent. Deliberately not
+      # `always()`: this job is superseded by cancel-in-progress, and a cancelled run must
+      # not post a "did not complete" status over the newer run's result.
       - name: Report review status on the PR
-        if: always()
-        uses: actions/github-script@v7
+        if: ${{ !cancelled() }}
+        uses: actions/github-script@v9
         env:
           CONCLUSION: ${{ steps.claude.outputs.conclusion }}
           EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
@@ -119,7 +115,9 @@ jobs:
                 + `To retry: remove and re-add the \`claude-review\` label, or re-run the `
                 + `failed job from the [run page](${runUrl}).`;
 
-            const { data: comments } = await github.rest.issues.listComments({
+            // Paginated: on a long thread the marker comment can fall past page 1, and
+            // missing it would post a second status comment instead of updating the first.
+            const comments = await github.paginate(github.rest.issues.listComments, {
               ...context.repo,
               issue_number: context.payload.pull_request.number,
               per_page: 100,

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,14 +17,19 @@ permissions:
 jobs:
   claude-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 30 # a hung run must not leave the check pending for hours
     # Forks get no secrets and a read-only token, so a fork PR would fail on auth
     # rather than on merit. Skip it — no label can rescue it, because this guard is
     # evaluated for the `labeled` event too. Fork PRs get a human review instead.
     # See CONTRIBUTING.md.
+    #
+    # Drafts are skipped, except when someone applies the label: that is an explicit
+    # request for a review, and silently ignoring it would leave no comment either.
     if: >-
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.draft == false &&
-      (github.event.action != 'labeled' || github.event.label.name == 'claude-review')
+      github.event.pull_request.head.repo.full_name == github.repository && (
+        (github.event.action == 'labeled' && github.event.label.name == 'claude-review') ||
+        (github.event.action != 'labeled' && github.event.pull_request.draft == false)
+      )
     steps:
       - uses: actions/checkout@v5
         with:
@@ -32,13 +37,26 @@ jobs:
 
       # The review criteria live in one file so the local pre-PR review documented in
       # CONTRIBUTING.md and this workflow cannot drift apart.
+      #
+      # Read it from the BASE branch, never from the PR checkout: a PR must not be able
+      # to rewrite the prompt that reviews it. (The Claude App's own default-branch check
+      # covers the workflow file, but not this one.) The heredoc delimiter is randomised
+      # so no line in the file can close it early and inject step outputs.
       - name: Load the shared review prompt
         id: review-prompt
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
+          set -euo pipefail
+          gh api -H "Accept: application/vnd.github.raw" \
+            "repos/${GITHUB_REPOSITORY}/contents/.github/review-prompt.md?ref=${BASE_SHA}" \
+            > "${RUNNER_TEMP}/review-prompt.md"
+          delimiter="REVIEW_PROMPT_$(openssl rand -hex 8)"
           {
-            echo 'text<<CLAUDE_REVIEW_PROMPT_EOF'
-            cat .github/review-prompt.md
-            echo 'CLAUDE_REVIEW_PROMPT_EOF'
+            printf 'text<<%s\n' "$delimiter"
+            cat "${RUNNER_TEMP}/review-prompt.md"
+            printf '\n%s\n' "$delimiter"
           } >> "$GITHUB_OUTPUT"
 
       - id: claude
@@ -50,8 +68,13 @@ jobs:
           # Swap this one line to `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}`
           # to decouple the reviewer from subscription rate limits entirely.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          track_progress: true # posts a live "in progress" comment
-          use_sticky_comment: true # re-runs update one comment instead of piling up
+          # Deliberately no `track_progress` / `use_sticky_comment`. Either one puts the
+          # action in tag mode, which appends `--permission-mode acceptEdits` and
+          # `Bash(git add|commit|push|rm)` to the tool list — so a "reviewer" could commit
+          # to the branch it is reviewing, held back only by a line in the prompt. Without
+          # them the action runs in agent mode, where the tool list below is the whole
+          # list and read-only is enforced rather than requested. The cost is no live
+          # "in progress" comment, and re-runs post a new summary instead of updating one.
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -62,7 +85,11 @@ jobs:
 
             Post specific findings with `mcp__github_inline_comment__create_inline_comment`
             (with `confirmed: true`). Post the summary and verdict with `gh pr comment`,
-            tagging the PR author.
+            tagging the PR author. Start that comment with this line exactly, so a re-run
+            can fold the superseded summary away:
+
+            <!-- claude-review-summary -->
+
             Only post via GitHub - do not return the review as a chat message.
             You are a reviewer: do not modify any files.
           claude_args: |
@@ -86,6 +113,8 @@ jobs:
           script: |
             const fs = require('fs');
             const MARKER = '<!-- claude-review-status -->';
+            const SUMMARY_MARKER = '<!-- claude-review-summary -->';
+            const COLLAPSED = '<!-- claude-review-summary-superseded -->';
             const ok = process.env.CONCLUSION === 'success';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}`
               + `/actions/runs/${context.runId}`;
@@ -170,6 +199,27 @@ jobs:
               per_page: 100,
             });
             const existing = comments.find((c) => c.body && c.body.includes(MARKER));
+
+            // Without a sticky comment, each run posts a fresh summary via `gh pr comment`.
+            // Fold every superseded one into a <details> so the newest review is the one
+            // you read, without destroying the older text. Only ever touches bot comments
+            // carrying the summary marker, and never fails the job.
+            try {
+              const summaries = comments.filter((c) =>
+                c.user && c.user.type === 'Bot'
+                && c.body && c.body.includes(SUMMARY_MARKER)
+                && !c.body.startsWith(COLLAPSED));
+              for (const stale of summaries.slice(0, -1)) {
+                await github.rest.issues.updateComment({
+                  ...context.repo,
+                  comment_id: stale.id,
+                  body: `${COLLAPSED}\n<details>\n<summary>Superseded review summary</summary>\n\n`
+                    + `${stale.body}\n</details>`,
+                });
+              }
+            } catch (err) {
+              core.warning(`Could not fold superseded summaries: ${err.message}`);
+            }
 
             if (existing) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -81,6 +81,7 @@ jobs:
         env:
           CONCLUSION: ${{ steps.claude.outputs.conclusion }}
           EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+          CLAUDE_OUTCOME: ${{ steps.claude.outcome }}
         with:
           script: |
             const fs = require('fs');
@@ -98,9 +99,25 @@ jobs:
             // "usage limit" and "401" - so grepping the transcript reports a usage
             // limit for any failure on a PR that touches this file. A generic message
             // is better than a confidently wrong one.
+            // The action exits cleanly without setting `conclusion` when the Claude
+            // GitHub App declines to mint a token because this workflow file is not on
+            // the default branch yet (`workflow_not_found_on_default_branch`). A green
+            // step with no conclusion is that skip, not a failure - and it is what
+            // every PR that edits this file will see until the change is merged.
+            const skipped = !ok
+              && !process.env.CONCLUSION
+              && process.env.CLAUDE_OUTCOME === 'success';
+
             let reason = 'The review job failed. See the run log for details.';
+            if (skipped) {
+              reason = 'The Claude GitHub App declined to run because this version of '
+                + '`.github/workflows/claude-review.yml` is not on the default branch yet. '
+                + 'That is expected on a PR that adds or edits the review workflow itself, '
+                + 'and it resolves once the PR is merged. No review was produced.';
+            }
+
             const file = process.env.EXECUTION_FILE;
-            if (!ok && file && fs.existsSync(file)) {
+            if (!ok && !skipped && file && fs.existsSync(file)) {
               let result = null;
               try {
                 const messages = JSON.parse(fs.readFileSync(file, 'utf8'));
@@ -162,4 +179,11 @@ jobs:
                 issue_number: context.payload.pull_request.number,
                 body,
               });
+            }
+
+            // A skipped review leaves the Claude step green, which would make this check
+            // green too - and a green check has to keep meaning "the review ran".
+            if (skipped) {
+              core.setFailed('No review was produced: this workflow file is not on the '
+                + 'default branch yet.');
             }

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -90,15 +90,6 @@ jobs:
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}`
               + `/actions/runs/${context.runId}`;
 
-            // Best-effort: name the cause so nobody has to read the log to know
-            // whether this was a rate limit or a real error.
-            //
-            // Match ONLY the final result message, never the file as a whole: the
-            // execution file is the entire session transcript, including every file
-            // Claude read. This workflow is one of them, and it contains the strings
-            // "usage limit" and "401" - so grepping the transcript reports a usage
-            // limit for any failure on a PR that touches this file. A generic message
-            // is better than a confidently wrong one.
             // The action exits cleanly without setting `conclusion` when the Claude
             // GitHub App declines to mint a token because this workflow file is not on
             // the default branch yet (`workflow_not_found_on_default_branch`). A green
@@ -116,6 +107,13 @@ jobs:
                 + 'and it resolves once the PR is merged. No review was produced.';
             }
 
+            // Best-effort: name the cause so nobody has to read the log to know whether
+            // this was a rate limit or a real error. Match ONLY the final result message,
+            // never the file as a whole: the execution file is the entire session
+            // transcript, including every file Claude read. This workflow is one of them,
+            // and it contains the strings "usage limit" and "401" - so grepping the
+            // transcript reports a usage limit for any failure on a PR that touches this
+            // file. A generic message is better than a confidently wrong one.
             const file = process.env.EXECUTION_FILE;
             if (!ok && !skipped && file && fs.existsSync(file)) {
               let result = null;
@@ -148,14 +146,21 @@ jobs:
               }
             }
 
+            // Retrying a skip cannot work - the workflow has to reach the default
+            // branch first - so do not send anyone round that loop.
+            const retry = skipped
+              ? `Re-running will not change this until the PR is merged. `
+                + `[Run log](${runUrl}).`
+              : `To retry: remove and re-add the \`claude-review\` label, or re-run the `
+                + `failed job from the [run page](${runUrl}).`;
+
             const body = ok
               ? `${MARKER}\n✅ Automated Claude review completed. [Run log](${runUrl})`
               : `${MARKER}\n### ⚠️ Automated Claude review did not complete\n\n`
                 + `${reason}\n\n`
                 + `**This PR has not been machine-reviewed, so treat human review as `
                 + `required.**\n\n`
-                + `To retry: remove and re-add the \`claude-review\` label, or re-run the `
-                + `failed job from the [run page](${runUrl}).`;
+                + retry;
 
             // Paginated: on a long thread the marker comment can fall past page 1, and
             // missing it would post a second status comment instead of updating the first.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,52 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read # lets Claude read CI results on PRs
+
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    # The action itself only responds to users with write access, and allowed_bots
+    # is left at its default (empty) so no bot can invoke it.
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          # Same trade-off as claude-review.yml: subscription auth shares the
+          # hourly/weekly budget with interactive use. Swap to
+          # `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}` to decouple.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model claude-sonnet-5
+            --effort high
+            --max-turns 40
+            --allowedTools "Bash(npm install),Bash(npm run lint),Bash(npx tsc --noEmit)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -8,7 +8,10 @@ on:
   pull_request_review:
     types: [submitted]
   issues:
-    types: [opened, assigned]
+    # Only `opened`: the `if` below keys off @claude in the issue body or title, which
+    # assigning does not change. To trigger on assignment instead, set the action's
+    # `assignee_trigger` input and add `assigned` back here.
+    types: [opened]
 
 concurrency:
   group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
@@ -49,4 +52,8 @@ jobs:
             --model claude-sonnet-5
             --effort high
             --max-turns 40
+            # Adds to the action's own tool list rather than replacing it. File edits do
+            # not need listing: the action runs @claude mentions with
+            # `--permission-mode acceptEdits`, which allows writes inside the workspace
+            # (and only there), so `@claude fix this` can still change files.
             --allowedTools "Bash(npm install),Bash(npm run lint),Bash(npx tsc --noEmit)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,10 +38,30 @@ You are a senior engineer reviewing a future pull request against the full codeb
 6. Post the review as a comment in the chat
 ```
 
+### Automated review on the PR
+
+After a PR is opened (or marked ready for review), a **`claude-review`** check runs the same
+review automatically and posts its findings as inline comments plus a summary.
+
+- **Green check** - the review ran. Read the comments.
+- **Red check** - the review did **not** run, and a comment on the PR says why. The most common
+  cause is the maintainer's Claude usage limit being reached; that is not a problem with your PR.
+  When this happens, human review is required before merge.
+
+The check never blocks a merge. To re-run it after pushing fixes, remove and re-add the
+`claude-review` label, or re-run the failed job from the Actions run page.
+
+Mention `@claude` in a PR or issue comment to ask a follow-up question about a finding, or to
+ask for a fix.
+
+**Pull requests from forks are not reviewed automatically.** GitHub does not give fork PRs access
+to the repository secrets the workflow needs. A maintainer applies the `claude-review` label once
+they have looked over the diff.
+
 ## How to set up your environment
 
 1. **Prerequisites**
-   - Node.js 18+
+   - Node.js 20.20.2 or newer (see `.nvmrc`)
    - Supabase project URL and key
    - Cloudflare Turnstile keys
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,25 +18,11 @@ Before opening a PR, run `npm run lint` and make sure your changes work locally.
 
 This is a local step before you open a PR; it is separate from any automated review that may run after the PR is opened.
 
-Paste the following into a coding assistant to get a review of your local changes:
+Paste the contents of [`.github/review-prompt.md`](.github/review-prompt.md) into a coding
+assistant to get a review of your local changes, and ask it to post the review in the chat.
 
-```
-You are a senior engineer reviewing a future pull request against the full codebase.
-
-1. Examine the files being modified, either stashed or not
-2. Check against these criteria:
-   - Correctness: bugs, logic errors, regressions
-   - Edge cases and null/undefined handling
-   - Security issues (auth, injection, data leaks)
-   - Performance concerns (N+1 queries, unnecessary re-renders, large allocations)
-   - Readability and maintainability
-   - Adherence to project conventions in CONTRIBUTING.md and README.md
-   - DRY and YAGNI: duplicated logic, unnecessary parameters, prop threading bloat
-3. Focus on high-signal issues. Do not nitpick style unless it impacts clarity.
-4. Compile findings as a list: file + line number, issue description, suggested fix, and severity (high/medium/low).
-5. Provide a final verdict: approve, or changes requested (with summary of blockers).
-6. Post the review as a comment in the chat
-```
+That file is the same prompt the automated review below runs, so it is kept in one place
+rather than copied here — a clean local pass is a good predictor of a clean PR review.
 
 ### Automated review on the PR
 
@@ -48,15 +34,18 @@ review automatically and posts its findings as inline comments plus a summary.
   cause is the maintainer's Claude usage limit being reached; that is not a problem with your PR.
   When this happens, human review is required before merge.
 
-The check never blocks a merge. To re-run it after pushing fixes, remove and re-add the
-`claude-review` label, or re-run the failed job from the Actions run page.
+The check never blocks a merge. On a PR from a branch in this repository, re-run it after
+pushing fixes by adding the `claude-review` label (remove and re-add it if it is already
+there), or re-run the job from the Actions run page.
 
 Mention `@claude` in a PR or issue comment to ask a follow-up question about a finding, or to
 ask for a fix.
 
-**Pull requests from forks are not reviewed automatically.** GitHub does not give fork PRs access
-to the repository secrets the workflow needs. A maintainer applies the `claude-review` label once
-they have looked over the diff.
+**Pull requests from forks are not reviewed automatically, and the `claude-review` label does
+not change that.** GitHub withholds the repository secrets the workflow needs from fork PRs, so
+the workflow skips them regardless of labels. Fork PRs are reviewed by a human instead; running
+the local step above before opening one is the quickest way to catch what the automated review
+would have.
 
 ## How to set up your environment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,8 @@ rather than copied here — a clean local pass is a good predictor of a clean PR
 ### Automated review on the PR
 
 After a PR is opened (or marked ready for review), a **`claude-review`** check runs the same
-review automatically and posts its findings as inline comments plus a summary.
+review automatically and posts its findings as inline comments plus a summary. The reviewer
+is read-only: it comments, and cannot change files on your branch.
 
 - **Green check** - the review ran. Read the comments.
 - **Red check** - the review did **not** run, and a comment on the PR says why. The most common
@@ -36,7 +37,9 @@ review automatically and posts its findings as inline comments plus a summary.
 
 The check never blocks a merge. On a PR from a branch in this repository, re-run it after
 pushing fixes by adding the `claude-review` label (remove and re-add it if it is already
-there), or re-run the job from the Actions run page.
+there), or re-run the job from the Actions run page. The label also works on a draft PR,
+which is otherwise not reviewed until it is marked ready. Each re-run posts a new summary
+and folds the previous one into a collapsed block.
 
 A PR that changes `.github/workflows/claude-review.yml` itself is the one case that always
 goes red: the Claude GitHub App only runs a workflow version that is already on `main`, so

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,10 @@ The check never blocks a merge. On a PR from a branch in this repository, re-run
 pushing fixes by adding the `claude-review` label (remove and re-add it if it is already
 there), or re-run the job from the Actions run page.
 
+A PR that changes `.github/workflows/claude-review.yml` itself is the one case that always
+goes red: the Claude GitHub App only runs a workflow version that is already on `main`, so
+the review is skipped until the change merges. The comment says so when it happens.
+
 Mention `@claude` in a PR or issue comment to ask a follow-up question about a finding, or to
 ask for a fix.
 


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? -->

- The PR review ran as a Claude Routine on a personal account. When the hourly or weekly subscription budget was spent the Routine stopped without posting anything, so an unreviewed PR looked identical to a reviewed-and-clean one to every other contributor.

Run the reviewer as a workflow instead, so its state is a first-class object on the PR:

- claude-review.yml reviews a PR on open/reopen/ready_for_review, and re-runs on demand via a `claude-review` label. It reports status back to the PR whether it succeeds or fails, naming the cause (usage limit vs. expired token vs. unknown) so a skipped review is never silent. The check is deliberately allowed to go red and must not be added to branch protection: a rate-limited reviewer should be visible, not blocking.

Both authenticate with CLAUDE_CODE_OAUTH_TOKEN, which shares the subscription budget, so this makes the failure visible rather than making the reviewer always available. Swapping the single auth line to anthropic_api_key decouples it from those limits if that is wanted later.

Fork PRs are skipped, since GitHub withholds secrets from them.

The review prompt targeted conventions in CLAUDE.md, which this repo does not have; it now reads CONTRIBUTING.md and README.md, and calls out the Supabase migration rules explicitly. Also corrects the stale Node.js 18+ prerequisite to match .nvmrc.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Schema / migration

## How I tested

<!-- What you tested before opening this PR. Example: Opened gang X → bought equipment → credits/rating updated -->

- With a test label

## Risk / rollout

<!-- e.g. Low / Medium — any deploy notes beyond database (env vars, feature flags, etc.). -->

- PR reviews stops - can stil be triggered manually
