### PR TITLE
Rank remaining N26 skill sets and share group labels through getSkill…

### DIFF
--- a/components/admin/admin-create-fighter-type.tsx
+++ b/components/admin/admin-create-fighter-type.tsx
@@ -11,7 +11,7 @@ import { GangType, Equipment } from "@/types/gang";
 import { EditionSelect, useEditions } from '@/components/edition-select';
 import { hasAlignment, hasSaveCharacteristic, allowsMultipleSubtypes, hasStartingXp, hasVehicles } from '@/types/edition';
 import { toggleFighterSubtype } from '@/utils/fighter-subtype-picker';
-import { getSkillSetRank } from "@/utils/skillSetRank";
+import { getSkillSetGroupLabel, getSkillSetRank } from "@/utils/skillSetRank";
 import { compareEquipmentCategories } from "@/utils/getEquipmentCategoryRank";
 import Modal from '@/components/ui/modal';
 
@@ -196,15 +196,7 @@ export function AdminCreateFighterTypeModal({ onClose, onSubmit }: AdminCreateFi
         })
         .reduce((groups, type) => {
           const rank = skillSetRank[type.skill_type.toLowerCase()] ?? Infinity;
-          let groupLabel = "Misc."; // Default category for unranked skills
-
-          if (rank <= 19) groupLabel = "Universal Skills";
-          else if (rank <= 39) groupLabel = "Gang-specific Skills";
-          else if (rank <= 59) groupLabel = "Wyrd Powers";
-          else if (rank <= 69) groupLabel = "Cult Wyrd Powers";
-          else if (rank <= 79) groupLabel = "Psychoteric Whispers";
-          else if (rank <= 89) groupLabel = "Legendary Names";
-          else if (rank <= 99) groupLabel = "Ironhead Squat Mining Clans";
+          const groupLabel = getSkillSetGroupLabel(rank);
 
           if (!groups[groupLabel]) groups[groupLabel] = [];
           groups[groupLabel].push(type);

--- a/components/admin/admin-create-skill.tsx
+++ b/components/admin/admin-create-skill.tsx
@@ -5,7 +5,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { toast } from 'sonner';
-import { getSkillSetRank } from "@/utils/skillSetRank";
+import { getSkillSetGroupLabel, getSkillSetRank } from "@/utils/skillSetRank";
 import { gangOriginRank } from "@/utils/gangOriginRank";
 import { EditionSelect, useEditions, editionSlugOf } from '@/components/edition-select';
 
@@ -190,15 +190,7 @@ export function AdminCreateSkillModal({ onClose, onSubmit }: AdminCreateSkillMod
                     })
                     .reduce((groups, type) => {
                       const rank = skillSetRank[type.skill_type.toLowerCase()] ?? Infinity;
-                      let groupLabel = "Misc."; // Default category for unlisted skill sets
-
-                      if (rank <= 19) groupLabel = "Universal Skills";
-                      else if (rank <= 39) groupLabel = "Gang-specific Skills";
-                      else if (rank <= 59) groupLabel = "Wyrd Powers";
-                      else if (rank <= 69) groupLabel = "Cult Wyrd Powers";
-                      else if (rank <= 79) groupLabel = "Psychoteric Whispers";
-                      else if (rank <= 89) groupLabel = "Legendary Names";
-                      else if (rank <= 99) groupLabel = "Ironhead Squat Mining Clans";
+                      const groupLabel = getSkillSetGroupLabel(rank);
 
                       if (!groups[groupLabel]) groups[groupLabel] = [];
                       groups[groupLabel].push(type);

--- a/components/admin/admin-edit-fighter-type.tsx
+++ b/components/admin/admin-edit-fighter-type.tsx
@@ -11,7 +11,7 @@ import { LuTrash2 } from "react-icons/lu";
 import { FighterType } from "@/types/fighter";
 import { GangType } from "@/types/gang";
 import { Equipment } from '@/types/equipment';
-import { getSkillSetRank } from "@/utils/skillSetRank";
+import { getSkillSetGroupLabel, getSkillSetRank } from "@/utils/skillSetRank";
 import { compareEquipmentCategories } from "@/utils/getEquipmentCategoryRank";
 import { AdminFighterEquipmentSelection, EquipmentSelection, guiToDataModel, dataModelToGui } from "@/components/admin/admin-fighter-equipment-selection";
 import { EditionSelect, useEditions } from '@/components/edition-select';
@@ -373,15 +373,7 @@ export function AdminEditFighterTypeModal({ onClose, onSubmit }: AdminEditFighte
         })
         .reduce((groups, type) => {
           const rank = skillSetRank[type.skill_type.toLowerCase()] ?? Infinity;
-          let groupLabel = "Misc.";
-
-          if (rank <= 19) groupLabel = "Universal Skills";
-          else if (rank <= 39) groupLabel = "Gang-specific Skills";
-          else if (rank <= 59) groupLabel = "Wyrd Powers";
-          else if (rank <= 69) groupLabel = "Cult Wyrd Powers";
-          else if (rank <= 79) groupLabel = "Psychoteric Whispers";
-          else if (rank <= 89) groupLabel = "Legendary Names";
-          else if (rank <= 99) groupLabel = "Ironhead Squat Mining Clans";
+          const groupLabel = getSkillSetGroupLabel(rank);
 
           if (!groups[groupLabel]) groups[groupLabel] = [];
           groups[groupLabel].push(type);

--- a/components/admin/admin-edit-skill.tsx
+++ b/components/admin/admin-edit-skill.tsx
@@ -5,7 +5,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { toast } from 'sonner';
-import { getSkillSetRank } from "@/utils/skillSetRank";
+import { getSkillSetGroupLabel, getSkillSetRank } from "@/utils/skillSetRank";
 import { gangOriginRank } from "@/utils/gangOriginRank";
 import { AdminFighterEffects } from './admin-fighter-effects';
 import { EditionSelect, useEditions, editionSlugOf } from '@/components/edition-select';
@@ -462,15 +462,7 @@ const handleSubmitSkill = async (operation: OperationType) => {
                     })
                     .reduce((groups, type) => {
                       const rank = skillSetRank[type.skill_type.toLowerCase()] ?? Infinity;
-                      let groupLabel = "Misc."; // Default category for unlisted skill sets
-
-                      if (rank <= 19) groupLabel = "Universal Skills";
-                      else if (rank <= 39) groupLabel = "Gang-specific Skills";
-                      else if (rank <= 59) groupLabel = "Wyrd Powers";
-                      else if (rank <= 69) groupLabel = "Cult Wyrd Powers";
-                      else if (rank <= 79) groupLabel = "Psychoteric Whispers";
-                      else if (rank <= 89) groupLabel = "Legendary Names";
-                      else if (rank <= 99) groupLabel = "Ironhead Squat Mining Clans";
+                      const groupLabel = getSkillSetGroupLabel(rank);
 
                       if (!groups[groupLabel]) groups[groupLabel] = [];
                       groups[groupLabel].push(type);

--- a/components/customise/custom-fighters.tsx
+++ b/components/customise/custom-fighters.tsx
@@ -22,7 +22,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createCustomFighter, deleteCustomFighter, updateCustomFighter } from '@/app/actions/customise/custom-fighters';
 import { DESCRIPTION_MAX_LENGTH } from '@/app/actions/customise/custom-constants';
 import { ShareCustomFighterModal } from '@/components/customise/custom-shared';
-import { getSkillSetRank } from '@/utils/skillSetRank';
+import { getSkillSetGroupLabel, getSkillSetRank } from '@/utils/skillSetRank';
 import type { UserCampaign } from '@/types/campaign';
 import type { EquipmentListItem } from '@/types/equipment';
 import {
@@ -62,14 +62,7 @@ function SkillSetOptions({ skillTypes, excludeIds, editionSlug }: {
   const groupByLabel: Record<string, SkillTypeItem[]> = {};
   standardTypes.forEach(st => {
     const rank = skillSetRank[st.skill_type.toLowerCase()] ?? Infinity;
-    let groupLabel = 'Misc.';
-    if (rank <= 19) groupLabel = 'Universal Skill Sets';
-    else if (rank <= 39) groupLabel = 'Gang-specific Skill Sets';
-    else if (rank <= 59) groupLabel = 'Wyrd Powers';
-    else if (rank <= 69) groupLabel = 'Cult Wyrd Powers';
-    else if (rank <= 79) groupLabel = 'Psychoteric Whispers';
-    else if (rank <= 89) groupLabel = 'Legendary Names';
-    else if (rank <= 99) groupLabel = 'Ironhead Squat Mining Clans';
+    const groupLabel = getSkillSetGroupLabel(rank);
     if (!groupByLabel[groupLabel]) groupByLabel[groupLabel] = [];
     groupByLabel[groupLabel].push(st);
   });

--- a/components/customise/custom-skills.tsx
+++ b/components/customise/custom-skills.tsx
@@ -11,7 +11,7 @@ import { toast } from 'sonner';
 import { LuEye, LuSquarePen, LuTrash2 } from 'react-icons/lu';
 import { FaRegCopy } from 'react-icons/fa';
 import { FiShare2 } from 'react-icons/fi';
-import { getSkillSetRank } from '@/utils/skillSetRank';
+import { getSkillSetGroupLabel, getSkillSetRank } from '@/utils/skillSetRank';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Textarea } from '@/components/ui/textarea';
 import { BiSolidNotepad } from 'react-icons/bi';
@@ -339,14 +339,7 @@ export function CustomiseSkills({ className, initialSkills = [], readOnly = fals
     const groupByLabel: Record<string, SkillType[]> = {};
     standardTypes.forEach(type => {
       const rank = skillSetRank[type.name.toLowerCase()] ?? Infinity;
-      let groupLabel = 'Misc.';
-      if (rank <= 19) groupLabel = 'Universal Skill Sets';
-      else if (rank <= 39) groupLabel = 'Gang-specific Skill Sets';
-      else if (rank <= 59) groupLabel = 'Wyrd Powers';
-      else if (rank <= 69) groupLabel = 'Cult Wyrd Powers';
-      else if (rank <= 79) groupLabel = 'Psychoteric Whispers';
-      else if (rank <= 89) groupLabel = 'Legendary Names';
-      else if (rank <= 99) groupLabel = 'Ironhead Squat Mining Clans';
+      const groupLabel = getSkillSetGroupLabel(rank);
       if (!groupByLabel[groupLabel]) groupByLabel[groupLabel] = [];
       groupByLabel[groupLabel].push(type);
     });

--- a/utils/skillSetRank.ts
+++ b/utils/skillSetRank.ts
@@ -33,7 +33,7 @@ export function getSkillSetGroupLabel(rank: number): string {
   if (rank <= 19) return 'Universal Skill Sets';
   if (rank <= 39) return 'Gang-specific Skill Sets';
   if (rank <= 59) return 'Wyrd Powers';
-  if (rank <= 69) return 'Cult Wyrd Powers';
+  if (rank <= 69) return 'Gang-specific Wyrd Powers';
   if (rank <= 79) return 'Psychoteric Whispers';
   if (rank <= 89) return 'Legendary Names';
   if (rank <= 99) return 'Ironhead Squat Mining Clans';

--- a/utils/skillSetRankN26.ts
+++ b/utils/skillSetRankN26.ts
@@ -5,4 +5,16 @@ export const skillSetRankN26: { [key: string]: number } = {
   "cunning": 4,
   "savant": 5,
   "shooting": 6,
+  //
+  "finesse": 20,
+  "muscle": 21,
+  //
+  "wyrd powers": 40,
+  //
+  "bonecrusher wyrd powers": 60,
+  "chaos helot wyrd powers": 61,
+  "genestealer wyrd powers": 62,
+  "malstrain wyrd powers": 63,
+  "psychoteric whispers": 64,
+  "psyrender wyrd powers": 65,
 };


### PR DESCRIPTION
…SetGroupLabel.

## Summary

- Rank the remaining N26 skill sets (Finesse, Muscle, Wyrd Powers, and gang-specific wyrd lists including Psychoteric Whispers) so they sort and group instead of falling into Misc.
- Rename the 60–69 band from Cult Wyrd Powers to Gang-specific Wyrd Powers.
- Route admin and customise skill-set dropdowns through ``getSkillSetGroupLabel`` so band labels live in one place.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Docs
- [ ] Schema / migration

## How I tested

- [x] Compared N26 ``skill_types`` in the DB against ``skillSetRankN26`` (Inherent left unranked on purpose)
- [x] Opened an N26 skill-set dropdown (customise / admin / fighter skill access) and confirmed Finesse, Muscle, and wyrd lists no longer sit under Misc
- [x] Confirmed gang-specific wyrd lists (including Psychoteric Whispers, Bonecrusher, Psyrender) group under Gang-specific Wyrd Powers
- [x] Spot-checked an N23 skill-set dropdown: Madness / Darkness / Delusion still under Psychoteric Whispers; former Cult Wyrd Powers now labelled Gang-specific Wyrd Powers

## Risk / rollout

- Low — sort order and optgroup labels only. No schema or runtime write-path changes. Admin dropdowns now use the shared wording (Universal Skill Sets / Gang-specific Skill Sets) instead of the shorter Universal Skills / Gang-specific Skills copy.
