### PR TITLE
Link alternate house gang lists to their root gang type so house iden…

### DIFF
--- a/supabase/README.md
+++ b/supabase/README.md
@@ -60,3 +60,4 @@ Syncing of those files is not automatic. If you update a function on Supabase, m
 | notify_gang_invite           | campaign_gangs     | Sends notification for gang invites       |
 | enqueue_notification_email   | notifications      | Queues an outbound email for a new notification |
 | handle_new_user              | auth.users         | Creates a profiles row on signup (`on_auth_user_created`) |
+| gang_types_parent_must_be_root | gang_types       | Keeps parent_gang_type_id one level deep (parent must be a root) |

--- a/supabase/functions/gang_types_parent_must_be_root.sql
+++ b/supabase/functions/gang_types_parent_must_be_root.sql
@@ -1,0 +1,44 @@
+-- Keep gang_types.parent_gang_type_id one level deep: the parent must itself be
+-- a root, and a type that already has children cannot become a child.
+--
+-- DEPLOY ORDER: apply migration 20260902172743_add_gang_types_parent_gang_type_id.sql
+-- (which creates the column) BEFORE this trigger goes live. UPDATE OF
+-- parent_gang_type_id will fail if the column does not exist.
+
+CREATE OR REPLACE FUNCTION public.gang_types_parent_must_be_root()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.parent_gang_type_id IS NOT NULL THEN
+    IF EXISTS (
+      SELECT 1
+      FROM public.gang_types
+      WHERE gang_type_id = NEW.parent_gang_type_id
+        AND parent_gang_type_id IS NOT NULL
+    ) THEN
+      RAISE EXCEPTION 'parent_gang_type_id must reference a root gang type';
+    END IF;
+
+    IF EXISTS (
+      SELECT 1
+      FROM public.gang_types
+      WHERE parent_gang_type_id = NEW.gang_type_id
+    ) THEN
+      RAISE EXCEPTION 'cannot set parent_gang_type_id on a gang type that is already a parent of other gang lists';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.gang_types_parent_must_be_root() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.gang_types_parent_must_be_root() FROM anon, authenticated;
+
+DROP TRIGGER IF EXISTS gang_types_parent_must_be_root ON public.gang_types;
+CREATE TRIGGER gang_types_parent_must_be_root
+  BEFORE INSERT OR UPDATE OF parent_gang_type_id ON public.gang_types
+  FOR EACH ROW
+  EXECUTE FUNCTION public.gang_types_parent_must_be_root();

--- a/supabase/migrations/20260902172743_add_gang_types_parent_gang_type_id.sql
+++ b/supabase/migrations/20260902172743_add_gang_types_parent_gang_type_id.sql
@@ -112,12 +112,25 @@ CREATE TRIGGER gang_types_parent_must_be_root
   EXECUTE FUNCTION public.gang_types_parent_must_be_root();
 
 -- One-time name heuristic: "{parent}: {suffix}" whose parent exists as an exact
--- gang_type in the same edition. Does not match Variant: … (no type named Variant).
+-- gang_type in the same edition. starts_with, not LIKE, so %/_ in a name are
+-- literal. A scalar subquery raises if a child matches more than one root
+-- (UPDATE ... FROM would otherwise pick one at random). Does not match
+-- Variant: … (no type named Variant).
 UPDATE public.gang_types AS child
-SET parent_gang_type_id = parent.gang_type_id
-FROM public.gang_types AS parent
+SET parent_gang_type_id = (
+  SELECT parent.gang_type_id
+  FROM public.gang_types AS parent
+  WHERE parent.parent_gang_type_id IS NULL
+    AND child.gang_type_id IS DISTINCT FROM parent.gang_type_id
+    AND child.edition_id IS NOT DISTINCT FROM parent.edition_id
+    AND starts_with(child.gang_type, parent.gang_type || ': ')
+)
 WHERE child.parent_gang_type_id IS NULL
-  AND parent.parent_gang_type_id IS NULL
-  AND child.gang_type_id IS DISTINCT FROM parent.gang_type_id
-  AND child.edition_id IS NOT DISTINCT FROM parent.edition_id
-  AND child.gang_type LIKE (parent.gang_type || ': %');
+  AND EXISTS (
+    SELECT 1
+    FROM public.gang_types AS parent
+    WHERE parent.parent_gang_type_id IS NULL
+      AND child.gang_type_id IS DISTINCT FROM parent.gang_type_id
+      AND child.edition_id IS NOT DISTINCT FROM parent.edition_id
+      AND starts_with(child.gang_type, parent.gang_type || ': ')
+  );

--- a/supabase/migrations/20260902172743_add_gang_types_parent_gang_type_id.sql
+++ b/supabase/migrations/20260902172743_add_gang_types_parent_gang_type_id.sql
@@ -1,0 +1,123 @@
+-- Alternate house gang lists (House Escher: Wyld Hunt, House Goliath: Unborn Gang, …)
+-- are their own gang_types rows with their own fighter catalogs. Until now the
+-- only link to the house was the name prefix. That is a display string, not a
+-- join key: Variant: Chaos Corrupted also contains a colon, and anything that
+-- needs "is this Escher?" (hatred, trading post, house equipment) cannot safely
+-- parse it.
+--
+-- parent_gang_type_id is that link. NULL = root type (House Escher). Set =
+-- replacement gang list of that house. Created gangs still store the gang list's own
+-- gang_type_id; join here when you need the house.
+--
+-- The composite FK against (gang_type_id, edition_id) forces parent and child
+-- to share an edition (MATCH SIMPLE leaves roots with a null parent alone).
+-- A trigger keeps the tree one level deep: the parent must itself be a root,
+-- and a type that already has children cannot become a child.
+
+ALTER TABLE public.gang_types
+  ADD COLUMN IF NOT EXISTS parent_gang_type_id uuid;
+
+COMMENT ON COLUMN public.gang_types.parent_gang_type_id IS
+  'House this gang list belongs to. House Escher: Wyld Hunt stores House Escher''s '
+  'gang_type_id here; House Escher itself stores null. Each row keeps its own '
+  'fighter types.';
+
+CREATE INDEX IF NOT EXISTS gang_types_parent_gang_type_id_idx
+  ON public.gang_types (parent_gang_type_id);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'gang_types_parent_not_self_check'
+      AND conrelid = 'public.gang_types'::regclass
+  ) THEN
+    ALTER TABLE public.gang_types
+      ADD CONSTRAINT gang_types_parent_not_self_check
+      CHECK (parent_gang_type_id IS DISTINCT FROM gang_type_id);
+  END IF;
+END $$;
+
+-- Composite FK is MATCH SIMPLE: if parent_gang_type_id is set but edition_id
+-- is null, Postgres does not check that the parent is in the same edition.
+-- This CHECK requires edition_id whenever a parent is set.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'gang_types_parent_requires_edition_check'
+      AND conrelid = 'public.gang_types'::regclass
+  ) THEN
+    ALTER TABLE public.gang_types
+      ADD CONSTRAINT gang_types_parent_requires_edition_check
+      CHECK (parent_gang_type_id IS NULL OR edition_id IS NOT NULL);
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'gang_types_parent_gang_type_edition_fkey'
+      AND conrelid = 'public.gang_types'::regclass
+  ) THEN
+    ALTER TABLE public.gang_types
+      ADD CONSTRAINT gang_types_parent_gang_type_edition_fkey
+      FOREIGN KEY (parent_gang_type_id, edition_id)
+      REFERENCES public.gang_types (gang_type_id, edition_id)
+      ON UPDATE CASCADE
+      ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+-- Trigger body also lives in supabase/functions/gang_types_parent_must_be_root.sql
+-- (canonical source redeployed by CI). Included here so the first apply is complete.
+CREATE OR REPLACE FUNCTION public.gang_types_parent_must_be_root()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.parent_gang_type_id IS NOT NULL THEN
+    IF EXISTS (
+      SELECT 1
+      FROM public.gang_types
+      WHERE gang_type_id = NEW.parent_gang_type_id
+        AND parent_gang_type_id IS NOT NULL
+    ) THEN
+      RAISE EXCEPTION 'parent_gang_type_id must reference a root gang type';
+    END IF;
+
+    IF EXISTS (
+      SELECT 1
+      FROM public.gang_types
+      WHERE parent_gang_type_id = NEW.gang_type_id
+    ) THEN
+      RAISE EXCEPTION 'cannot set parent_gang_type_id on a gang type that is already a parent of other gang lists';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.gang_types_parent_must_be_root() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.gang_types_parent_must_be_root() FROM anon, authenticated;
+
+DROP TRIGGER IF EXISTS gang_types_parent_must_be_root ON public.gang_types;
+CREATE TRIGGER gang_types_parent_must_be_root
+  BEFORE INSERT OR UPDATE OF parent_gang_type_id ON public.gang_types
+  FOR EACH ROW
+  EXECUTE FUNCTION public.gang_types_parent_must_be_root();
+
+-- One-time name heuristic: "{parent}: {suffix}" whose parent exists as an exact
+-- gang_type in the same edition. Does not match Variant: … (no type named Variant).
+UPDATE public.gang_types AS child
+SET parent_gang_type_id = parent.gang_type_id
+FROM public.gang_types AS parent
+WHERE child.parent_gang_type_id IS NULL
+  AND parent.parent_gang_type_id IS NULL
+  AND child.gang_type_id IS DISTINCT FROM parent.gang_type_id
+  AND child.edition_id IS NOT DISTINCT FROM parent.edition_id
+  AND child.gang_type LIKE (parent.gang_type || ': %');


### PR DESCRIPTION
…tity is a foreign key, not a name prefix.

## Summary

- Add ``parent_gang_type_id`` on ``gang_types`` so N26 gang lists (Wyld Hunt, Chymist Cult, Furnace Brutes, Unborn) reference their house.
- Keep the tree one level deep (parent must be a root) and backfill existing colon-named rows in the same edition.

**Why:** those gang lists are separate ``gang_types`` rows with their own fighter catalogs, but they are still House Escher / House Goliath for hatred, the list of gangs when creating a gang, and for potential other effects applying to a whole House. The only link today is the name (``House Escher: Wyld Hunt``). That is not a join key: ``Variant: Chaos Corrupted`` also contains a colon, and ``ILIKE 'House Escher%'`` is unsafe. Without a parent FK, unhiding the lists would treat them as extra houses, and Hatred (type of gang) on House Escher would not cover Wyld Hunt or Chymist Cult. This is also needed to add a secondary choice when creating a gang where a user chooses House Escher, for them to select if they want the standard gang, or one of the child gang (ie. Chymist cult, Wyld hunt)

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Schema / migration

## How I tested

- [x] Migration not applied yet
- [ ] After apply: four children parented to House Escher / House Goliath; ``Variant: …`` rows stay roots

## Database

- [x] Migration added under ``supabase/migrations/``
- [x] RPC/SQL function changed: updated both ``supabase/migrations/`` and the matching file under ``supabase/functions/``

### Migration status

- [x] Needs maintainer to apply the migration before merge
- [ ] Migration already applied

## Risk / rollout

- Low — additive nullable column, no app callers yet. Apply the migration before this PR is merged (or before the functions file is deployed from ``main``), or the ``UPDATE OF parent_gang_type_id`` trigger will fail.