### PR TITLE
Scope Equipment List grants by gang origin, gang variant and fighter subtype

### DIFF
--- a/app/api/admin/equipment/route.ts
+++ b/app/api/admin/equipment/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { createClient } from "@/utils/supabase/server";
 import { checkAdmin } from "@/utils/auth";
-import { WeaponProfileInput, EquipmentAvailability, EquipmentOriginAvailability, EquipmentVariantAvailability, GangAdjustedCost, GangOriginAdjustedCost } from "@/types/equipment";
+import { WeaponProfileInput, EquipmentAvailability, EquipmentOriginAvailability, EquipmentVariantAvailability, FighterTypeEquipmentGrant, GangAdjustedCost, GangOriginAdjustedCost } from "@/types/equipment";
 import {
   FighterEffectType,
   FighterEffectTypeModifier,
@@ -344,11 +344,15 @@ export async function GET(request: Request) {
           console.warn('Error fetching fighter types:', fighterTypesError);
         }
 
-        // Fetch fighter types that have this equipment
+        // Fetch fighter types that have this equipment. Vehicle rows belong to the
+        // vehicle admin and carry a null fighter_type_id, so they are filtered out
+        // rather than surfacing here as blank entries.
         const { data: equipmentFighterTypes, error: equipmentFighterTypesError } = await supabase
           .from('fighter_type_equipment')
-          .select('fighter_type_id')
-          .eq('equipment_id', id);
+          .select('fighter_type_id, gang_origin_id, gang_variant_id')
+          .eq('equipment_id', id)
+          .is('vehicle_type_id', null)
+          .not('fighter_type_id', 'is', null);
 
         if (equipmentFighterTypesError) {
           console.warn('Error fetching fighter types with equipment:', equipmentFighterTypesError);
@@ -617,7 +621,7 @@ export async function PATCH(request: Request) {
       is_editable,
       is_consumable,
       weapon_profiles,
-      fighter_types,
+      fighter_type_grants,
       gang_adjusted_costs,
       gang_origin_adjusted_costs,
       equipment_availabilities,
@@ -693,51 +697,42 @@ export async function PATCH(request: Request) {
       }
     }
 
-    // More robust fighter type association handling
-    if (fighter_types !== undefined) {
-      
-      // First, get current associations to ensure we don't lose data
-      const { data: currentAssociations, error: fetchError } = await supabase
+    // Handle fighter type associations
+    if (fighter_type_grants !== undefined) {
+      // Only the rows this screen owns: vehicle rows belong to the vehicle admin.
+      const { error: deleteError } = await supabase
         .from('fighter_type_equipment')
-        .select('fighter_type_id')
-        .eq('equipment_id', id);
-      
-      if (fetchError) {
-        console.error('Error fetching current fighter type associations:', fetchError);
-        // Continue with the operation even if this check fails
-      }
-      
-      // Only proceed with deleting & updating if:
-      // 1. We successfully fetched the current associations
-      // 2. The new list is different from the current list
-      if (currentAssociations) {
-        const currentIds = currentAssociations.map(a => a.fighter_type_id);
-        const hasChanges = JSON.stringify(currentIds.sort()) !== JSON.stringify([...fighter_types].sort());
-        
-        if (hasChanges) {
-          // Delete existing associations
-          const { error: deleteError } = await supabase
-            .from('fighter_type_equipment')
-            .delete()
-            .eq('equipment_id', id);
-          
-          if (deleteError) throw deleteError;
-          
-          // Insert new associations if there are any
-          if (fighter_types.length > 0) {
-            const { error: insertError } = await supabase
-              .from('fighter_type_equipment')
-              .insert(
-                fighter_types.map((fighter_type_id: string) => ({
-                  fighter_type_id,
-                  equipment_id: id,
-                  updated_at: new Date().toISOString()
-                }))
-              );
-            
-            if (insertError) throw insertError;
-          }
-        }
+        .delete()
+        .eq('equipment_id', id)
+        .is('vehicle_type_id', null)
+        .not('fighter_type_id', 'is', null);
+
+      if (deleteError) throw deleteError;
+
+      if (Array.isArray(fighter_type_grants) && fighter_type_grants.length > 0) {
+        // fighter_type_equipment_fighter_scope_uidx is NULLS NOT DISTINCT, so a
+        // repeated scope is a unique violation rather than a no-op.
+        const seen = new Set<string>();
+        const grantRecords = (fighter_type_grants as FighterTypeEquipmentGrant[])
+          .map(grant => ({
+            fighter_type_id: grant.fighter_type_id,
+            equipment_id: id,
+            gang_origin_id: grant.gang_origin_id ?? null,
+            gang_variant_id: grant.gang_variant_id ?? null,
+            updated_at: new Date().toISOString()
+          }))
+          .filter(record => {
+            const key = `${record.fighter_type_id}|${record.gang_origin_id ?? ''}|${record.gang_variant_id ?? ''}`;
+            if (seen.has(key)) return false;
+            seen.add(key);
+            return true;
+          });
+
+        const { error: insertError } = await supabase
+          .from('fighter_type_equipment')
+          .insert(grantRecords);
+
+        if (insertError) throw insertError;
       }
     }
 

--- a/app/api/admin/equipment/route.ts
+++ b/app/api/admin/equipment/route.ts
@@ -15,6 +15,20 @@ interface FighterTypeEquipment {
   equipment_id: string;
 }
 
+/**
+ * The fighter_type_equipment rows this screen owns: plain fighter-type grants,
+ * scoped at most by gang origin and variant. Vehicle rows belong to the vehicle
+ * admin, and gang-type / subtype / deny rows to screens that can express them —
+ * none may be read here, because the save deletes everything it reads.
+ * Applied to the read and the delete alike so the two cannot drift apart.
+ */
+function scopeToFighterTypeGrants<T>(query: T): T {
+  return ['vehicle_type_id', 'custom_fighter_type_id', 'gang_type_id', 'fighter_subtype']
+    .reduce((q, column) => q.is(column, null), query as any)
+    .not('fighter_type_id', 'is', null)
+    .eq('excluded', false) as T;
+}
+
 /** Normalize admin Trade Points input: "E" or non-negative integer digits. */
 function normalizeAdminTradePoints(value: unknown): { ok: true; value: string } | { ok: false; error: string } {
   if (value == null || value === '') {
@@ -344,20 +358,21 @@ export async function GET(request: Request) {
           console.warn('Error fetching fighter types:', fighterTypesError);
         }
 
-        // Fetch fighter types that have this equipment. Vehicle rows belong to the
-        // vehicle admin and carry a null fighter_type_id, so they are filtered out
-        // rather than surfacing here as blank entries.
-        const { data: equipmentFighterTypes, error: equipmentFighterTypesError } = await supabase
-          .from('fighter_type_equipment')
-          .select('fighter_type_id, gang_origin_id, gang_variant_id')
-          .eq('equipment_id', id)
-          .is('vehicle_type_id', null)
-          .not('fighter_type_id', 'is', null);
-
-        if (equipmentFighterTypesError) {
+        // Fetch fighter types that have this equipment
+        try {
+          fighterTypesWithEquipment = await fetchAllRows((from, to) =>
+            scopeToFighterTypeGrants(
+              supabase
+                .from('fighter_type_equipment')
+                .select('fighter_type_id, gang_origin_id, gang_variant_id')
+                .eq('equipment_id', id)
+            )
+              .order('fighter_type_id')
+              .order('id')
+              .range(from, to)
+          );
+        } catch (equipmentFighterTypesError) {
           console.warn('Error fetching fighter types with equipment:', equipmentFighterTypesError);
-        } else {
-          fighterTypesWithEquipment = equipmentFighterTypes || [];
         }
       } catch (error) {
         console.warn('Error in fighter types fetch:', error);
@@ -699,13 +714,12 @@ export async function PATCH(request: Request) {
 
     // Handle fighter type associations
     if (fighter_type_grants !== undefined) {
-      // Only the rows this screen owns: vehicle rows belong to the vehicle admin.
-      const { error: deleteError } = await supabase
-        .from('fighter_type_equipment')
-        .delete()
-        .eq('equipment_id', id)
-        .is('vehicle_type_id', null)
-        .not('fighter_type_id', 'is', null);
+      const { error: deleteError } = await scopeToFighterTypeGrants(
+        supabase
+          .from('fighter_type_equipment')
+          .delete()
+          .eq('equipment_id', id)
+      );
 
       if (deleteError) throw deleteError;
 

--- a/app/api/admin/equipment/route.ts
+++ b/app/api/admin/equipment/route.ts
@@ -16,16 +16,19 @@ interface FighterTypeEquipment {
 }
 
 /**
- * The fighter_type_equipment rows this screen owns: plain fighter-type grants,
- * scoped at most by gang origin and variant. Vehicle rows belong to the vehicle
- * admin, and gang-type / subtype / deny rows to screens that can express them —
+ * The fighter_type_equipment rows this screen owns: grants scoped at most by
+ * gang origin, gang variant and fighter subtype. Vehicle rows belong to the
+ * vehicle admin, and gang-type / deny rows to screens that can express them —
  * none may be read here, because the save deletes everything it reads.
  * Applied to the read and the delete alike so the two cannot drift apart.
+ *
+ * Deliberately all-AND. A row identifying nothing (no fighter type and no
+ * subtype) grants nothing either way, and round-trips through here unchanged,
+ * so it is not worth an or() to exclude.
  */
 function scopeToFighterTypeGrants<T>(query: T): T {
-  return ['vehicle_type_id', 'custom_fighter_type_id', 'gang_type_id', 'fighter_subtype']
+  return ['vehicle_type_id', 'custom_fighter_type_id', 'gang_type_id']
     .reduce((q, column) => q.is(column, null), query as any)
-    .not('fighter_type_id', 'is', null)
     .eq('excluded', false) as T;
 }
 
@@ -364,7 +367,7 @@ export async function GET(request: Request) {
             scopeToFighterTypeGrants(
               supabase
                 .from('fighter_type_equipment')
-                .select('fighter_type_id, gang_origin_id, gang_variant_id')
+                .select('fighter_type_id, gang_origin_id, gang_variant_id, fighter_subtype')
                 .eq('equipment_id', id)
             )
               .order('fighter_type_id')
@@ -729,14 +732,15 @@ export async function PATCH(request: Request) {
         const seen = new Set<string>();
         const grantRecords = (fighter_type_grants as FighterTypeEquipmentGrant[])
           .map(grant => ({
-            fighter_type_id: grant.fighter_type_id,
+            fighter_type_id: grant.fighter_type_id ?? null,
             equipment_id: id,
             gang_origin_id: grant.gang_origin_id ?? null,
             gang_variant_id: grant.gang_variant_id ?? null,
+            fighter_subtype: grant.fighter_subtype ?? null,
             updated_at: new Date().toISOString()
           }))
           .filter(record => {
-            const key = `${record.fighter_type_id}|${record.gang_origin_id ?? ''}|${record.gang_variant_id ?? ''}`;
+            const key = `${record.fighter_type_id ?? ''}|${record.gang_origin_id ?? ''}|${record.gang_variant_id ?? ''}|${record.fighter_subtype ?? ''}`;
             if (seen.has(key)) return false;
             seen.add(key);
             return true;

--- a/app/api/admin/equipment/route.ts
+++ b/app/api/admin/equipment/route.ts
@@ -16,15 +16,10 @@ interface FighterTypeEquipment {
 }
 
 /**
- * The fighter_type_equipment rows this screen owns: grants scoped at most by
- * gang origin, gang variant and fighter subtype. Vehicle rows belong to the
- * vehicle admin, and gang-type / deny rows to screens that can express them —
- * none may be read here, because the save deletes everything it reads.
- * Applied to the read and the delete alike so the two cannot drift apart.
- *
- * Deliberately all-AND. A row identifying nothing (no fighter type and no
- * subtype) grants nothing either way, and round-trips through here unchanged,
- * so it is not worth an or() to exclude.
+ * The rows this screen owns: grants scoped at most by gang origin, variant and
+ * fighter subtype. Vehicle and gang-type rows belong to other screens and must
+ * not be read here, because the save deletes everything it reads — so this is
+ * applied to the read and the delete alike.
  */
 function scopeToFighterTypeGrants<T>(query: T): T {
   return ['vehicle_type_id', 'custom_fighter_type_id', 'gang_type_id']

--- a/app/api/admin/fighter-types/route.ts
+++ b/app/api/admin/fighter-types/route.ts
@@ -188,11 +188,15 @@ export async function GET(request: Request) {
         throw skillsError;
       }
 
-      // Fetch equipment list
+      // Fetch equipment list. This screen only edits unscoped grants; origin- and
+      // variant-scoped ones are the equipment admin's and must not be listed here,
+      // or saving would rewrite them unscoped.
       const { data: equipmentList, error: equipmentListError } = await supabase
         .from('fighter_type_equipment')
         .select('equipment_id')
-        .eq('fighter_type_id', fighterType.id);
+        .eq('fighter_type_id', fighterType.id)
+        .is('gang_origin_id', null)
+        .is('gang_variant_id', null);
 
       if (equipmentListError) {
         console.error('Error fetching equipment list:', equipmentListError);
@@ -335,11 +339,13 @@ export async function GET(request: Request) {
               throw skillsError;
             }
 
-            // Fetch equipment list
+            // Fetch equipment list (unscoped grants only, as above)
             const { data: equipmentList, error: equipmentListError } = await supabase
               .from('fighter_type_equipment')
               .select('equipment_id')
-              .eq('fighter_type_id', fighter.id);
+              .eq('fighter_type_id', fighter.id)
+              .is('gang_origin_id', null)
+              .is('gang_variant_id', null);
 
             if (equipmentListError) {
               console.error('Error fetching equipment list:', equipmentListError);
@@ -598,11 +604,14 @@ export async function PATCH(request: Request) {
 
     // Handle equipment list
     if (data.equipment_list) {
-      // First delete existing equipment list entries
+      // First delete existing equipment list entries, matching the scope this
+      // screen reads so scoped grants survive the rewrite
       const { error: deleteError } = await supabase
         .from('fighter_type_equipment')
         .delete()
-        .eq('fighter_type_id', id);
+        .eq('fighter_type_id', id)
+        .is('gang_origin_id', null)
+        .is('gang_variant_id', null);
 
       if (deleteError) throw deleteError;
 

--- a/app/api/admin/fighter-types/route.ts
+++ b/app/api/admin/fighter-types/route.ts
@@ -9,11 +9,10 @@ function isNonEmptyArray(value: unknown): boolean {
 }
 
 /**
- * The fighter_type_equipment rows this screen owns: grants that apply to the
- * fighter type unconditionally. Anything narrowed to a gang origin, variant,
- * gang type or subtype — and any deny row — belongs to the equipment admin and
- * must not be read here, because the save deletes everything it reads.
- * Applied to the reads and the delete alike so the two cannot drift apart.
+ * The rows this screen owns: grants that apply to the fighter type
+ * unconditionally. Anything scoped belongs to the equipment admin and must not
+ * be read here, because the save deletes everything it reads — so this is
+ * applied to the reads and the delete alike.
  */
 function scopeToUnscopedGrants<T>(query: T): T {
   return ['gang_origin_id', 'gang_variant_id', 'gang_type_id', 'fighter_subtype']

--- a/app/api/admin/fighter-types/route.ts
+++ b/app/api/admin/fighter-types/route.ts
@@ -8,6 +8,19 @@ function isNonEmptyArray(value: unknown): boolean {
   return Array.isArray(value) && value.length > 0;
 }
 
+/**
+ * The fighter_type_equipment rows this screen owns: grants that apply to the
+ * fighter type unconditionally. Anything narrowed to a gang origin, variant,
+ * gang type or subtype — and any deny row — belongs to the equipment admin and
+ * must not be read here, because the save deletes everything it reads.
+ * Applied to the reads and the delete alike so the two cannot drift apart.
+ */
+function scopeToUnscopedGrants<T>(query: T): T {
+  return ['gang_origin_id', 'gang_variant_id', 'gang_type_id', 'fighter_subtype']
+    .reduce((q, column) => q.is(column, null), query as any)
+    .eq('excluded', false) as T;
+}
+
 // Get all fighter types
 export async function GET(request: Request) {
   const supabase = await createClient();
@@ -188,15 +201,13 @@ export async function GET(request: Request) {
         throw skillsError;
       }
 
-      // Fetch equipment list. This screen only edits unscoped grants; origin- and
-      // variant-scoped ones are the equipment admin's and must not be listed here,
-      // or saving would rewrite them unscoped.
-      const { data: equipmentList, error: equipmentListError } = await supabase
-        .from('fighter_type_equipment')
-        .select('equipment_id')
-        .eq('fighter_type_id', fighterType.id)
-        .is('gang_origin_id', null)
-        .is('gang_variant_id', null);
+      // Fetch equipment list
+      const { data: equipmentList, error: equipmentListError } = await scopeToUnscopedGrants(
+        supabase
+          .from('fighter_type_equipment')
+          .select('equipment_id')
+          .eq('fighter_type_id', fighterType.id)
+      );
 
       if (equipmentListError) {
         console.error('Error fetching equipment list:', equipmentListError);
@@ -339,13 +350,13 @@ export async function GET(request: Request) {
               throw skillsError;
             }
 
-            // Fetch equipment list (unscoped grants only, as above)
-            const { data: equipmentList, error: equipmentListError } = await supabase
-              .from('fighter_type_equipment')
-              .select('equipment_id')
-              .eq('fighter_type_id', fighter.id)
-              .is('gang_origin_id', null)
-              .is('gang_variant_id', null);
+            // Fetch equipment list
+            const { data: equipmentList, error: equipmentListError } = await scopeToUnscopedGrants(
+              supabase
+                .from('fighter_type_equipment')
+                .select('equipment_id')
+                .eq('fighter_type_id', fighter.id)
+            );
 
             if (equipmentListError) {
               console.error('Error fetching equipment list:', equipmentListError);
@@ -604,14 +615,13 @@ export async function PATCH(request: Request) {
 
     // Handle equipment list
     if (data.equipment_list) {
-      // First delete existing equipment list entries, matching the scope this
-      // screen reads so scoped grants survive the rewrite
-      const { error: deleteError } = await supabase
-        .from('fighter_type_equipment')
-        .delete()
-        .eq('fighter_type_id', id)
-        .is('gang_origin_id', null)
-        .is('gang_variant_id', null);
+      // First delete existing equipment list entries
+      const { error: deleteError } = await scopeToUnscopedGrants(
+        supabase
+          .from('fighter_type_equipment')
+          .delete()
+          .eq('fighter_type_id', id)
+      );
 
       if (deleteError) throw deleteError;
 

--- a/components/admin/admin-edit-equipment.tsx
+++ b/components/admin/admin-edit-equipment.tsx
@@ -84,6 +84,24 @@ function GangOriginOptions({ origins }: { origins: GangOriginOption[] }) {
   );
 }
 
+/** Gang-variant <option>s ordered by gangVariantRank. */
+function GangVariantOptions({ variants }: { variants: Array<{ id: string; variant: string }> }) {
+  return (
+    <>
+      {[...variants]
+        .sort((a, b) =>
+          (gangVariantRank[a.variant.toLowerCase()] ?? Infinity)
+          - (gangVariantRank[b.variant.toLowerCase()] ?? Infinity)
+        )
+        .map((variant) => (
+          <option key={variant.id} value={variant.id}>
+            {variant.variant}
+          </option>
+        ))}
+    </>
+  );
+}
+
 /** Blank grant options only when the target is found with a confirmed different edition. */
 function sanitizeGrantsOptionsForEdition(
   grants: EquipmentGrants,
@@ -1644,17 +1662,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                                 className="w-full p-2 border rounded-md"
                               >
                                 <option key="default" value="">Select a Gang Variant</option>
-                                {[...gangVariantList]
-                                  .sort((a, b) => {
-                                    const rankA = gangVariantRank[a.variant.toLowerCase()] ?? Infinity;
-                                    const rankB = gangVariantRank[b.variant.toLowerCase()] ?? Infinity;
-                                    return rankA - rankB;
-                                  })
-                                  .map((variant) => (
-                                    <option key={variant.id} value={variant.id}>
-                                      {variant.variant}
-                                    </option>
-                                  ))}
+                                <GangVariantOptions variants={gangVariantList} />
                               </select>
                             </div>
 
@@ -1678,23 +1686,18 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
               {/* Move Fighter Types with this Equipment to its own row */}
               {equipmentType !== 'vehicle_upgrade' && (
                 <div className="col-span-3">
-                  <div className="flex items-center justify-between mb-1">
-                    <label className="block text-sm font-medium text-muted-foreground">
-                      Fighter Types with this Equipment
-                    </label>
-                    <Button
-                      onClick={() => setShowScopedGrantDialog(true)}
-                      variant="outline"
-                      size="sm"
-                      disabled={!selectedEquipmentId}
-                    >
-                      Add Scoped
-                    </Button>
-                  </div>
-                  <p className="text-sm text-muted-foreground mb-2">
-                    Puts this item on a fighter type&apos;s Equipment List. &quot;Add Scoped&quot; limits
-                    that to gangs of a given origin or variant.
-                  </p>
+                  <label className="block text-sm font-medium text-muted-foreground mb-1">
+                    Fighter Types with this Equipment
+                  </label>
+                  <Button
+                    onClick={() => setShowScopedGrantDialog(true)}
+                    variant="outline"
+                    size="sm"
+                    className="mb-2"
+                    disabled={!selectedEquipmentId}
+                  >
+                    Add Scoped
+                  </Button>
                   <select
                     value=""
                     onChange={(e) => {
@@ -1775,7 +1778,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                         };
                         if (fighterTypeGrants.some(g => grantKey(g) === grantKey(grant))) {
                           toast.error('This fighter type already has that scope');
-                          return;
+                          return false;
                         }
                         setFighterTypeGrants([...fighterTypeGrants, grant]);
                         setShowScopedGrantDialog(false);
@@ -1797,7 +1800,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                             onChange={(e) => setScopedGrantFighterType(e.target.value)}
                             className="w-full p-2 border rounded-md"
                           >
-                            <option value="">Select a Fighter Type</option>
+                            <option key="default" value="">Select a Fighter Type</option>
                             {filteredFighterTypes.map((ft) => (
                               <option key={ft.id} value={ft.id}>
                                 {fighterTypeLabel(ft)}
@@ -1813,7 +1816,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                             onChange={(e) => setScopedGrantOrigin(e.target.value)}
                             className="w-full p-2 border rounded-md"
                           >
-                            <option value="">Any Gang Origin</option>
+                            <option key="default" value="">Any Gang Origin</option>
                             <GangOriginOptions origins={gangOriginList} />
                           </select>
                         </div>
@@ -1825,17 +1828,8 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                             onChange={(e) => setScopedGrantVariant(e.target.value)}
                             className="w-full p-2 border rounded-md"
                           >
-                            <option value="">Any Gang Variant</option>
-                            {[...gangVariantList]
-                              .sort((a, b) =>
-                                (gangVariantRank[a.variant.toLowerCase()] ?? Infinity)
-                                - (gangVariantRank[b.variant.toLowerCase()] ?? Infinity)
-                              )
-                              .map((variant) => (
-                                <option key={variant.id} value={variant.id}>
-                                  {variant.variant}
-                                </option>
-                              ))}
+                            <option key="default" value="">Any Gang Variant</option>
+                            <GangVariantOptions variants={gangVariantList} />
                           </select>
                         </div>
                       </div>

--- a/components/admin/admin-edit-equipment.tsx
+++ b/components/admin/admin-edit-equipment.tsx
@@ -532,15 +532,13 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
   const filteredFighterTypes = useMemo(
     () => (editionId ? fighterTypes.filter(ft => ft.edition_id === editionId) : [...fighterTypes])
       .sort((a, b) => {
-        // First sort by gang type
         const gangCompare = a.gang_type.localeCompare(b.gang_type);
         if (gangCompare !== 0) return gangCompare;
-        // Then by fighter subtype priority (per fighter type's own edition)
+        // Subtype priority is per fighter type's own edition
         const subtypeCompare =
           getFighterSubtypeSortRank(a.fighter_subtypes, editionSlugOf(editions, a.edition_id))
           - getFighterSubtypeSortRank(b.fighter_subtypes, editionSlugOf(editions, b.edition_id));
         if (subtypeCompare !== 0) return subtypeCompare;
-        // Finally by fighter type name
         return a.fighter_type.localeCompare(b.fighter_type);
       }),
     [fighterTypes, editionId, editions]
@@ -553,7 +551,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
       if (!response.ok) throw new Error('Failed to fetch gang origins');
       return response.json();
     },
-    // Also needed unopened, to label origin-scoped equipment grants
+    // Also needed unopened, to label scoped grants
     enabled: !!selectedEquipmentId || showOriginAvailabilityDialog || showOriginAdjustedCostDialog,
     staleTime: 5 * 60 * 1000,
   });
@@ -565,7 +563,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
       if (!response.ok) throw new Error('Failed to fetch gang variants');
       return response.json();
     },
-    // Also needed unopened, to label variant-scoped equipment grants
+    // Also needed unopened, to label scoped grants
     enabled: !!selectedEquipmentId || showVariantAvailabilityDialog,
     staleTime: 5 * 60 * 1000,
   });
@@ -1756,7 +1754,6 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                       const ft = grant.fighter_type_id
                         ? fighterTypes.find(f => f.id === grant.fighter_type_id)
                         : null;
-                      // A grant naming a fighter type we can't resolve stays hidden
                       if (grant.fighter_type_id && !ft) return null;
 
                       const scope = [
@@ -1821,8 +1818,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                       }}
                       confirmText="Save"
                       confirmDisabled={
-                        // Needs something to identify the fighter, and a scope
-                        // narrower than the plain dropdown above already gives
+                        // Needs an identity, and a scope the dropdown can't already give
                         (!scopedGrantFighterType && !scopedGrantSubtype)
                         || (!scopedGrantOrigin && !scopedGrantVariant && !scopedGrantSubtype)
                       }

--- a/components/admin/admin-edit-equipment.tsx
+++ b/components/admin/admin-edit-equipment.tsx
@@ -1621,7 +1621,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                               );
                               if (alreadyExists) {
                                 toast.error('This variant already has an availability set');
-                                return;
+                                return false;
                               }
 
                               const selectedVariant = gangVariantList.find(g => g.id === selectedAvailabilityGangVariant);

--- a/components/admin/admin-edit-equipment.tsx
+++ b/components/admin/admin-edit-equipment.tsx
@@ -50,7 +50,9 @@ const fighterTypeLabel = (ft: FighterType) => {
 };
 
 const grantKey = (grant: FighterTypeEquipmentGrant) =>
-  `${grant.fighter_type_id}|${grant.gang_origin_id ?? ''}|${grant.gang_variant_id ?? ''}`;
+  [grant.fighter_type_id, grant.gang_origin_id, grant.gang_variant_id, grant.fighter_subtype]
+    .map(part => part ?? '')
+    .join('|');
 
 /** Gang-origin <option>s grouped by the category gangOriginRank implies. */
 function GangOriginOptions({ origins }: { origins: GangOriginOption[] }) {
@@ -173,6 +175,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
   const [scopedGrantFighterType, setScopedGrantFighterType] = useState('');
   const [scopedGrantOrigin, setScopedGrantOrigin] = useState('');
   const [scopedGrantVariant, setScopedGrantVariant] = useState('');
+  const [scopedGrantSubtype, setScopedGrantSubtype] = useState('');
   const [showAdjustedCostDialog, setShowAdjustedCostDialog] = useState(false);
   const [selectedGangType, setSelectedGangType] = useState("");
   const [adjustedCostValue, setAdjustedCostValue] = useState("");
@@ -465,9 +468,10 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
 
       if (equipmentDetails.fighter_types_with_equipment) {
         setFighterTypeGrants(equipmentDetails.fighter_types_with_equipment.map((ft: any) => ({
-          fighter_type_id: ft.fighter_type_id,
+          fighter_type_id: ft.fighter_type_id ?? null,
           gang_origin_id: ft.gang_origin_id ?? null,
-          gang_variant_id: ft.gang_variant_id ?? null
+          gang_variant_id: ft.gang_variant_id ?? null,
+          fighter_subtype: ft.fighter_subtype ?? null
         })));
       }
 
@@ -565,6 +569,27 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
     enabled: !!selectedEquipmentId || showVariantAvailabilityDialog,
     staleTime: 5 * 60 * 1000,
   });
+
+  const { data: fighterSubtypeList = [] } = useQuery<Array<{id: string, subtype_name: string, edition_id?: string | null}>>({
+    queryKey: ['admin-fighter-subtypes'],
+    queryFn: async () => {
+      const response = await fetch('/api/admin/fighter-subtypes');
+      if (!response.ok) throw new Error('Failed to fetch fighter subtypes');
+      return response.json();
+    },
+    enabled: !!selectedEquipmentId,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  // Subtypes are stored on the grant by name, but the names are per edition
+  const filteredFighterSubtypes = useMemo(
+    () => (editionId ? fighterSubtypeList.filter(s => s.edition_id === editionId) : [...fighterSubtypeList])
+      .sort((a, b) =>
+        getFighterSubtypeSortRank([a.subtype_name], editionSlug)
+        - getFighterSubtypeSortRank([b.subtype_name], editionSlug)
+      ),
+    [fighterSubtypeList, editionId, editionSlug]
+  );
 
   const isLoading = isEquipmentDetailsLoading || isWeaponsLoading || isSubmitting;
 
@@ -1705,7 +1730,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                       if (value) {
                         setFighterTypeGrants([
                           ...fighterTypeGrants,
-                          { fighter_type_id: value, gang_origin_id: null, gang_variant_id: null }
+                          { fighter_type_id: value, gang_origin_id: null, gang_variant_id: null, fighter_subtype: null }
                         ]);
                       }
                       e.target.value = "";
@@ -1716,7 +1741,8 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                     <option value="">Select fighter type to add</option>
                     {filteredFighterTypes
                       .filter(ft => !fighterTypeGrants.some(
-                        g => g.fighter_type_id === ft.id && !g.gang_origin_id && !g.gang_variant_id
+                        g => g.fighter_type_id === ft.id
+                          && !g.gang_origin_id && !g.gang_variant_id && !g.fighter_subtype
                       ))
                       .map((ft) => (
                         <option key={ft.id} value={ft.id}>
@@ -1727,8 +1753,11 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
 
                   <div className="mt-2 flex flex-wrap gap-2">
                     {fighterTypeGrants.map((grant) => {
-                      const ft = fighterTypes.find(f => f.id === grant.fighter_type_id);
-                      if (!ft) return null;
+                      const ft = grant.fighter_type_id
+                        ? fighterTypes.find(f => f.id === grant.fighter_type_id)
+                        : null;
+                      // A grant naming a fighter type we can't resolve stays hidden
+                      if (grant.fighter_type_id && !ft) return null;
 
                       const scope = [
                         grant.gang_origin_id
@@ -1736,7 +1765,8 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                           : null,
                         grant.gang_variant_id
                           ? `Variant: ${gangVariantList.find(v => v.id === grant.gang_variant_id)?.variant ?? '…'}`
-                          : null
+                          : null,
+                        grant.fighter_subtype ? `Subtype: ${grant.fighter_subtype}` : null
                       ].filter(Boolean).join(', ');
 
                       return (
@@ -1744,7 +1774,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                           key={grantKey(grant)}
                           className="flex items-center gap-1 px-2 py-1 rounded-full text-sm bg-muted"
                         >
-                          <span>{fighterTypeLabel(ft)}{scope && ` — ${scope}`}</span>
+                          <span>{ft ? fighterTypeLabel(ft) : 'Any fighter type'}{scope && ` — ${scope}`}</span>
                           <button
                             type="button"
                             onClick={() => setFighterTypeGrants(
@@ -1763,21 +1793,23 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                   {showScopedGrantDialog && (
                     <Modal
                       title="Scoped Equipment List Entry"
-                      helper="Select a fighter type and narrow it to a gang origin and/or variant"
+                      helper="Narrow a grant to a gang origin, variant and/or fighter subtype. Leave Fighter Type as Any for a subtype rule spanning every gang."
                       onClose={() => {
                         setShowScopedGrantDialog(false);
                         setScopedGrantFighterType("");
                         setScopedGrantOrigin("");
                         setScopedGrantVariant("");
+                        setScopedGrantSubtype("");
                       }}
                       onConfirm={() => {
                         const grant: FighterTypeEquipmentGrant = {
-                          fighter_type_id: scopedGrantFighterType,
+                          fighter_type_id: scopedGrantFighterType || null,
                           gang_origin_id: scopedGrantOrigin || null,
-                          gang_variant_id: scopedGrantVariant || null
+                          gang_variant_id: scopedGrantVariant || null,
+                          fighter_subtype: scopedGrantSubtype || null
                         };
                         if (fighterTypeGrants.some(g => grantKey(g) === grantKey(grant))) {
-                          toast.error('This fighter type already has that scope');
+                          toast.error('That combination is already on the list');
                           return false;
                         }
                         setFighterTypeGrants([...fighterTypeGrants, grant]);
@@ -1785,10 +1817,14 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                         setScopedGrantFighterType("");
                         setScopedGrantOrigin("");
                         setScopedGrantVariant("");
+                        setScopedGrantSubtype("");
                       }}
                       confirmText="Save"
                       confirmDisabled={
-                        !scopedGrantFighterType || (!scopedGrantOrigin && !scopedGrantVariant)
+                        // Needs something to identify the fighter, and a scope
+                        // narrower than the plain dropdown above already gives
+                        (!scopedGrantFighterType && !scopedGrantSubtype)
+                        || (!scopedGrantOrigin && !scopedGrantVariant && !scopedGrantSubtype)
                       }
                       width="sm"
                     >
@@ -1800,10 +1836,26 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                             onChange={(e) => setScopedGrantFighterType(e.target.value)}
                             className="w-full p-2 border rounded-md"
                           >
-                            <option key="default" value="">Select a Fighter Type</option>
+                            <option key="default" value="">Any Fighter Type</option>
                             {filteredFighterTypes.map((ft) => (
                               <option key={ft.id} value={ft.id}>
                                 {fighterTypeLabel(ft)}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+
+                        <div>
+                          <label className="block text-sm font-medium mb-1">Fighter Subtype</label>
+                          <select
+                            value={scopedGrantSubtype}
+                            onChange={(e) => setScopedGrantSubtype(e.target.value)}
+                            className="w-full p-2 border rounded-md"
+                          >
+                            <option key="default" value="">Any Fighter Subtype</option>
+                            {filteredFighterSubtypes.map((subtype) => (
+                              <option key={subtype.id} value={subtype.subtype_name}>
+                                {subtype.subtype_name}
                               </option>
                             ))}
                           </select>

--- a/components/admin/admin-edit-equipment.tsx
+++ b/components/admin/admin-edit-equipment.tsx
@@ -583,10 +583,10 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
   const filteredFighterSubtypes = useMemo(
     () => (editionId ? fighterSubtypeList.filter(s => s.edition_id === editionId) : [...fighterSubtypeList])
       .sort((a, b) =>
-        getFighterSubtypeSortRank([a.subtype_name], editionSlug)
-        - getFighterSubtypeSortRank([b.subtype_name], editionSlug)
+        getFighterSubtypeSortRank([a.subtype_name], editionSlugOf(editions, a.edition_id))
+        - getFighterSubtypeSortRank([b.subtype_name], editionSlugOf(editions, b.edition_id))
       ),
-    [fighterSubtypeList, editionId, editionSlug]
+    [fighterSubtypeList, editionId, editions]
   );
 
   const isLoading = isEquipmentDetailsLoading || isWeaponsLoading || isSubmitting;

--- a/components/admin/admin-edit-equipment.tsx
+++ b/components/admin/admin-edit-equipment.tsx
@@ -8,7 +8,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { AvailabilityPicker, parseAvailability, combineAvailability } from '@/components/ui/availability-picker';
 import { toast } from 'sonner';
 import { FighterType } from "@/types/fighter";
-import { WeaponProfileInput, emptyWeaponProfile, EquipmentGrants, EquipmentAvailability, EquipmentOriginAvailability, EquipmentVariantAvailability, GangAdjustedCost, GangOriginAdjustedCost } from "@/types/equipment";
+import { WeaponProfileInput, emptyWeaponProfile, EquipmentGrants, EquipmentAvailability, EquipmentOriginAvailability, EquipmentVariantAvailability, FighterTypeEquipmentGrant, GangAdjustedCost, GangOriginAdjustedCost } from "@/types/equipment";
 import { HiX } from "react-icons/hi";
 import { getFighterSubtypeSortRank } from "@/utils/fighterSubtypeRank";
 import { gangOriginRank } from "@/utils/gangOriginRank";
@@ -35,6 +35,54 @@ interface AdminEditEquipmentModalProps {
 
 const EQUIPMENT_TYPES = ['wargear', 'weapon', 'vehicle_upgrade'] as const;
 type EquipmentType = typeof EQUIPMENT_TYPES[number];
+
+interface GangOriginOption {
+  id: string;
+  origin_name: string;
+}
+
+const fighterTypeLabel = (ft: FighterType) => {
+  const suffix = [ft.fighter_variant, ft.fighter_specialisations?.specialisation_name]
+    .filter(Boolean)
+    .map(n => ` - ${n}`)
+    .join('');
+  return `${ft.gang_type} - ${ft.fighter_type} (${ft.fighter_subtypes?.join(', ')})${suffix}`;
+};
+
+const grantKey = (grant: FighterTypeEquipmentGrant) =>
+  `${grant.fighter_type_id}|${grant.gang_origin_id ?? ''}|${grant.gang_variant_id ?? ''}`;
+
+/** Gang-origin <option>s grouped by the category gangOriginRank implies. */
+function GangOriginOptions({ origins }: { origins: GangOriginOption[] }) {
+  const groups = [...origins]
+    .sort((a, b) =>
+      (gangOriginRank[a.origin_name.toLowerCase()] ?? Infinity)
+      - (gangOriginRank[b.origin_name.toLowerCase()] ?? Infinity)
+    )
+    .reduce((acc, origin) => {
+      const rank = gangOriginRank[origin.origin_name.toLowerCase()] ?? Infinity;
+      const label = rank <= 19 ? 'Prefecture'
+        : rank <= 39 ? 'Ancestry'
+        : rank <= 59 ? 'Tribe'
+        : 'Misc.';
+      (acc[label] ||= []).push(origin);
+      return acc;
+    }, {} as Record<string, GangOriginOption[]>);
+
+  return (
+    <>
+      {Object.entries(groups).map(([label, group]) => (
+        <optgroup key={label} label={label}>
+          {group.map((origin) => (
+            <option key={origin.id} value={origin.id}>
+              {origin.origin_name}
+            </option>
+          ))}
+        </optgroup>
+      ))}
+    </>
+  );
+}
 
 /** Blank grant options only when the target is found with a confirmed different edition. */
 function sanitizeGrantsOptionsForEdition(
@@ -102,7 +150,11 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
   const [weaponProfiles, setWeaponProfiles] = useState<WeaponProfileInput[]>([emptyWeaponProfile(1)]);
   const [categoryFilter, setCategoryFilter] = useState('');
   const [fighterTypes, setFighterTypes] = useState<FighterType[]>([]);
-  const [selectedFighterTypes, setSelectedFighterTypes] = useState<string[]>([]);
+  const [fighterTypeGrants, setFighterTypeGrants] = useState<FighterTypeEquipmentGrant[]>([]);
+  const [showScopedGrantDialog, setShowScopedGrantDialog] = useState(false);
+  const [scopedGrantFighterType, setScopedGrantFighterType] = useState('');
+  const [scopedGrantOrigin, setScopedGrantOrigin] = useState('');
+  const [scopedGrantVariant, setScopedGrantVariant] = useState('');
   const [showAdjustedCostDialog, setShowAdjustedCostDialog] = useState(false);
   const [selectedGangType, setSelectedGangType] = useState("");
   const [adjustedCostValue, setAdjustedCostValue] = useState("");
@@ -209,9 +261,9 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
           return !tp || tp.edition_id === newEditionId;
         })
       );
-      setSelectedFighterTypes(prev =>
-        prev.filter(id => {
-          const ft = fighterTypes.find(f => f.id === id);
+      setFighterTypeGrants(prev =>
+        prev.filter(grant => {
+          const ft = fighterTypes.find(f => f.id === grant.fighter_type_id);
           return !ft || ft.edition_id === newEditionId;
         })
       );
@@ -298,6 +350,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
       setEquipmentOriginAvailabilities([]);
       setEquipmentVariantAvailabilities([]);
       setSelectedTradingPosts([]);
+      setFighterTypeGrants([]);
     } else if (equipmentDetails) {
       setEquipmentName(equipmentDetails.equipment_name);
       const parsed = parseAvailability(equipmentDetails.availability);
@@ -393,7 +446,11 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
       }
 
       if (equipmentDetails.fighter_types_with_equipment) {
-        setSelectedFighterTypes(equipmentDetails.fighter_types_with_equipment.map((ft: any) => ft.fighter_type_id));
+        setFighterTypeGrants(equipmentDetails.fighter_types_with_equipment.map((ft: any) => ({
+          fighter_type_id: ft.fighter_type_id,
+          gang_origin_id: ft.gang_origin_id ?? null,
+          gang_variant_id: ft.gang_variant_id ?? null
+        })));
       }
 
       if (equipmentDetails.weapon_profiles && equipmentDetails.weapon_profiles.length > 0) {
@@ -451,8 +508,20 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
   );
 
   const filteredFighterTypes = useMemo(
-    () => editionId ? fighterTypes.filter(ft => ft.edition_id === editionId) : fighterTypes,
-    [fighterTypes, editionId]
+    () => (editionId ? fighterTypes.filter(ft => ft.edition_id === editionId) : [...fighterTypes])
+      .sort((a, b) => {
+        // First sort by gang type
+        const gangCompare = a.gang_type.localeCompare(b.gang_type);
+        if (gangCompare !== 0) return gangCompare;
+        // Then by fighter subtype priority (per fighter type's own edition)
+        const subtypeCompare =
+          getFighterSubtypeSortRank(a.fighter_subtypes, editionSlugOf(editions, a.edition_id))
+          - getFighterSubtypeSortRank(b.fighter_subtypes, editionSlugOf(editions, b.edition_id));
+        if (subtypeCompare !== 0) return subtypeCompare;
+        // Finally by fighter type name
+        return a.fighter_type.localeCompare(b.fighter_type);
+      }),
+    [fighterTypes, editionId, editions]
   );
 
   const { data: gangOriginList = [] } = useQuery<Array<{id: string, origin_name: string, category_name: string}>>({
@@ -462,7 +531,8 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
       if (!response.ok) throw new Error('Failed to fetch gang origins');
       return response.json();
     },
-    enabled: showOriginAvailabilityDialog || showOriginAdjustedCostDialog,
+    // Also needed unopened, to label origin-scoped equipment grants
+    enabled: !!selectedEquipmentId || showOriginAvailabilityDialog || showOriginAdjustedCostDialog,
     staleTime: 5 * 60 * 1000,
   });
 
@@ -473,7 +543,8 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
       if (!response.ok) throw new Error('Failed to fetch gang variants');
       return response.json();
     },
-    enabled: showVariantAvailabilityDialog,
+    // Also needed unopened, to label variant-scoped equipment grants
+    enabled: !!selectedEquipmentId || showVariantAvailabilityDialog,
     staleTime: 5 * 60 * 1000,
   });
 
@@ -518,8 +589,6 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
         throw new Error('Invalid category selected');
       }
 
-      const hasEditedFighterTypes = selectedFighterTypes.length !== fighterTypes.filter(ft => selectedFighterTypes.includes(ft.id)).length;
-
       // Validate and normalize grants_equipment - treat empty options as no grants.
       // An option with no equipment picked is dropped: a blank equipment_id can never
       // be granted, and it is not a uuid, so anything casting it downstream breaks.
@@ -553,7 +622,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
             weapon_group_id: profile.weapon_group_id || selectedEquipmentId
           }))
         } : {}),
-        ...(hasEditedFighterTypes ? { fighter_types: selectedFighterTypes } : {}),
+        fighter_type_grants: fighterTypeGrants,
         gang_adjusted_costs: gangAdjustedCosts.map(d => ({
           gang_type_id: d.gang_type_id,
           adjusted_cost: d.adjusted_cost
@@ -1349,34 +1418,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                                 className="w-full p-2 border rounded-md"
                               >
                                 <option key="default" value="">Select a Gang Origin</option>
-                                {Object.entries(
-                                  gangOriginList
-                                    .sort((a, b) => {
-                                      const rankA = gangOriginRank[a.origin_name.toLowerCase()] ?? Infinity;
-                                      const rankB = gangOriginRank[b.origin_name.toLowerCase()] ?? Infinity;
-                                      return rankA - rankB;
-                                    })
-                                    .reduce((groups, origin) => {
-                                      const rank = gangOriginRank[origin.origin_name.toLowerCase()] ?? Infinity;
-                                      let groupLabel = "Misc."; // Default category for unlisted origins
-
-                                      if (rank <= 19) groupLabel = "Prefecture";
-                                      else if (rank <= 39) groupLabel = "Ancestry";
-                                      else if (rank <= 59) groupLabel = "Tribe";
-
-                                      if (!groups[groupLabel]) groups[groupLabel] = [];
-                                      groups[groupLabel].push(origin);
-                                      return groups;
-                                    }, {} as Record<string, typeof gangOriginList>)
-                                ).map(([groupLabel, origins]) => (
-                                  <optgroup key={groupLabel} label={groupLabel}>
-                                    {origins.map((origin) => (
-                                      <option key={origin.id} value={origin.id}>
-                                        {origin.origin_name}
-                                      </option>
-                                    ))}
-                                  </optgroup>
-                                ))}
+                                <GangOriginOptions origins={gangOriginList} />
                               </select>
                             </div>
 
@@ -1488,34 +1530,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                                 className="w-full p-2 border rounded-md"
                               >
                                 <option key="default" value="">Select a Gang Origin</option>
-                                {Object.entries(
-                                  gangOriginList
-                                    .sort((a, b) => {
-                                      const rankA = gangOriginRank[a.origin_name.toLowerCase()] ?? Infinity;
-                                      const rankB = gangOriginRank[b.origin_name.toLowerCase()] ?? Infinity;
-                                      return rankA - rankB;
-                                    })
-                                    .reduce((groups, origin) => {
-                                      const rank = gangOriginRank[origin.origin_name.toLowerCase()] ?? Infinity;
-                                      let groupLabel = "Misc."; // Default category for unlisted origins
-
-                                      if (rank <= 19) groupLabel = "Prefecture";
-                                      else if (rank <= 39) groupLabel = "Ancestry";
-                                      else if (rank <= 59) groupLabel = "Tribe";
-
-                                      if (!groups[groupLabel]) groups[groupLabel] = [];
-                                      groups[groupLabel].push(origin);
-                                      return groups;
-                                    }, {} as Record<string, typeof gangOriginList>)
-                                ).map(([groupLabel, origins]) => (
-                                  <optgroup key={groupLabel} label={groupLabel}>
-                                    {origins.map((origin) => (
-                                      <option key={origin.id} value={origin.id}>
-                                        {origin.origin_name}
-                                      </option>
-                                    ))}
-                                  </optgroup>
-                                ))}
+                                <GangOriginOptions origins={gangOriginList} />
                               </select>
                             </div>
 
@@ -1629,7 +1644,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                                 className="w-full p-2 border rounded-md"
                               >
                                 <option key="default" value="">Select a Gang Variant</option>
-                                {gangVariantList
+                                {[...gangVariantList]
                                   .sort((a, b) => {
                                     const rankA = gangVariantRank[a.variant.toLowerCase()] ?? Infinity;
                                     const rankB = gangVariantRank[b.variant.toLowerCase()] ?? Infinity;
@@ -1663,15 +1678,32 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
               {/* Move Fighter Types with this Equipment to its own row */}
               {equipmentType !== 'vehicle_upgrade' && (
                 <div className="col-span-3">
-                  <label className="block text-sm font-medium text-muted-foreground mb-1">
-                    Fighter Types with this Equipment
-                  </label>
+                  <div className="flex items-center justify-between mb-1">
+                    <label className="block text-sm font-medium text-muted-foreground">
+                      Fighter Types with this Equipment
+                    </label>
+                    <Button
+                      onClick={() => setShowScopedGrantDialog(true)}
+                      variant="outline"
+                      size="sm"
+                      disabled={!selectedEquipmentId}
+                    >
+                      Add Scoped
+                    </Button>
+                  </div>
+                  <p className="text-sm text-muted-foreground mb-2">
+                    Puts this item on a fighter type&apos;s Equipment List. &quot;Add Scoped&quot; limits
+                    that to gangs of a given origin or variant.
+                  </p>
                   <select
                     value=""
                     onChange={(e) => {
                       const value = e.target.value;
-                      if (value && !selectedFighterTypes.includes(value)) {
-                        setSelectedFighterTypes([...selectedFighterTypes, value]);
+                      if (value) {
+                        setFighterTypeGrants([
+                          ...fighterTypeGrants,
+                          { fighter_type_id: value, gang_origin_id: null, gang_variant_id: null }
+                        ]);
                       }
                       e.target.value = "";
                     }}
@@ -1680,43 +1712,41 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                   >
                     <option value="">Select fighter type to add</option>
                     {filteredFighterTypes
-                      .filter(ft => !selectedFighterTypes.includes(ft.id))
-                      .sort((a, b) => {
-                        // First sort by gang type
-                        const gangCompare = a.gang_type.localeCompare(b.gang_type);
-                        if (gangCompare !== 0) return gangCompare;
-                        // Then by fighter subtype priority (per fighter type's own edition)
-                        const subtypeCompare =
-                          getFighterSubtypeSortRank(a.fighter_subtypes, editionSlugOf(editions, a.edition_id))
-                          - getFighterSubtypeSortRank(b.fighter_subtypes, editionSlugOf(editions, b.edition_id));
-                        if (subtypeCompare !== 0) return subtypeCompare;
-                        // Finally by fighter type name
-                        return a.fighter_type.localeCompare(b.fighter_type);
-                      })
-                      .map((ft) => {
-                        const specialisationText = [ft.fighter_variant, ft.fighter_specialisations?.specialisation_name].filter(Boolean).map(n => ` - ${n}`).join('');
-                        return (
-                          <option key={ft.id} value={ft.id}>
-                            {`${ft.gang_type} - ${ft.fighter_type} (${ft.fighter_subtypes?.join(', ')})${specialisationText}`}
-                          </option>
-                        );
-                      })}
+                      .filter(ft => !fighterTypeGrants.some(
+                        g => g.fighter_type_id === ft.id && !g.gang_origin_id && !g.gang_variant_id
+                      ))
+                      .map((ft) => (
+                        <option key={ft.id} value={ft.id}>
+                          {fighterTypeLabel(ft)}
+                        </option>
+                      ))}
                   </select>
 
                   <div className="mt-2 flex flex-wrap gap-2">
-                    {selectedFighterTypes.map((ftId) => {
-                      const ft = fighterTypes.find(f => f.id === ftId);
+                    {fighterTypeGrants.map((grant) => {
+                      const ft = fighterTypes.find(f => f.id === grant.fighter_type_id);
                       if (!ft) return null;
+
+                      const scope = [
+                        grant.gang_origin_id
+                          ? `Origin: ${gangOriginList.find(o => o.id === grant.gang_origin_id)?.origin_name ?? '…'}`
+                          : null,
+                        grant.gang_variant_id
+                          ? `Variant: ${gangVariantList.find(v => v.id === grant.gang_variant_id)?.variant ?? '…'}`
+                          : null
+                      ].filter(Boolean).join(', ');
 
                       return (
                         <div
-                          key={ft.id}
+                          key={grantKey(grant)}
                           className="flex items-center gap-1 px-2 py-1 rounded-full text-sm bg-muted"
                         >
-                          <span>{`${ft.gang_type} - ${ft.fighter_type} (${ft.fighter_subtypes?.join(', ')})${[ft.fighter_variant, ft.fighter_specialisations?.specialisation_name].filter(Boolean).map(n => ` - ${n}`).join('')}`}</span>
+                          <span>{fighterTypeLabel(ft)}{scope && ` — ${scope}`}</span>
                           <button
                             type="button"
-                            onClick={() => setSelectedFighterTypes(selectedFighterTypes.filter(id => id !== ft.id))}
+                            onClick={() => setFighterTypeGrants(
+                              fighterTypeGrants.filter(g => grantKey(g) !== grantKey(grant))
+                            )}
                             className="hover:text-red-500 focus:outline-hidden"
                             disabled={!selectedEquipmentId}
                           >
@@ -1726,6 +1756,91 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                       );
                     })}
                   </div>
+
+                  {showScopedGrantDialog && (
+                    <Modal
+                      title="Scoped Equipment List Entry"
+                      helper="Select a fighter type and narrow it to a gang origin and/or variant"
+                      onClose={() => {
+                        setShowScopedGrantDialog(false);
+                        setScopedGrantFighterType("");
+                        setScopedGrantOrigin("");
+                        setScopedGrantVariant("");
+                      }}
+                      onConfirm={() => {
+                        const grant: FighterTypeEquipmentGrant = {
+                          fighter_type_id: scopedGrantFighterType,
+                          gang_origin_id: scopedGrantOrigin || null,
+                          gang_variant_id: scopedGrantVariant || null
+                        };
+                        if (fighterTypeGrants.some(g => grantKey(g) === grantKey(grant))) {
+                          toast.error('This fighter type already has that scope');
+                          return;
+                        }
+                        setFighterTypeGrants([...fighterTypeGrants, grant]);
+                        setShowScopedGrantDialog(false);
+                        setScopedGrantFighterType("");
+                        setScopedGrantOrigin("");
+                        setScopedGrantVariant("");
+                      }}
+                      confirmText="Save"
+                      confirmDisabled={
+                        !scopedGrantFighterType || (!scopedGrantOrigin && !scopedGrantVariant)
+                      }
+                      width="sm"
+                    >
+                      <div className="space-y-4">
+                        <div>
+                          <label className="block text-sm font-medium mb-1">Fighter Type</label>
+                          <select
+                            value={scopedGrantFighterType}
+                            onChange={(e) => setScopedGrantFighterType(e.target.value)}
+                            className="w-full p-2 border rounded-md"
+                          >
+                            <option value="">Select a Fighter Type</option>
+                            {filteredFighterTypes.map((ft) => (
+                              <option key={ft.id} value={ft.id}>
+                                {fighterTypeLabel(ft)}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+
+                        <div>
+                          <label className="block text-sm font-medium mb-1">Gang Origin</label>
+                          <select
+                            value={scopedGrantOrigin}
+                            onChange={(e) => setScopedGrantOrigin(e.target.value)}
+                            className="w-full p-2 border rounded-md"
+                          >
+                            <option value="">Any Gang Origin</option>
+                            <GangOriginOptions origins={gangOriginList} />
+                          </select>
+                        </div>
+
+                        <div>
+                          <label className="block text-sm font-medium mb-1">Gang Variant</label>
+                          <select
+                            value={scopedGrantVariant}
+                            onChange={(e) => setScopedGrantVariant(e.target.value)}
+                            className="w-full p-2 border rounded-md"
+                          >
+                            <option value="">Any Gang Variant</option>
+                            {[...gangVariantList]
+                              .sort((a, b) =>
+                                (gangVariantRank[a.variant.toLowerCase()] ?? Infinity)
+                                - (gangVariantRank[b.variant.toLowerCase()] ?? Infinity)
+                              )
+                              .map((variant) => (
+                                <option key={variant.id} value={variant.id}>
+                                  {variant.variant}
+                                </option>
+                              ))}
+                          </select>
+                        </div>
+                      </div>
+                    </Modal>
+                  )}
                 </div>
               )}
 

--- a/supabase/functions/get_equipment_detailed_data.sql
+++ b/supabase/functions/get_equipment_detailed_data.sql
@@ -61,6 +61,9 @@ AS $$
             cg.campaign_type_allegiance_id,
             fgl.fighter_type_id AS legacy_ft_id,
             ga.fighter_type_id  AS affiliation_ft_id,
+            -- NULL when called without a fighter ($6); an empty array then
+            -- matches no subtype-scoped row rather than every one
+            COALESCE(f.fighter_subtypes, '[]'::jsonb) AS fighter_subtypes,
             COALESCE(gt.edition_id, cgt.edition_id) AS edition_id
         FROM (SELECT 1) AS _dummy
         LEFT JOIN gangs g ON g.id = $8
@@ -412,10 +415,18 @@ AS $$
                  AND (fte.fighter_type_id = gd.legacy_ft_id OR fte.vehicle_type_id = gd.legacy_ft_id)
                  AND $4 = true)
              OR (gd.affiliation_ft_id IS NOT NULL
-                 AND (fte.fighter_type_id = gd.affiliation_ft_id OR fte.vehicle_type_id = gd.affiliation_ft_id)))
+                 AND (fte.fighter_type_id = gd.affiliation_ft_id OR fte.vehicle_type_id = gd.affiliation_ft_id))
+             -- A subtype rule spanning every gang carries no fighter or vehicle
+             -- of its own. fighter_subtype must be set, or an all-NULL row would
+             -- match every fighter.
+             OR (fte.fighter_type_id IS NULL
+                 AND fte.vehicle_type_id IS NULL
+                 AND fte.custom_fighter_type_id IS NULL
+                 AND fte.fighter_subtype IS NOT NULL))
         AND (fte.gang_origin_id IS NULL OR fte.gang_origin_id = gd.gang_origin_id)
         AND (fte.gang_variant_id IS NULL OR gd.gang_variants ? fte.gang_variant_id::text)
         AND (fte.gang_type_id IS NULL OR fte.gang_type_id = $1)
+        AND (fte.fighter_subtype IS NULL OR gd.fighter_subtypes ? fte.fighter_subtype)
 
     -- Is this system equipment on the current custom fighter type's equipment list?
     -- ($3 is a custom_fighter_types.id when the fighter is a custom fighter.)
@@ -432,8 +443,9 @@ AS $$
     -- so the predicate lives in exactly one place.
     LEFT JOIN LATERAL (
         SELECT (
-            fte.fighter_type_id IS NOT NULL
-            OR fte.vehicle_type_id IS NOT NULL
+            -- Any matched fte row puts the item on the list, including a
+            -- gang-wide subtype rule, which carries neither id
+            fte.id IS NOT NULL
             OR ea_var.id IS NOT NULL
             OR ea_origin.id IS NOT NULL
             OR cftl.is_ftl IS NOT NULL

--- a/supabase/functions/get_equipment_detailed_data.sql
+++ b/supabase/functions/get_equipment_detailed_data.sql
@@ -465,7 +465,14 @@ AS $$
         -- Core equipment gating
         AND (
             COALESCE(e.core_equipment, false) = false
-            OR (e.core_equipment = true AND (fte.fighter_type_id IS NOT NULL OR cftl.is_ftl IS NOT NULL OR $3 IS NULL))
+            OR (e.core_equipment = true AND (
+                fte.fighter_type_id IS NOT NULL
+                -- A matched gang-wide subtype rule carries no fighter id of its
+                -- own, so it needs the same allowance is_fighter_list gives it
+                OR (fte.id IS NOT NULL AND fte.fighter_type_id IS NULL AND fte.vehicle_type_id IS NULL)
+                OR cftl.is_ftl IS NOT NULL
+                OR $3 IS NULL
+            ))
         )
         -- Fighter list / trading post filter logic
         AND (

--- a/supabase/functions/get_equipment_detailed_data.sql
+++ b/supabase/functions/get_equipment_detailed_data.sql
@@ -403,7 +403,7 @@ AS $$
         AND ea_origin.gang_origin_id IS NOT NULL
         AND ea_origin.gang_origin_id = gd.gang_origin_id
 
-    -- Fighter type equipment (unchanged)
+    -- Fighter type equipment
     LEFT JOIN fighter_type_equipment fte
         ON e.id = fte.equipment_id
         AND (fte.fighter_type_id = $3
@@ -414,6 +414,7 @@ AS $$
              OR (gd.affiliation_ft_id IS NOT NULL
                  AND (fte.fighter_type_id = gd.affiliation_ft_id OR fte.vehicle_type_id = gd.affiliation_ft_id)))
         AND (fte.gang_origin_id IS NULL OR fte.gang_origin_id = gd.gang_origin_id)
+        AND (fte.gang_variant_id IS NULL OR gd.gang_variants ? fte.gang_variant_id::text)
         AND (fte.gang_type_id IS NULL OR fte.gang_type_id = $1)
 
     -- Is this system equipment on the current custom fighter type's equipment list?

--- a/supabase/functions/get_equipment_detailed_data.sql
+++ b/supabase/functions/get_equipment_detailed_data.sql
@@ -61,8 +61,8 @@ AS $$
             cg.campaign_type_allegiance_id,
             fgl.fighter_type_id AS legacy_ft_id,
             ga.fighter_type_id  AS affiliation_ft_id,
-            -- NULL when called without a fighter ($6); an empty array then
-            -- matches no subtype-scoped row rather than every one
+            -- Empty when called without a fighter ($6), so it matches no
+            -- subtype rule rather than every one
             COALESCE(f.fighter_subtypes, '[]'::jsonb) AS fighter_subtypes,
             COALESCE(gt.edition_id, cgt.edition_id) AS edition_id
         FROM (SELECT 1) AS _dummy
@@ -416,9 +416,8 @@ AS $$
                  AND $4 = true)
              OR (gd.affiliation_ft_id IS NOT NULL
                  AND (fte.fighter_type_id = gd.affiliation_ft_id OR fte.vehicle_type_id = gd.affiliation_ft_id))
-             -- A subtype rule spanning every gang carries no fighter or vehicle
-             -- of its own. fighter_subtype must be set, or an all-NULL row would
-             -- match every fighter.
+             -- A subtype rule spanning every gang names no fighter of its own.
+             -- fighter_subtype must be set, or an all-NULL row matches everything.
              OR (fte.fighter_type_id IS NULL
                  AND fte.vehicle_type_id IS NULL
                  AND fte.custom_fighter_type_id IS NULL
@@ -443,8 +442,8 @@ AS $$
     -- so the predicate lives in exactly one place.
     LEFT JOIN LATERAL (
         SELECT (
-            -- Any matched fte row puts the item on the list, including a
-            -- gang-wide subtype rule, which carries neither id
+            -- Any matched row counts, including a gang-wide subtype rule,
+            -- which has neither id
             fte.id IS NOT NULL
             OR ea_var.id IS NOT NULL
             OR ea_origin.id IS NOT NULL

--- a/types/equipment.ts
+++ b/types/equipment.ts
@@ -253,13 +253,17 @@ export interface EquipmentVariantAvailability {
 
 /**
  * An entry on a fighter type's Equipment List, optionally narrowed to gangs of a
- * given origin or variant. Both scopes null means the grant applies to every gang
- * running that fighter type.
+ * given origin or variant and to fighters of a given subtype. All scopes null
+ * means the grant applies to every gang running that fighter type.
+ *
+ * fighter_type_id is null for a subtype rule spanning every gang ("all Leaders
+ * may buy this"); fighter_subtype is then required, or the row matches nothing.
  */
 export interface FighterTypeEquipmentGrant {
-  fighter_type_id: string;
+  fighter_type_id: string | null;
   gang_origin_id: string | null;
   gang_variant_id: string | null;
+  fighter_subtype: string | null;
 }
 
 /**

--- a/types/equipment.ts
+++ b/types/equipment.ts
@@ -252,6 +252,17 @@ export interface EquipmentVariantAvailability {
 }
 
 /**
+ * An entry on a fighter type's Equipment List, optionally narrowed to gangs of a
+ * given origin or variant. Both scopes null means the grant applies to every gang
+ * running that fighter type.
+ */
+export interface FighterTypeEquipmentGrant {
+  fighter_type_id: string;
+  gang_origin_id: string | null;
+  gang_variant_id: string | null;
+}
+
+/**
  * Per-gang adjusted-cost entries used by the equipment admin editor.
  * The label fields (gang_type / origin_name) are for display only; the API
  * persists the id + adjusted_cost.

--- a/types/equipment.ts
+++ b/types/equipment.ts
@@ -252,12 +252,10 @@ export interface EquipmentVariantAvailability {
 }
 
 /**
- * An entry on a fighter type's Equipment List, optionally narrowed to gangs of a
- * given origin or variant and to fighters of a given subtype. All scopes null
- * means the grant applies to every gang running that fighter type.
- *
- * fighter_type_id is null for a subtype rule spanning every gang ("all Leaders
- * may buy this"); fighter_subtype is then required, or the row matches nothing.
+ * An entry on a fighter type's Equipment List, optionally narrowed by gang
+ * origin, gang variant and fighter subtype. fighter_type_id is null for a
+ * subtype rule spanning every gang; fighter_subtype is then required, or the
+ * row matches nothing.
  */
 export interface FighterTypeEquipmentGrant {
   fighter_type_id: string | null;


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? -->

- `fighter_type_equipment` has carried `gang_origin_id`, `gang_variant_id` and `fighter_subtype` for a while, but the equipment admin only ever wrote bare `(equipment_id, fighter_type_id)` rows, so a grant could not be limited to gangs of a given origin or variant, or to fighters of a given subtype. Only the vehicle admin exposed the origin axis. No fighter-type row in the database carried any scope.
- "Fighter Types with this Equipment" keeps its one-click dropdown for unscoped grants and gains an **Add Scoped** dialog for the rest. Fighter Type is optional there, so a subtype rule can span every gang — this is what lets "Leaders and Champions of a Corrupted gang may purchase Psychic Familiars" be two rows rather than one per gang's Leader and Champion type.
- Grants now round-trip as `fighter_type_grants` objects rather than a flat id array.
- **Two data-loss bugs fixed in the same paths.** The equipment PATCH deleted on `equipment_id` alone, destroying the vehicle admin's rows on every save (1,023 rows exposed); the client gate meant to prevent it misfired precisely when such rows existed, because the GET returned vehicle rows as null `fighter_type_id`s. The fighter-type PATCH stripped scope columns and re-inserted them unscoped. Both routes now define the rows they own once and apply that to the read and the delete alike, so a screen can only delete what it can see and re-create.
- Also fixed: the "Availability per Gang Variant" dialog returned bare on a duplicate, and `Modal.handleConfirm` closes on anything but an explicit `false` — so it toasted *and* dismissed, discarding the entry.

`excluded` (deny rows) is deliberately out of scope and left for a follow-up.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [x] Schema / migration

## How I tested

<!-- What you tested before opening this PR. Example: Opened gang X → bought equipment → credits/rating updated -->

- [x] `npx tsc --noEmit` clean; `eslint` clean on all changed files apart from one pre-existing `filteredWeapons` React Compiler error that reproduces identically on `main`. `next build` compiles and typechecks.
- [x] Verified the new SQL predicates against live data rather than by inspection: a Leader fighter matches a `fighter_subtype = 'Leader'` rule and not a Champion one; a call with no fighter (`'[]'`) matches neither; all 17,468 existing rows still pass both new predicates, so no current grant is lost.
- [x] Verified the scope filters select exactly the 16,444 plain fighter grants, leaving the other 1,024 vehicle/orphan rows untouched.
- [x] Confirmed the deployed `get_equipment_detailed_data` did not read `gang_variant_id` or `fighter_subtype` on `fighter_type_equipment` before this change (dumped `pg_get_functiondef` from the live project).
- [ ] **Not run — needs a reviewer with the app running.** No app credentials in my environment, so the end-to-end checks are unverified: (a) the vehicle-row regression — pick equipment a vehicle grants, save it through the equipment admin, confirm the row count holds (on `main` it drops to zero); (b) a matching-origin gang sees the item on the fighter's Equipment List and a different-origin gang does not; (c) the add/save/reopen/remove round trip for all three scopes.

## Database

<!-- Delete this section if not applicable. Migrations are not auto-applied — a maintainer must apply them before this PR is merged. -->

- [ ] Migration added under `supabase/migrations/`
- [x] RPC/SQL function changed: updated both `supabase/migrations/` and the matching file under `supabase/functions/`

No migration is needed — the columns already exist from `20260822120000`, which added them and noted that the companion `get_equipment_detailed_data` change "is applied separately". That deploy never happened, so this PR supplies it. Following the convention of `20260723120000` and `20260822120000`, the function body lives in `supabase/functions/` only and is not duplicated into a migration.

The RPC needed three changes for subtype, not just a predicate:
1. A rule spanning every gang carries no `fighter_type_id`, and the join's identity branch required one, so such a row could never match. That branch now also accepts a row naming no fighter, vehicle or custom type — provided it names a subtype, without which the single all-NULL row in the table would match every fighter.
2. `gang_data` now carries the fighter's subtypes, coalesced to an empty array so a call with no fighter matches no subtype rule.
3. `is_fighter_list` keyed off `fighter_type_id`/`vehicle_type_id`, neither of which a gang-wide row has, so it now keys off `fte.id`.

### Migration status

<!-- Check one. Migrations are not auto-applied. -->

- [x] Needs maintainer to apply the migration before merge
- [ ] Migration already applied

**Apply `supabase/functions/get_equipment_detailed_data.sql` from the dashboard before merging.** Origin scoping works on merge because its predicate is already live; variant- and subtype-scoped grants will save correctly but have no effect until the function is applied.

## Risk / rollout

<!-- e.g. Low / Medium — any deploy notes beyond database (env vars, feature flags, etc.). -->

- **Medium.** The scope-ownership fix touches a path every equipment save goes through, and the RPC change touches the query behind every equipment list. Mitigating: the new predicates were verified against all 17,468 live rows without excluding any, `SELECT DISTINCT` absorbs the extra join fan-out from variant being multi-valued per gang, and no fighter-type row currently carries any scope, so nothing existing changes behaviour.
- Worth knowing for the `excluded` follow-up: dropping the broken `hasEditedFighterTypes` gate means the grant rewrite now runs on *every* save rather than almost never. That is why the read/delete/write scope had to be made symmetric here — the follow-up would otherwise have been the first thing to populate those columns and the first to silently destroy them.