### PR TITLE
fix(admin): edition-gate the Gang Origin and Gang Variant pickers

### DIFF
--- a/app/api/admin/gang-origins/route.ts
+++ b/app/api/admin/gang-origins/route.ts
@@ -30,7 +30,6 @@ export async function GET(request: Request) {
     const transformedData = origins.map((origin: any) => ({
       id: origin.id,
       origin_name: origin.origin_name,
-      // Origins are edition-scoped; clients filter their pickers on this
       edition_id: origin.edition_id ?? null,
       category_id: origin.gang_origin_category_id,
       category_name: (origin.gang_origin_categories as any)?.category_name || 'Unknown'

--- a/app/api/admin/gang-origins/route.ts
+++ b/app/api/admin/gang-origins/route.ts
@@ -16,6 +16,7 @@ export async function GET(request: Request) {
       .select(`
         id,
         origin_name,
+        edition_id,
         gang_origin_category_id,
         gang_origin_categories!gang_origin_category_id (
           id,
@@ -29,6 +30,8 @@ export async function GET(request: Request) {
     const transformedData = origins.map((origin: any) => ({
       id: origin.id,
       origin_name: origin.origin_name,
+      // Origins are edition-scoped; clients filter their pickers on this
+      edition_id: origin.edition_id ?? null,
       category_id: origin.gang_origin_category_id,
       category_name: (origin.gang_origin_categories as any)?.category_name || 'Unknown'
     }));

--- a/app/api/gang-variant-types/route.ts
+++ b/app/api/gang-variant-types/route.ts
@@ -6,6 +6,7 @@ import { editionSlugFromJoin } from "@/types/edition";
 interface Variant {
     id: string;
     variant: string;
+    edition_id?: string | null;
     editions?: { slug: string } | { slug: string }[] | null;
 }
 
@@ -21,7 +22,7 @@ export async function GET(request: Request) {
 
         let query = supabase
             .from('gang_variant_types')
-            .select('id, variant, editions:edition_id (slug)')
+            .select('id, variant, edition_id, editions:edition_id (slug)')
             .order('variant')
 
         const { data, error } = await query;
@@ -31,6 +32,9 @@ export async function GET(request: Request) {
         const modelData = data.map((variant: Variant) => ({
             id: variant.id,
             variant: variant.variant,
+            // Slug for the player-side callers, which reason in slugs; id for the
+            // admin catalog editor, which filters and stores an edition_id
+            edition_id: variant.edition_id ?? null,
             edition_slug: editionSlugFromJoin(variant.editions),
         }));
 

--- a/app/api/gang-variant-types/route.ts
+++ b/app/api/gang-variant-types/route.ts
@@ -32,8 +32,7 @@ export async function GET(request: Request) {
         const modelData = data.map((variant: Variant) => ({
             id: variant.id,
             variant: variant.variant,
-            // Slug for the player-side callers, which reason in slugs; id for the
-            // admin catalog editor, which filters and stores an edition_id
+            // Slug for the player-side callers; id for the admin editor, which saves one
             edition_id: variant.edition_id ?? null,
             edition_slug: editionSlugFromJoin(variant.editions),
         }));

--- a/components/admin/admin-edit-equipment.tsx
+++ b/components/admin/admin-edit-equipment.tsx
@@ -484,8 +484,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
     staleTime: 5 * 60 * 1000,
   });
 
-  // The same origin and variant names exist in more than one edition under
-  // different ids, so only the selected edition's rows may be newly picked
+  // Origin and variant names repeat across editions under different ids
   const filteredGangOrigins = useMemo(
     () => editionId ? gangOriginList.filter(origin => origin.edition_id === editionId) : gangOriginList,
     [gangOriginList, editionId]
@@ -544,8 +543,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
     }
     // Gang types are edition-scoped; clear any in-progress Cost-per-Gang pick
     setSelectedGangType('');
-    // Origin, variant and subtype picks are edition-scoped too. An id left in a
-    // select whose options no longer contain it renders blank but still saves.
+    // Origin/variant/subtype picks are edition-scoped too; drop in-progress ones
     setSelectedAdjustedCostGangOrigin('');
     setSelectedAvailabilityGangOrigin('');
     setSelectedAvailabilityGangVariant('');
@@ -561,9 +559,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
           return !tp || tp.edition_id === newEditionId;
         })
       );
-      // A grant is dropped if any part of its scope is confirmed foreign. Its
-      // fighter_subtype is deliberately not judged: subtypes are stored by name
-      // and the same name is legitimately defined in more than one edition.
+      // fighter_subtype is not judged: it is stored by name, and names repeat per edition
       setFighterTypeGrants(prev =>
         prev.filter(grant => {
           const ft = fighterTypes.find(f => f.id === grant.fighter_type_id);
@@ -582,8 +578,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
           return !gt || gt.edition_id === newEditionId;
         })
       );
-      // Origin- and variant-scoped rows are edition-scoped as well. A scope the
-      // catalog doesn't list can't be confirmed foreign, so it stays.
+      // Origin- and variant-scoped rows are edition-scoped as well
       setGangOriginAdjustedCosts(prev =>
         prev.filter(cost => {
           const origin = gangOriginList.find(o => o.id === cost.gang_origin_id);
@@ -1432,10 +1427,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                         variant="outline"
                         size="sm"
                         className="mb-2"
-                        // Unlike the Availability sections this one isn't edition-gated,
-                        // so an edition that defines no origins has nothing to add. Only
-                        // a loaded catalog can say that — an empty one is still fetching,
-                        // and this click is what enables the query.
+                        // Nothing to add once the catalog is loaded and has no origins here
                         disabled={gangOriginList.length > 0 && filteredGangOrigins.length === 0}
                       >
                         Add Origin

--- a/components/admin/admin-edit-equipment.tsx
+++ b/components/admin/admin-edit-equipment.tsx
@@ -1427,7 +1427,8 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                         variant="outline"
                         size="sm"
                         className="mb-2"
-                        // Nothing to add once the catalog is loaded and has no origins here
+                        // Unlike the Availability sections this one renders in every
+                        // edition, so it can be the one with no origins left to add
                         disabled={gangOriginList.length > 0 && filteredGangOrigins.length === 0}
                       >
                         Add Origin

--- a/components/admin/admin-edit-equipment.tsx
+++ b/components/admin/admin-edit-equipment.tsx
@@ -15,7 +15,7 @@ import { gangOriginRank } from "@/utils/gangOriginRank";
 import { gangVariantRank } from "@/utils/gangVariantRank";
 import { AdminFighterEffects } from "./admin-fighter-effects";
 import { EditionSelect, useEditions, editionSlugOf } from '@/components/edition-select';
-import { hasLethalityStatline, hasTradePoints } from '@/types/edition';
+import { hasLethalityStatline, hasTradePoints, sameEditionForDisplay } from '@/types/edition';
 import { isValidTradePoints } from '@/utils/campaigns/resources';
 import { WeaponProfileFields } from '@/components/ui/weapon-profile-fields';
 import { AdminTradingPost } from "./admin-trading-post";
@@ -248,90 +248,6 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
   // Str, AP, D and Am. Only the stats the selected edition uses are offered.
   const usesLethality = hasLethalityStatline(editionSlug);
 
-  const handleEditionChange = (newEditionId: string) => {
-    setEditionId(newEditionId);
-    if (newEditionId && selectedEquipmentId) {
-      const selected = equipmentList.find(item => item.id === selectedEquipmentId);
-      if (selected && selected.edition_id !== newEditionId) {
-        setSelectedEquipmentId('');
-      }
-    }
-    if (categoryFilter && newEditionId) {
-      // categoryFilter is a name; the same name can exist per edition
-      const stillValid = categories.some(
-        category => category.category_name === categoryFilter && category.edition_id === newEditionId
-      );
-      if (!stillValid) {
-        setCategoryFilter('');
-        setSelectedEquipmentId('');
-      }
-    }
-    if (equipmentCategory) {
-      const selected = categories.find(category => category.id === equipmentCategory);
-      if (selected && newEditionId && selected.edition_id !== newEditionId) {
-        setEquipmentCategory('');
-      }
-    }
-    // Gang types are edition-scoped; clear any in-progress Cost-per-Gang pick
-    setSelectedGangType('');
-    // Drop trading posts / fighter types that belong to another edition
-    if (newEditionId) {
-      setSelectedTradingPosts(prev =>
-        prev.filter(id => {
-          const tp = tradingPostTypes.find(t => t.id === id);
-          return !tp || tp.edition_id === newEditionId;
-        })
-      );
-      setFighterTypeGrants(prev =>
-        prev.filter(grant => {
-          const ft = fighterTypes.find(f => f.id === grant.fighter_type_id);
-          return !ft || ft.edition_id === newEditionId;
-        })
-      );
-      // Cost per Gang is keyed on a gang type, which is edition-scoped too
-      setGangAdjustedCosts(prev =>
-        prev.filter(cost => {
-          const gt = gangTypeOptions.find(g => g.gang_type_id === cost.gang_type_id);
-          return !gt || gt.edition_id === newEditionId;
-        })
-      );
-    }
-    // N26 uses Trade Points instead of Availability; drop stale N23 rows
-    if (hasTradePoints(editionSlugOf(editions, newEditionId))) {
-      setShowAvailabilityDialog(false);
-      setSelectedAvailabilityGangType('');
-      setAvailValueLetter('');
-      setAvailValueNumber(6);
-      setAvailExclusive(false);
-      setEquipmentAvailabilities([]);
-      setShowOriginAvailabilityDialog(false);
-      setSelectedAvailabilityGangOrigin('');
-      setOriginAvailValueLetter('');
-      setOriginAvailValueNumber(6);
-      setEquipmentOriginAvailabilities([]);
-      setShowVariantAvailabilityDialog(false);
-      setSelectedAvailabilityGangVariant('');
-      setVariantAvailValueLetter('');
-      setVariantAvailValueNumber(6);
-      setEquipmentVariantAvailabilities([]);
-    }
-    // Weapon Group parents are edition-scoped; drop a cross-edition pick
-    if (newEditionId) {
-      setWeaponProfiles(profiles => profiles.map(profile => {
-        if (!profile.weapon_group_id) return profile;
-        const parent = weapons.find(w => w.id === profile.weapon_group_id);
-        if (parent && parent.edition_id !== newEditionId) {
-          return { ...profile, weapon_group_id: null };
-        }
-        return profile;
-      }));
-      // Grants options are edition-scoped; blank confirmed cross-edition picks
-      setGrantsEquipment(current =>
-        current ? sanitizeGrantsOptionsForEdition(current, allEquipment, newEditionId) : current
-      );
-    }
-  };
-
   const { data: equipmentDetails, isLoading: isEquipmentDetailsLoading } = useQuery<any>({
     queryKey: ['admin-equipment-details', selectedEquipmentId],
     queryFn: async () => {
@@ -544,7 +460,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
     [fighterTypes, editionId, editions]
   );
 
-  const { data: gangOriginList = [] } = useQuery<Array<{id: string, origin_name: string, category_name: string}>>({
+  const { data: gangOriginList = [] } = useQuery<Array<{id: string, origin_name: string, category_name: string, edition_id?: string | null}>>({
     queryKey: ['admin-gang-origins'],
     queryFn: async () => {
       const response = await fetch('/api/admin/gang-origins');
@@ -556,7 +472,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
     staleTime: 5 * 60 * 1000,
   });
 
-  const { data: gangVariantList = [] } = useQuery<Array<{id: string, variant: string}>>({
+  const { data: gangVariantList = [] } = useQuery<Array<{id: string, variant: string, edition_slug?: string | null}>>({
     queryKey: ['admin-gang-variants'],
     queryFn: async () => {
       const response = await fetch('/api/gang-variant-types');
@@ -567,6 +483,22 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
     enabled: !!selectedEquipmentId || showVariantAvailabilityDialog,
     staleTime: 5 * 60 * 1000,
   });
+
+  // The same origin and variant names exist in more than one edition under
+  // different ids, so only the selected edition's rows may be newly picked
+  const filteredGangOrigins = useMemo(
+    () => editionId ? gangOriginList.filter(origin => origin.edition_id === editionId) : gangOriginList,
+    [gangOriginList, editionId]
+  );
+
+  // Variants come from the shared route, which returns a slug rather than an id.
+  // An edition that hasn't resolved yet makes no claim, so it filters nothing.
+  const filteredGangVariants = useMemo(
+    () => editionId && editionSlug
+      ? gangVariantList.filter(variant => sameEditionForDisplay(variant.edition_slug, editionSlug))
+      : gangVariantList,
+    [gangVariantList, editionId, editionSlug]
+  );
 
   const { data: fighterSubtypeList = [] } = useQuery<Array<{id: string, subtype_name: string, edition_id?: string | null}>>({
     queryKey: ['admin-fighter-subtypes'],
@@ -588,6 +520,130 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
       ),
     [fighterSubtypeList, editionId, editions]
   );
+
+  const handleEditionChange = (newEditionId: string) => {
+    setEditionId(newEditionId);
+    const newSlug = editionSlugOf(editions, newEditionId);
+    if (newEditionId && selectedEquipmentId) {
+      const selected = equipmentList.find(item => item.id === selectedEquipmentId);
+      if (selected && selected.edition_id !== newEditionId) {
+        setSelectedEquipmentId('');
+      }
+    }
+    if (categoryFilter && newEditionId) {
+      // categoryFilter is a name; the same name can exist per edition
+      const stillValid = categories.some(
+        category => category.category_name === categoryFilter && category.edition_id === newEditionId
+      );
+      if (!stillValid) {
+        setCategoryFilter('');
+        setSelectedEquipmentId('');
+      }
+    }
+    if (equipmentCategory) {
+      const selected = categories.find(category => category.id === equipmentCategory);
+      if (selected && newEditionId && selected.edition_id !== newEditionId) {
+        setEquipmentCategory('');
+      }
+    }
+    // Gang types are edition-scoped; clear any in-progress Cost-per-Gang pick
+    setSelectedGangType('');
+    // Origin, variant and subtype picks are edition-scoped too. An id left in a
+    // select whose options no longer contain it renders blank but still saves.
+    setSelectedAdjustedCostGangOrigin('');
+    setSelectedAvailabilityGangOrigin('');
+    setSelectedAvailabilityGangVariant('');
+    setScopedGrantFighterType('');
+    setScopedGrantSubtype('');
+    setScopedGrantOrigin('');
+    setScopedGrantVariant('');
+    // Drop trading posts / fighter types that belong to another edition
+    if (newEditionId) {
+      setSelectedTradingPosts(prev =>
+        prev.filter(id => {
+          const tp = tradingPostTypes.find(t => t.id === id);
+          return !tp || tp.edition_id === newEditionId;
+        })
+      );
+      // A grant is dropped if any part of its scope is confirmed foreign. Its
+      // fighter_subtype is deliberately not judged: subtypes are stored by name
+      // and the same name is legitimately defined in more than one edition.
+      setFighterTypeGrants(prev =>
+        prev.filter(grant => {
+          const ft = fighterTypes.find(f => f.id === grant.fighter_type_id);
+          if (ft && ft.edition_id !== newEditionId) return false;
+          const origin = gangOriginList.find(o => o.id === grant.gang_origin_id);
+          if (origin && origin.edition_id !== newEditionId) return false;
+          const variant = gangVariantList.find(v => v.id === grant.gang_variant_id);
+          if (variant && newSlug && !sameEditionForDisplay(variant.edition_slug, newSlug)) return false;
+          return true;
+        })
+      );
+      // Cost per Gang is keyed on a gang type, which is edition-scoped too
+      setGangAdjustedCosts(prev =>
+        prev.filter(cost => {
+          const gt = gangTypeOptions.find(g => g.gang_type_id === cost.gang_type_id);
+          return !gt || gt.edition_id === newEditionId;
+        })
+      );
+      // Origin- and variant-scoped rows are edition-scoped as well. A scope the
+      // catalog doesn't list can't be confirmed foreign, so it stays.
+      setGangOriginAdjustedCosts(prev =>
+        prev.filter(cost => {
+          const origin = gangOriginList.find(o => o.id === cost.gang_origin_id);
+          return !origin || origin.edition_id === newEditionId;
+        })
+      );
+      setEquipmentOriginAvailabilities(prev =>
+        prev.filter(avail => {
+          const origin = gangOriginList.find(o => o.id === avail.gang_origin_id);
+          return !origin || origin.edition_id === newEditionId;
+        })
+      );
+      if (newSlug) {
+        setEquipmentVariantAvailabilities(prev =>
+          prev.filter(avail => {
+            const variant = gangVariantList.find(v => v.id === avail.gang_variant_id);
+            return !variant || sameEditionForDisplay(variant.edition_slug, newSlug);
+          })
+        );
+      }
+    }
+    // N26 uses Trade Points instead of Availability; drop stale N23 rows
+    if (hasTradePoints(newSlug)) {
+      setShowAvailabilityDialog(false);
+      setSelectedAvailabilityGangType('');
+      setAvailValueLetter('');
+      setAvailValueNumber(6);
+      setAvailExclusive(false);
+      setEquipmentAvailabilities([]);
+      setShowOriginAvailabilityDialog(false);
+      setSelectedAvailabilityGangOrigin('');
+      setOriginAvailValueLetter('');
+      setOriginAvailValueNumber(6);
+      setEquipmentOriginAvailabilities([]);
+      setShowVariantAvailabilityDialog(false);
+      setSelectedAvailabilityGangVariant('');
+      setVariantAvailValueLetter('');
+      setVariantAvailValueNumber(6);
+      setEquipmentVariantAvailabilities([]);
+    }
+    // Weapon Group parents are edition-scoped; drop a cross-edition pick
+    if (newEditionId) {
+      setWeaponProfiles(profiles => profiles.map(profile => {
+        if (!profile.weapon_group_id) return profile;
+        const parent = weapons.find(w => w.id === profile.weapon_group_id);
+        if (parent && parent.edition_id !== newEditionId) {
+          return { ...profile, weapon_group_id: null };
+        }
+        return profile;
+      }));
+      // Grants options are edition-scoped; blank confirmed cross-edition picks
+      setGrantsEquipment(current =>
+        current ? sanitizeGrantsOptionsForEdition(current, allEquipment, newEditionId) : current
+      );
+    }
+  };
 
   const isLoading = isEquipmentDetailsLoading || isWeaponsLoading || isSubmitting;
 
@@ -1382,6 +1438,11 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                         variant="outline"
                         size="sm"
                         className="mb-2"
+                        // Unlike the Availability sections this one isn't edition-gated,
+                        // so an edition that defines no origins has nothing to add. Only
+                        // a loaded catalog can say that — an empty one is still fetching,
+                        // and this click is what enables the query.
+                        disabled={gangOriginList.length > 0 && filteredGangOrigins.length === 0}
                       >
                         Add Origin
                       </Button>
@@ -1459,7 +1520,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                                 className="w-full p-2 border rounded-md"
                               >
                                 <option key="default" value="">Select a Gang Origin</option>
-                                <GangOriginOptions origins={gangOriginList} />
+                                <GangOriginOptions origins={filteredGangOrigins} />
                               </select>
                             </div>
 
@@ -1571,7 +1632,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                                 className="w-full p-2 border rounded-md"
                               >
                                 <option key="default" value="">Select a Gang Origin</option>
-                                <GangOriginOptions origins={gangOriginList} />
+                                <GangOriginOptions origins={filteredGangOrigins} />
                               </select>
                             </div>
 
@@ -1685,7 +1746,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                                 className="w-full p-2 border rounded-md"
                               >
                                 <option key="default" value="">Select a Gang Variant</option>
-                                <GangVariantOptions variants={gangVariantList} />
+                                <GangVariantOptions variants={filteredGangVariants} />
                               </select>
                             </div>
 
@@ -1865,7 +1926,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                             className="w-full p-2 border rounded-md"
                           >
                             <option key="default" value="">Any Gang Origin</option>
-                            <GangOriginOptions origins={gangOriginList} />
+                            <GangOriginOptions origins={filteredGangOrigins} />
                           </select>
                         </div>
 
@@ -1877,7 +1938,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                             className="w-full p-2 border rounded-md"
                           >
                             <option key="default" value="">Any Gang Variant</option>
-                            <GangVariantOptions variants={gangVariantList} />
+                            <GangVariantOptions variants={filteredGangVariants} />
                           </select>
                         </div>
                       </div>

--- a/components/admin/admin-edit-equipment.tsx
+++ b/components/admin/admin-edit-equipment.tsx
@@ -15,7 +15,7 @@ import { gangOriginRank } from "@/utils/gangOriginRank";
 import { gangVariantRank } from "@/utils/gangVariantRank";
 import { AdminFighterEffects } from "./admin-fighter-effects";
 import { EditionSelect, useEditions, editionSlugOf } from '@/components/edition-select';
-import { hasLethalityStatline, hasTradePoints, sameEditionForDisplay } from '@/types/edition';
+import { hasLethalityStatline, hasTradePoints } from '@/types/edition';
 import { isValidTradePoints } from '@/utils/campaigns/resources';
 import { WeaponProfileFields } from '@/components/ui/weapon-profile-fields';
 import { AdminTradingPost } from "./admin-trading-post";
@@ -472,7 +472,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
     staleTime: 5 * 60 * 1000,
   });
 
-  const { data: gangVariantList = [] } = useQuery<Array<{id: string, variant: string, edition_slug?: string | null}>>({
+  const { data: gangVariantList = [] } = useQuery<Array<{id: string, variant: string, edition_id?: string | null}>>({
     queryKey: ['admin-gang-variants'],
     queryFn: async () => {
       const response = await fetch('/api/gang-variant-types');
@@ -491,13 +491,9 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
     [gangOriginList, editionId]
   );
 
-  // Variants come from the shared route, which returns a slug rather than an id.
-  // An edition that hasn't resolved yet makes no claim, so it filters nothing.
   const filteredGangVariants = useMemo(
-    () => editionId && editionSlug
-      ? gangVariantList.filter(variant => sameEditionForDisplay(variant.edition_slug, editionSlug))
-      : gangVariantList,
-    [gangVariantList, editionId, editionSlug]
+    () => editionId ? gangVariantList.filter(variant => variant.edition_id === editionId) : gangVariantList,
+    [gangVariantList, editionId]
   );
 
   const { data: fighterSubtypeList = [] } = useQuery<Array<{id: string, subtype_name: string, edition_id?: string | null}>>({
@@ -575,7 +571,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
           const origin = gangOriginList.find(o => o.id === grant.gang_origin_id);
           if (origin && origin.edition_id !== newEditionId) return false;
           const variant = gangVariantList.find(v => v.id === grant.gang_variant_id);
-          if (variant && newSlug && !sameEditionForDisplay(variant.edition_slug, newSlug)) return false;
+          if (variant && variant.edition_id !== newEditionId) return false;
           return true;
         })
       );
@@ -600,14 +596,12 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
           return !origin || origin.edition_id === newEditionId;
         })
       );
-      if (newSlug) {
-        setEquipmentVariantAvailabilities(prev =>
-          prev.filter(avail => {
-            const variant = gangVariantList.find(v => v.id === avail.gang_variant_id);
-            return !variant || sameEditionForDisplay(variant.edition_slug, newSlug);
-          })
-        );
-      }
+      setEquipmentVariantAvailabilities(prev =>
+        prev.filter(avail => {
+          const variant = gangVariantList.find(v => v.id === avail.gang_variant_id);
+          return !variant || variant.edition_id === newEditionId;
+        })
+      );
     }
     // N26 uses Trade Points instead of Availability; drop stale N23 rows
     if (hasTradePoints(newSlug)) {


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? -->

- **The bug:** Edit Equipment already treats edition as its top-level filter, but the Gang Origin and Gang Variant selects rendered straight off the raw query results, so they listed every edition's rows at once. Not cosmetic — three variant names (Chaos Corrupted, Genestealer Infected, Malstrain Corrupted) exist in **both** n23 and n26 under different ids, and the duplicate entries are indistinguishable in the list, so an admin editing an n26 item could silently attach an n23 scope id and produce a grant that can never match.
- All four origin/variant dropdowns now offer only the selected edition's rows: the Scoped Equipment List Entry modal, plus Cost per Gang Origin and the two Availability dialogs.
- Both filters compare `edition_id`, matching the other 73 edition comparisons across `components/admin/`. `/api/admin/gang-origins` now returns `edition_id` (it exposed nothing edition-related before); `/api/gang-variant-types` returns it alongside the `edition_slug` it already flattened, so the three player-side callers keep the slug — they submit only `v.id`, never the rows, so the extra field is inert for them.
- The grant-chip labels stay **unfiltered on purpose**: selecting an equipment sets `editionId` directly with no prune, so an already-saved cross-edition scope is legitimately present on load and has to keep rendering its name to stay removable. Same selectable-vs-listed split as `admin-trading-post.tsx`.
- `handleEditionChange` now prunes what it was missing — origin- and variant-scoped adjusted costs and availabilities, and the origin/variant half of a fighter-type grant. A scope absent from the catalog is kept, never dropped: both queries are `enabled`-gated, so an empty list means "still fetching", not "foreign". A grant's `fighter_subtype` is deliberately still not judged — it is stored by name, and the same name is legitimately defined in more than one edition.
- `handleEditionChange` moved below the catalog queries it reads. Reading `gangOriginList` from above its declaration made React Compiler give up on preserving the manual memoization; the move clears that **and** the pre-existing bail-out on `filteredWeapons`, taking repo lint errors from 7 to 5.
- Under n26 the Gang Origin picker is legitimately empty — there are no n26 rows in `gang_origins` yet. Left as an empty picker rather than hidden, and no `EDITION_CAPABILITIES` row added: that is a data-authoring fact, not a rules statement, so it starts working by itself once n26 origins are authored.

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Schema / migration

## How I tested

<!-- What you tested before opening this PR. Example: Opened gang X → bought equipment → credits/rating updated -->

- [x] `npx tsc --noEmit` clean; `npm run lint` clean on all three changed files (repo total down from 7 errors to 5)
- [x] `npm run build` compiles and passes its TypeScript pass
- [x] Confirmed against the live DB that the duplicate-name variants are real (9 n23 + 3 n26 rows, three names shared) and that all 27 `gang_origins` rows are n23
- [x] Confirmed the two API changes are additive: re-read all four other `/api/admin/gang-origins` consumers and all three other `/api/gang-variant-types` consumers — each declares its own structural query generic and none re-posts the rows
- [ ] **Not done — no Supabase credentials in my environment, so I could not run the app.** Worth a manual pass before merge: switch edition n23→n26 in Edit Equipment and confirm Gang Variant lists only the 3 n26 rows; confirm a saved n23-scoped grant chip still shows its name and its ✕ still removes it; confirm switching edition prunes the origin/variant rows it should

## Risk / rollout

<!-- e.g. Low / Medium — any deploy notes beyond database (env vars, feature flags, etc.). -->

- **Low.** No env vars, no feature flags, no migration. Both API changes only add a field to a GET response.
- No behaviour change for player-side code: `/api/gang-variant-types` keeps returning `edition_slug`, and its three other callers are untouched.
- The one intentional behaviour change beyond the fix: switching edition now drops already-picked origin/variant rows that belong to another edition, consistent with what the handler already did for fighter types, trading posts and gang types.