### PR TITLE
Promote Prospects to Gangers at 13XP+ should count advancements correctly

### DIFF
--- a/app/lib/fighter-advancements.ts
+++ b/app/lib/fighter-advancements.ts
@@ -40,6 +40,7 @@ export const getGangFighters = async (gangId: string, supabase: any) => {
     id: f.id,
     fighter_name: f.fighter_name,
     fighter_type: f.fighter_type,
+    fighter_subtypes: Array.isArray(f.fighter_subtypes) ? f.fighter_subtypes : [],
     fighter_type_subtypes: Array.isArray(f.fighter_types?.fighter_subtypes)
       ? f.fighter_types.fighter_subtypes
       : [],

--- a/app/lib/fighter-advancements.ts
+++ b/app/lib/fighter-advancements.ts
@@ -40,6 +40,9 @@ export const getGangFighters = async (gangId: string, supabase: any) => {
     id: f.id,
     fighter_name: f.fighter_name,
     fighter_type: f.fighter_type,
+    fighter_type_subtypes: Array.isArray(f.fighter_types?.fighter_subtypes)
+      ? f.fighter_types.fighter_subtypes
+      : [],
     xp: f.xp,
     starting_xp: f.starting_xp ?? null,
     advancements_taken: countAdvancementsTaken(

--- a/app/lib/shared/gang-assembly.ts
+++ b/app/lib/shared/gang-assembly.ts
@@ -677,6 +677,9 @@ export function assembleGangFighters(
           label: fighter.label,
           fighter_type: fighter.fighter_type || fighterTypeInfo.fighter_type || 'Unknown',
           fighter_subtypes: fighter.fighter_subtypes || [],
+          fighter_type_subtypes: Array.isArray(fighterTypeInfo.fighter_subtypes)
+            ? fighterTypeInfo.fighter_subtypes
+            : [],
           fighter_specialisation: fighterSpecialisationInfo ? {
             fighter_specialisation: fighterSpecialisationInfo.specialisation_name,
             fighter_specialisation_id: fighterSpecialisationInfo.id

--- a/app/lib/shared/gang-data.ts
+++ b/app/lib/shared/gang-data.ts
@@ -137,6 +137,12 @@ export interface GangFighter {
   label?: string;
   fighter_type: string;
   fighter_subtypes: string[];
+  /**
+   * Catalog subtypes on the fighter_type row. Kept-type promotion
+   * (Prospect→Ganger/Specialist) leaves this on the origin type while live
+   * `fighter_subtypes` flip; it is the stable signal for "was recruited as X".
+   */
+  fighter_type_subtypes?: string[];
   fighter_specialisation?: {
     fighter_specialisation: string;
     fighter_specialisation_id: string;

--- a/components/fighter/fighter-advancement-list.tsx
+++ b/components/fighter/fighter-advancement-list.tsx
@@ -9,7 +9,7 @@ import { TypeSpecificData } from '@/types/fighter-effect';
 import { createClient } from '@/utils/supabase/client';
 import { getSkillSetRank } from "@/utils/skillSetRank";
 import { characteristicRank } from "@/utils/characteristicRank";
-import { countAdvancementsTaken, openAdvancementsFor } from "@/utils/advancementRanks";
+import { countAdvancementsTaken, openAdvancementsFor, N26_PROSPECT_PROMOTION_TIER_XP } from "@/utils/advancementRanks";
 import { List } from "@/components/ui/list";
 import { UserPermissions } from '@/types/user-permissions';
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -40,12 +40,13 @@ import {
   type TableEntry,
   type N26AdvancementEntry
 } from '@/utils/dice';
-import { hasCumulativeXp } from '@/types/edition';
+import { hasCumulativeXp, hasProspectSpecialisationPromotion } from '@/types/edition';
 import { skillAccessDeniedMessage } from '@/utils/venatorSkillAccess';
 import {
   N26_CHAMPION_PROMOTION_SKILL_NAME,
   N26_PROSPECT_PROMOTION_CREDITS,
   getN26ProspectSpecialisation,
+  isN26ProspectByCatalog,
 } from '@/utils/keepTypePromotionN26';
 
 // AdvancementModal Interfaces
@@ -55,10 +56,26 @@ interface AdvancementModalProps {
   openAdvancements: number;
   editionSlug?: string | null;
   fighterSubtypes: string[];
+  /**
+   * Catalog subtypes on the fighter's fighter_type row. Distinct from live
+   * `fighterSubtypes` because N26 keep-type promotion leaves the catalog on
+   * Prospect while live subtypes flip to Ganger+Specialist — needed for the
+   * count exclusion to hold across pre- and post-promotion.
+   */
+  fighterCatalogSubtypes?: string[];
   advancements: Array<FighterEffectType>;
   skills: Record<string, any>;
   onClose: () => void;
   onAdvancementAdded: (advancement: FighterEffectType) => void;
+  /**
+   * Runs an N26 Prospect promotion (existing standalone flow), returning once
+   * the mutation settles. Provided by the parent so this modal reuses the
+   * outer mutation's optimistic updates, id reconciliation, and rollback
+   * instead of forking a second copy.
+   */
+  onProspectPromotion?: (data: FighterPromotionResult) => Promise<void>;
+  /** True while the parent's standalone promotion mutation is in flight. */
+  prospectPromotionPending?: boolean;
   onSkillUpdate?: (updatedSkills: Record<string, any>) => void;
   onXpCreditsUpdate?: (xpChange: number, creditsChange: number) => void;
   onAdvancementUpdate: (updatedAdvancements: FighterEffectType[]) => void;
@@ -188,6 +205,13 @@ interface AdvancementsListProps {
   fighterId: string;
   editionSlug?: string | null;
   fighterSubtypes: string[];
+  /**
+   * Catalog subtypes on the fighter's fighter_type row. Distinct from live
+   * `fighterSubtypes` because N26 keep-type promotion leaves the catalog on
+   * Prospect while live subtypes flip to Ganger+Specialist — needed for the
+   * count exclusion to hold across pre- and post-promotion.
+   */
+  fighterCatalogSubtypes?: string[];
   advancements: Array<FighterEffectType>;
   skills: FighterSkills;
   userPermissions: UserPermissions;
@@ -484,6 +508,7 @@ export function AdvancementModal({
   openAdvancements,
   editionSlug = null,
   fighterSubtypes,
+  fighterCatalogSubtypes = [],
   advancements,
   skills,
   onClose,
@@ -501,7 +526,9 @@ export function AdvancementModal({
   fighterTypeName = '',
   fighterTypeId = '',
   fighterSpecialisationId = '',
-  onFighterDetailsUpdate
+  onFighterDetailsUpdate,
+  onProspectPromotion,
+  prospectPromotionPending = false,
 }: AdvancementModalProps) {
   
   const [skillSetCategories, setSkillSetCategories] = useState<SkillType[]>([]);
@@ -593,6 +620,7 @@ export function AdvancementModal({
   const [championPreviewSkillAccess, setChampionPreviewSkillAccess] = useState<SkillAccess[]>([]);
   const [championPreviewSkillAccessLoading, setChampionPreviewSkillAccessLoading] = useState(false);
   const [championPurchaseBusy, setChampionPurchaseBusy] = useState(false);
+  const [prospectPromotionOpen, setProspectPromotionOpen] = useState(false);
   // isSubmitting unused; removed
   const [skillAccess, setSkillAccess] = useState<SkillAccess[]>([]);
   const [skillAccessLoading, setSkillAccessLoading] = useState(false);
@@ -2172,6 +2200,11 @@ export function AdvancementModal({
   const isGangerOrExoticBeastRestricted =
     fighterSubtypes.includes('Ganger') || fighterSubtypes.includes('Exotic Beast');
 
+  const isN26ProspectPromotionRequired =
+    hasProspectSpecialisationPromotion(editionSlug) &&
+    fighterSubtypes.includes('Prospect') &&
+    currentXp >= N26_PROSPECT_PROMOTION_TIER_XP;
+
   const handleAdvancementPurchase = async () => {
     if (gangerModalRollBuy) {
       setGangerPurchaseBusy(true);
@@ -2319,6 +2352,45 @@ export function AdvancementModal({
         </div>
 
         <div className="p-2 overflow-y-auto grow">
+        {isN26ProspectPromotionRequired ? (
+          <div className="space-y-4">
+            <p className="text-sm">
+              This Prospect has reached <strong>{N26_PROSPECT_PROMOTION_TIER_XP} XP</strong> and must be
+              promoted to <strong>Ganger + Specialist</strong> before earning any further Advancements.
+              Rating increases by <strong>{N26_PROSPECT_PROMOTION_CREDITS}</strong>, and the fighter
+              gains the skill associated with the specialisation you pick.
+            </p>
+            <div className="flex justify-center">
+              <Button
+                type="button"
+                variant="default"
+                className="w-full sm:w-auto"
+                onClick={() => setProspectPromotionOpen(true)}
+                disabled={!userPermissions?.canEdit || prospectPromotionPending}
+              >
+                Promote to Ganger + Specialist
+              </Button>
+            </div>
+            <FighterPromotionModal
+              currentSubtype={fighterSubtypes[0] || ''}
+              currentSubtypes={fighterSubtypes}
+              currentSpecialRules={fighterSpecialRules}
+              currentFighterType={fighterTypeName}
+              currentFighterTypeId={fighterTypeId}
+              currentFighterSpecialisationId={fighterSpecialisationId || undefined}
+              fighterTypes={preFetchedFighterTypes}
+              editionSlug={editionSlug}
+              isOpen={prospectPromotionOpen}
+              onClose={() => setProspectPromotionOpen(false)}
+              onPromoted={(data) => {
+                setProspectPromotionOpen(false);
+                if (!onProspectPromotion) return;
+                onProspectPromotion(data).then(onClose, () => undefined);
+              }}
+            />
+          </div>
+        ) : (
+          <>
           <div className="mb-4">
             <p className="text-sm text-muted-foreground mb-2">
               {isCumulativeXp
@@ -2944,6 +3016,8 @@ export function AdvancementModal({
               </Button>
             </div>
           </div>
+          </>
+        )}
         </div>
       </div>
     </div>
@@ -2958,6 +3032,7 @@ export function AdvancementsList({
   fighterId,
   editionSlug = null,
   fighterSubtypes,
+  fighterCatalogSubtypes = [],
   advancements = [],
   skills = {},
   userPermissions,
@@ -3381,11 +3456,14 @@ export function AdvancementsList({
   // Taken count: characteristic effects plus is_advance skills (shared with gang cards).
   const advancementCount = countAdvancementsTaken({ advancements }, skills);
 
+  const excludeProspectPromotionTier = isN26ProspectByCatalog(editionSlug, fighterCatalogSubtypes);
+
   const openAdvancements = openAdvancementsFor(
     editionSlug,
     fighterStartingXp,
     fighterXp,
     advancementCount,
+    { excludeProspectPromotionTier },
   );
 
   const title = (
@@ -3501,6 +3579,7 @@ export function AdvancementsList({
           openAdvancements={openAdvancements}
           editionSlug={editionSlug}
           fighterSubtypes={fighterSubtypes}
+          fighterCatalogSubtypes={fighterCatalogSubtypes}
           advancements={advancements}
           skills={skills}
           onClose={() => setIsAdvancementModalOpen(false)}
@@ -3519,6 +3598,8 @@ export function AdvancementsList({
           fighterTypeId={fighterTypeId}
           fighterSpecialisationId={fighterSpecialisationId}
           onFighterDetailsUpdate={onFighterDetailsUpdate}
+          onProspectPromotion={(data) => standalonePromotionMutation.mutateAsync(data).then(() => undefined)}
+          prospectPromotionPending={standalonePromotionMutation.isPending}
         />
       )}
 

--- a/components/fighter/fighter-advancement-list.tsx
+++ b/components/fighter/fighter-advancement-list.tsx
@@ -9,7 +9,7 @@ import { TypeSpecificData } from '@/types/fighter-effect';
 import { createClient } from '@/utils/supabase/client';
 import { getSkillSetRank } from "@/utils/skillSetRank";
 import { characteristicRank } from "@/utils/characteristicRank";
-import { countAdvancementsTaken, openAdvancementsFor, N26_PROSPECT_PROMOTION_TIER_XP } from "@/utils/advancementRanks";
+import { countAdvancementsTaken, openAdvancementsFor } from "@/utils/advancementRanks";
 import { List } from "@/components/ui/list";
 import { UserPermissions } from '@/types/user-permissions';
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -40,13 +40,13 @@ import {
   type TableEntry,
   type N26AdvancementEntry
 } from '@/utils/dice';
-import { hasCumulativeXp, hasProspectSpecialisationPromotion } from '@/types/edition';
+import { hasCumulativeXp } from '@/types/edition';
 import { skillAccessDeniedMessage } from '@/utils/venatorSkillAccess';
 import {
   N26_CHAMPION_PROMOTION_SKILL_NAME,
   N26_PROSPECT_PROMOTION_CREDITS,
   getN26ProspectSpecialisation,
-  isN26ProspectByCatalog,
+  hasN26ProspectPromotionOccurred,
 } from '@/utils/keepTypePromotionN26';
 
 // AdvancementModal Interfaces
@@ -67,15 +67,6 @@ interface AdvancementModalProps {
   skills: Record<string, any>;
   onClose: () => void;
   onAdvancementAdded: (advancement: FighterEffectType) => void;
-  /**
-   * Runs an N26 Prospect promotion (existing standalone flow), returning once
-   * the mutation settles. Provided by the parent so this modal reuses the
-   * outer mutation's optimistic updates, id reconciliation, and rollback
-   * instead of forking a second copy.
-   */
-  onProspectPromotion?: (data: FighterPromotionResult) => Promise<void>;
-  /** True while the parent's standalone promotion mutation is in flight. */
-  prospectPromotionPending?: boolean;
   onSkillUpdate?: (updatedSkills: Record<string, any>) => void;
   onXpCreditsUpdate?: (xpChange: number, creditsChange: number) => void;
   onAdvancementUpdate: (updatedAdvancements: FighterEffectType[]) => void;
@@ -527,8 +518,6 @@ export function AdvancementModal({
   fighterTypeId = '',
   fighterSpecialisationId = '',
   onFighterDetailsUpdate,
-  onProspectPromotion,
-  prospectPromotionPending = false,
 }: AdvancementModalProps) {
   
   const [skillSetCategories, setSkillSetCategories] = useState<SkillType[]>([]);
@@ -620,7 +609,6 @@ export function AdvancementModal({
   const [championPreviewSkillAccess, setChampionPreviewSkillAccess] = useState<SkillAccess[]>([]);
   const [championPreviewSkillAccessLoading, setChampionPreviewSkillAccessLoading] = useState(false);
   const [championPurchaseBusy, setChampionPurchaseBusy] = useState(false);
-  const [prospectPromotionOpen, setProspectPromotionOpen] = useState(false);
   // isSubmitting unused; removed
   const [skillAccess, setSkillAccess] = useState<SkillAccess[]>([]);
   const [skillAccessLoading, setSkillAccessLoading] = useState(false);
@@ -2200,11 +2188,6 @@ export function AdvancementModal({
   const isGangerOrExoticBeastRestricted =
     fighterSubtypes.includes('Ganger') || fighterSubtypes.includes('Exotic Beast');
 
-  const isN26ProspectPromotionRequired =
-    hasProspectSpecialisationPromotion(editionSlug) &&
-    fighterSubtypes.includes('Prospect') &&
-    currentXp >= N26_PROSPECT_PROMOTION_TIER_XP;
-
   const handleAdvancementPurchase = async () => {
     if (gangerModalRollBuy) {
       setGangerPurchaseBusy(true);
@@ -2352,45 +2335,6 @@ export function AdvancementModal({
         </div>
 
         <div className="p-2 overflow-y-auto grow">
-        {isN26ProspectPromotionRequired ? (
-          <div className="space-y-4">
-            <p className="text-sm">
-              This Prospect has reached <strong>{N26_PROSPECT_PROMOTION_TIER_XP} XP</strong> and must be
-              promoted to <strong>Ganger + Specialist</strong> before earning any further Advancements.
-              Rating increases by <strong>{N26_PROSPECT_PROMOTION_CREDITS}</strong>, and the fighter
-              gains the skill associated with the specialisation you pick.
-            </p>
-            <div className="flex justify-center">
-              <Button
-                type="button"
-                variant="default"
-                className="w-full sm:w-auto"
-                onClick={() => setProspectPromotionOpen(true)}
-                disabled={!userPermissions?.canEdit || prospectPromotionPending}
-              >
-                Promote to Ganger + Specialist
-              </Button>
-            </div>
-            <FighterPromotionModal
-              currentSubtype={fighterSubtypes[0] || ''}
-              currentSubtypes={fighterSubtypes}
-              currentSpecialRules={fighterSpecialRules}
-              currentFighterType={fighterTypeName}
-              currentFighterTypeId={fighterTypeId}
-              currentFighterSpecialisationId={fighterSpecialisationId || undefined}
-              fighterTypes={preFetchedFighterTypes}
-              editionSlug={editionSlug}
-              isOpen={prospectPromotionOpen}
-              onClose={() => setProspectPromotionOpen(false)}
-              onPromoted={(data) => {
-                setProspectPromotionOpen(false);
-                if (!onProspectPromotion) return;
-                onProspectPromotion(data).then(onClose, () => undefined);
-              }}
-            />
-          </div>
-        ) : (
-          <>
           <div className="mb-4">
             <p className="text-sm text-muted-foreground mb-2">
               {isCumulativeXp
@@ -3016,8 +2960,6 @@ export function AdvancementModal({
               </Button>
             </div>
           </div>
-          </>
-        )}
         </div>
       </div>
     </div>
@@ -3456,14 +3398,18 @@ export function AdvancementsList({
   // Taken count: characteristic effects plus is_advance skills (shared with gang cards).
   const advancementCount = countAdvancementsTaken({ advancements }, skills);
 
-  const excludeProspectPromotionTier = isN26ProspectByCatalog(editionSlug, fighterCatalogSubtypes);
+  const prospectPromotionConsumed = hasN26ProspectPromotionOccurred(
+    editionSlug,
+    fighterCatalogSubtypes,
+    fighterSubtypes,
+  );
 
   const openAdvancements = openAdvancementsFor(
     editionSlug,
     fighterStartingXp,
     fighterXp,
     advancementCount,
-    { excludeProspectPromotionTier },
+    { prospectPromotionConsumed },
   );
 
   const title = (
@@ -3598,8 +3544,6 @@ export function AdvancementsList({
           fighterTypeId={fighterTypeId}
           fighterSpecialisationId={fighterSpecialisationId}
           onFighterDetailsUpdate={onFighterDetailsUpdate}
-          onProspectPromotion={(data) => standalonePromotionMutation.mutateAsync(data).then(() => undefined)}
-          prospectPromotionPending={standalonePromotionMutation.isPending}
         />
       )}
 

--- a/components/fighter/fighter-advancement-list.tsx
+++ b/components/fighter/fighter-advancement-list.tsx
@@ -56,13 +56,6 @@ interface AdvancementModalProps {
   openAdvancements: number;
   editionSlug?: string | null;
   fighterSubtypes: string[];
-  /**
-   * Catalog subtypes on the fighter's fighter_type row. Distinct from live
-   * `fighterSubtypes` because N26 keep-type promotion leaves the catalog on
-   * Prospect while live subtypes flip to Ganger+Specialist — needed for the
-   * count exclusion to hold across pre- and post-promotion.
-   */
-  fighterCatalogSubtypes?: string[];
   advancements: Array<FighterEffectType>;
   skills: Record<string, any>;
   onClose: () => void;
@@ -499,7 +492,6 @@ export function AdvancementModal({
   openAdvancements,
   editionSlug = null,
   fighterSubtypes,
-  fighterCatalogSubtypes = [],
   advancements,
   skills,
   onClose,
@@ -3525,7 +3517,6 @@ export function AdvancementsList({
           openAdvancements={openAdvancements}
           editionSlug={editionSlug}
           fighterSubtypes={fighterSubtypes}
-          fighterCatalogSubtypes={fighterCatalogSubtypes}
           advancements={advancements}
           skills={skills}
           onClose={() => setIsAdvancementModalOpen(false)}

--- a/components/fighter/fighter-page.tsx
+++ b/components/fighter/fighter-page.tsx
@@ -33,7 +33,7 @@ import { applyWeaponModifiers } from '@/utils/effect-modifiers';
 import { sortFightersByPositioning } from '@/utils/fighter-positioning';
 import { hasCumulativeXp } from '@/types/edition';
 import { nextTierStartFor, openAdvancementsFor } from '@/utils/advancementRanks';
-import { isN26ProspectByCatalog } from '@/utils/keepTypePromotionN26';
+import { hasN26ProspectPromotionOccurred } from '@/utils/keepTypePromotionN26';
 
 interface FighterPageProps {
   initialFighterData: any;
@@ -41,6 +41,7 @@ interface FighterPageProps {
     id: string;
     fighter_name: string;
     fighter_type: string;
+    fighter_subtypes?: string[];
     fighter_type_subtypes?: string[];
     xp: number | null;
     starting_xp?: number | null;
@@ -169,6 +170,7 @@ interface FighterPageState {
     id: string;
     fighter_name: string;
     fighter_type: string;
+    fighter_subtypes?: string[];
     fighter_type_subtypes?: string[];
     xp: number | null;
     starting_xp?: number | null;
@@ -649,9 +651,10 @@ export default function FighterPage({
             currentXp,
             f.advancements_taken ?? 0,
             {
-              excludeProspectPromotionTier: isN26ProspectByCatalog(
+              prospectPromotionConsumed: hasN26ProspectPromotionOccurred(
                 editionSlug,
                 f.fighter_type_subtypes,
+                f.fighter_subtypes,
               ),
             },
           )

--- a/components/fighter/fighter-page.tsx
+++ b/components/fighter/fighter-page.tsx
@@ -33,6 +33,7 @@ import { applyWeaponModifiers } from '@/utils/effect-modifiers';
 import { sortFightersByPositioning } from '@/utils/fighter-positioning';
 import { hasCumulativeXp } from '@/types/edition';
 import { nextTierStartFor, openAdvancementsFor } from '@/utils/advancementRanks';
+import { isN26ProspectByCatalog } from '@/utils/keepTypePromotionN26';
 
 interface FighterPageProps {
   initialFighterData: any;
@@ -40,6 +41,7 @@ interface FighterPageProps {
     id: string;
     fighter_name: string;
     fighter_type: string;
+    fighter_type_subtypes?: string[];
     xp: number | null;
     starting_xp?: number | null;
     advancements_taken?: number;
@@ -167,6 +169,7 @@ interface FighterPageState {
     id: string;
     fighter_name: string;
     fighter_type: string;
+    fighter_type_subtypes?: string[];
     xp: number | null;
     starting_xp?: number | null;
     advancements_taken?: number;
@@ -645,6 +648,12 @@ export default function FighterPage({
             f.starting_xp ?? null,
             currentXp,
             f.advancements_taken ?? 0,
+            {
+              excludeProspectPromotionTier: isN26ProspectByCatalog(
+                editionSlug,
+                f.fighter_type_subtypes,
+              ),
+            },
           )
         : 0;
       const showAdvancementIcon = isCumulativeXp && openAdvancements > 0;
@@ -943,6 +952,7 @@ export default function FighterPage({
             fighterId={fighterData.fighter?.id || ''}
             editionSlug={fighterData.gang?.edition_slug ?? fighterData.fighter?.edition_slug ?? null}
             fighterSubtypes={fighterData.fighter?.fighter_subtypes || []}
+            fighterCatalogSubtypes={fighterData.fighter?.fighter_type?.fighter_subtypes || []}
             advancements={fighterData.fighter?.effects?.advancements || []}
             skills={fighterData.fighter?.skills || {}}
             userPermissions={userPermissions}

--- a/components/gang/fighter-card.tsx
+++ b/components/gang/fighter-card.tsx
@@ -7,7 +7,7 @@ import { FighterProps, FighterEffect, Vehicle, VehicleEquipment, FighterSkills }
 import { hasSaveCharacteristic } from '@/types/edition';
 import { calculateAdjustedStats, applySpecialRulesModifiers } from '@/utils/effect-modifiers';
 import { countAdvancementsTaken, openAdvancementsFor } from '@/utils/advancementRanks';
-import { isN26ProspectByCatalog } from '@/utils/keepTypePromotionN26';
+import { hasN26ProspectPromotionOccurred } from '@/utils/keepTypePromotionN26';
 import { injuryAggregationLabel } from '@/utils/injuryTarget';
 import { TbMeatOff } from "react-icons/tb";
 import { GiHandcuffs, GiImprisoned } from "react-icons/gi";
@@ -470,10 +470,14 @@ const FighterCard = memo(function FighterCard({
       xp,
       countAdvancementsTaken(effects, skills),
       {
-        excludeProspectPromotionTier: isN26ProspectByCatalog(edition_slug, fighter_type_subtypes),
+        prospectPromotionConsumed: hasN26ProspectPromotionOccurred(
+          edition_slug,
+          fighter_type_subtypes,
+          fighter_subtypes,
+        ),
       },
     ),
-    [edition_slug, starting_xp, xp, effects, skills, fighter_type_subtypes]
+    [edition_slug, starting_xp, xp, effects, skills, fighter_type_subtypes, fighter_subtypes]
   );
 
   // Determine a unique and valid id for the fighter card based on its status.

--- a/components/gang/fighter-card.tsx
+++ b/components/gang/fighter-card.tsx
@@ -7,6 +7,7 @@ import { FighterProps, FighterEffect, Vehicle, VehicleEquipment, FighterSkills }
 import { hasSaveCharacteristic } from '@/types/edition';
 import { calculateAdjustedStats, applySpecialRulesModifiers } from '@/utils/effect-modifiers';
 import { countAdvancementsTaken, openAdvancementsFor } from '@/utils/advancementRanks';
+import { isN26ProspectByCatalog } from '@/utils/keepTypePromotionN26';
 import { injuryAggregationLabel } from '@/utils/injuryTarget';
 import { TbMeatOff } from "react-icons/tb";
 import { GiHandcuffs, GiImprisoned } from "react-icons/gi";
@@ -136,6 +137,7 @@ const FighterCard = memo(function FighterCard({
   type,
   label,
   fighter_subtypes,
+  fighter_type_subtypes,
   fighter_specialisation,
   fighter_variant,
   alliance_crew_name,
@@ -466,9 +468,12 @@ const FighterCard = memo(function FighterCard({
       edition_slug,
       starting_xp,
       xp,
-      countAdvancementsTaken(effects, skills)
+      countAdvancementsTaken(effects, skills),
+      {
+        excludeProspectPromotionTier: isN26ProspectByCatalog(edition_slug, fighter_type_subtypes),
+      },
     ),
-    [edition_slug, starting_xp, xp, effects, skills]
+    [edition_slug, starting_xp, xp, effects, skills, fighter_type_subtypes]
   );
 
   // Determine a unique and valid id for the fighter card based on its status.

--- a/types/fighter.ts
+++ b/types/fighter.ts
@@ -183,6 +183,12 @@ export interface FighterProps {
   captured_by_gang_name?: string;
   free_skill?: boolean;
   fighter_subtypes: string[];
+  /**
+   * Catalog subtypes on the fighter's fighter_type row. Kept-type promotion
+   * (Prospect→Ganger/Specialist) leaves this on the origin type, so it is the
+   * stable signal for "was originally a Prospect".
+   */
+  fighter_type_subtypes?: string[];
   note?: string;
   effects: {
     injuries: FighterEffect[];

--- a/utils/advancementRanks.ts
+++ b/utils/advancementRanks.ts
@@ -110,22 +110,14 @@ export function currentXpLadderRankFor(
 const tiersAtOrBelow = (tiers: readonly number[], xp: number): number =>
   tiers.filter((tierStart) => tierStart <= xp).length;
 
-/**
- * Rank 4 (13 XP) is the mandatory Prospect→Ganger/Specialist promotion in N26,
- * not a normal Advancement. Sourced from the ladder rather than a literal so
- * a ladder rebalance stays in one place.
- */
-export const N26_PROSPECT_PROMOTION_TIER_XP =
-  n26XpLadder.find((row) => row.rank === 4)!.xpMin;
-
 export type AdvancementCountOptions = {
   /**
-   * When true, drop the 13-XP tier from the count. The Prospect→Ganger promotion
-   * consumes that tier by rule, so a fighter whose catalog type is a Prospect
-   * (pre- or post-promotion, since keep-type leaves the catalog on Prospect)
-   * would otherwise be credited one advancement they never earn.
+   * True when the N26 Prospect→Ganger promotion has been applied to this
+   * fighter. The 13-XP tier remains a normal Advancement (a CGC Initiate can
+   * spend it on a stat/skill instead), but using the promotion trades that
+   * Advancement in — so once it has been used, the open count drops by one.
    */
-  excludeProspectPromotionTier?: boolean;
+  prospectPromotionConsumed?: boolean;
 };
 
 /**
@@ -146,12 +138,8 @@ export function advancementsEarnedFor(
   editionSlug: string | null | undefined,
   startingXp: number | null,
   currentXp: number,
-  options?: AdvancementCountOptions,
 ): number {
-  const allTiers = tierStartsFor(editionSlug);
-  const tiers = options?.excludeProspectPromotionTier
-    ? allTiers.filter((tierStart) => tierStart !== N26_PROSPECT_PROMOTION_TIER_XP)
-    : allTiers;
+  const tiers = tierStartsFor(editionSlug);
 
   // XP below the recruitment value is only reachable by editing a fighter after
   // the fact; it means no Advancement, never a negative one.
@@ -200,8 +188,9 @@ export function openAdvancementsFor(
   advancementsTaken: number,
   options?: AdvancementCountOptions,
 ): number {
+  const promotionCost = options?.prospectPromotionConsumed ? 1 : 0;
   return Math.max(
     0,
-    advancementsEarnedFor(editionSlug, startingXp, currentXp, options) - advancementsTaken,
+    advancementsEarnedFor(editionSlug, startingXp, currentXp) - advancementsTaken - promotionCost,
   );
 }

--- a/utils/advancementRanks.ts
+++ b/utils/advancementRanks.ts
@@ -111,6 +111,24 @@ const tiersAtOrBelow = (tiers: readonly number[], xp: number): number =>
   tiers.filter((tierStart) => tierStart <= xp).length;
 
 /**
+ * Rank 4 (13 XP) is the mandatory Prospect→Ganger/Specialist promotion in N26,
+ * not a normal Advancement. Sourced from the ladder rather than a literal so
+ * a ladder rebalance stays in one place.
+ */
+export const N26_PROSPECT_PROMOTION_TIER_XP =
+  n26XpLadder.find((row) => row.rank === 4)!.xpMin;
+
+export type AdvancementCountOptions = {
+  /**
+   * When true, drop the 13-XP tier from the count. The Prospect→Ganger promotion
+   * consumes that tier by rule, so a fighter whose catalog type is a Prospect
+   * (pre- or post-promotion, since keep-type leaves the catalog on Prospect)
+   * would otherwise be credited one advancement they never earn.
+   */
+  excludeProspectPromotionTier?: boolean;
+};
+
+/**
  * How many Advancements a model has earned in total.
  *
  * N26 never spends XP, so `currentXp` is starting XP plus everything ever
@@ -128,8 +146,12 @@ export function advancementsEarnedFor(
   editionSlug: string | null | undefined,
   startingXp: number | null,
   currentXp: number,
+  options?: AdvancementCountOptions,
 ): number {
-  const tiers = tierStartsFor(editionSlug);
+  const allTiers = tierStartsFor(editionSlug);
+  const tiers = options?.excludeProspectPromotionTier
+    ? allTiers.filter((tierStart) => tierStart !== N26_PROSPECT_PROMOTION_TIER_XP)
+    : allTiers;
 
   // XP below the recruitment value is only reachable by editing a fighter after
   // the fact; it means no Advancement, never a negative one.
@@ -176,6 +198,10 @@ export function openAdvancementsFor(
   startingXp: number | null,
   currentXp: number,
   advancementsTaken: number,
+  options?: AdvancementCountOptions,
 ): number {
-  return Math.max(0, advancementsEarnedFor(editionSlug, startingXp, currentXp) - advancementsTaken);
+  return Math.max(
+    0,
+    advancementsEarnedFor(editionSlug, startingXp, currentXp, options) - advancementsTaken,
+  );
 }

--- a/utils/keepTypePromotionN26.ts
+++ b/utils/keepTypePromotionN26.ts
@@ -45,18 +45,24 @@ export function shouldClearSpecialisationForSubtypes(
 }
 
 /**
- * True when the fighter's catalog fighter_type is a Prospect on an edition that
- * uses Prospect keep-type promotion. Catalog rather than live subtypes because
- * the promotion keeps the type row (Ganger+Specialist land on the fighter, not
- * the type), so this stays true after promotion and correctly identifies both
- * pre- and post-promotion Prospects.
+ * True when the fighter went through the N26 Prospect keep-type promotion —
+ * catalog fighter_type is still Prospect (keep-type preserves the catalog) but
+ * live subtypes no longer include Prospect (they now include Ganger+Specialist).
+ *
+ * RAW, the 13-XP Advancement roll is what a Prospect trades in to become a
+ * Ganger+Specialist; the roll itself remains a normal Advancement (a CGC
+ * Initiate can spend it on a stat or skill instead). This helper is the signal
+ * to deduct one from the fighter's available Advancements once the trade has
+ * been made.
  */
-export function isN26ProspectByCatalog(
+export function hasN26ProspectPromotionOccurred(
   editionSlug?: string | null,
-  catalogSubtypes?: string[] | null
+  catalogSubtypes?: string[] | null,
+  currentSubtypes?: string[] | null
 ): boolean {
   return hasProspectSpecialisationPromotion(editionSlug)
-    && (catalogSubtypes ?? []).includes('Prospect');
+    && (catalogSubtypes ?? []).includes('Prospect')
+    && !(currentSubtypes ?? []).includes('Prospect');
 }
 
 /** Catalog ids for the eight houseless specialisations offered on Prospect promotion. */

--- a/utils/keepTypePromotionN26.ts
+++ b/utils/keepTypePromotionN26.ts
@@ -12,7 +12,7 @@
  * (fighter_specialisations / fighter_defaults) if these ever drift.
  */
 
-import { hasFighterSpecialisations } from '@/types/edition';
+import { hasFighterSpecialisations, hasProspectSpecialisationPromotion } from '@/types/edition';
 
 export const N26_PROSPECT_PROMOTION_CREDITS = 15;
 
@@ -42,6 +42,21 @@ export function shouldClearSpecialisationForSubtypes(
   subtypes?: string[] | null
 ): boolean {
   return hasFighterSpecialisations(editionSlug) && !hasN26SpecialistSubtype(subtypes);
+}
+
+/**
+ * True when the fighter's catalog fighter_type is a Prospect on an edition that
+ * uses Prospect keep-type promotion. Catalog rather than live subtypes because
+ * the promotion keeps the type row (Ganger+Specialist land on the fighter, not
+ * the type), so this stays true after promotion and correctly identifies both
+ * pre- and post-promotion Prospects.
+ */
+export function isN26ProspectByCatalog(
+  editionSlug?: string | null,
+  catalogSubtypes?: string[] | null
+): boolean {
+  return hasProspectSpecialisationPromotion(editionSlug)
+    && (catalogSubtypes ?? []).includes('Prospect');
 }
 
 /** Catalog ids for the eight houseless specialisations offered on Prospect promotion. */


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? -->
The advancement count was over-counting by 1 for Prospects. 

The 13-XP tier is the (RAW: mandatory) Prospect to Ganger(+Specialist) promotion, not a normal advancement, but we want to make sure that users can add and advancement, or promote, if they choose to promote, it should consume an advancement.

**From ticket 1264:** A Prospect at 77 XP was showing 11 available advancements when they should only have 10.
## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Schema / migration

## How I tested

<!-- What you tested before opening this PR. Example: Opened gang X → bought equipment → credits/rating updated -->

- [x] tested locally


https://github.com/user-attachments/assets/9af42348-cfec-4040-8411-7bd7c4621907

**Confirm Gangers are unaffected**

https://github.com/user-attachments/assets/78bcce76-9f71-405c-a333-f9e4af03211d




## Risk / rollout

<!-- e.g. Low / Medium — any deploy notes beyond database (env vars, feature flags, etc.). -->

- Low


