### PR TITLE
Feat/n26 chem alchemy equipment categories

### DIFF
--- a/app/actions/chem-alchemy.ts
+++ b/app/actions/chem-alchemy.ts
@@ -57,7 +57,7 @@ export async function createChemAlchemy({
 
     const gangEdition = gangEditionJoin(gangData);
     if (!hasChemAlchemy(gangEdition?.slug)) {
-      throw new Error('Chem-Alchemy is not available for this gang edition');
+      throw new Error('Chem-alchemy is not available for this gang edition');
     }
 
     if (gangData.credits < totalCost) {

--- a/app/user-guide/page.tsx
+++ b/app/user-guide/page.tsx
@@ -8,7 +8,7 @@ const defaultUrl = process.env.NODE_ENV === 'development'
 
 // SEO constants - edit these to update all metadata
 const PAGE_TITLE = 'User Guide - How to Use Munda Manager';
-const PAGE_DESCRIPTION = 'Complete user guide for Munda Manager. Learn how to create gangs, manage fighters, run campaigns, use custom assets, and explore advanced features like Chem-Alchemy and Gene-Smithing for Necromunda.';
+const PAGE_DESCRIPTION = 'Complete user guide for Munda Manager. Learn how to create gangs, manage fighters, run campaigns, use custom assets, and explore advanced features like Chem-alchemy and Gene-Smithing for Necromunda.';
 const PAGE_DESCRIPTION_SHORT = 'Complete user guide for Munda Manager. Learn how to create gangs, manage fighters, run campaigns, and explore advanced features.';
 const PAGE_KEYWORDS = 'Munda Manager user guide, Necromunda guide, gang management tutorial, campaign management guide, how to use Munda Manager, Necromunda gang builder guide';
 

--- a/components/gang/stash-tab.tsx
+++ b/components/gang/stash-tab.tsx
@@ -827,7 +827,7 @@ export default function GangInventory({
                   size="sm"
                   className="font-medium"
                 >
-                  Chem-Alchemy
+                  Chem-alchemy
                 </Button>
               )}
               <Button

--- a/components/munda-manager-info/what-is-munda-manager.tsx
+++ b/components/munda-manager-info/what-is-munda-manager.tsx
@@ -40,7 +40,7 @@ export default function WhatIsMundaManager({ userCount, gangCount, campaignCount
     {
       icon: <FaCogs className="h-6 w-6" />,
       title: "Advanced Gang Mechanics",
-      description: "Use Chem-Alchemy, Gene-smithing, Archaeo-Cyberteknika for your gangs, or bring your gang to the Ash Wastes with our vehicle support."
+      description: "Use Chem-alchemy, Gene-smithing, Archaeo-Cyberteknika for your gangs, or bring your gang to the Ash Wastes with our vehicle support."
     }
   ];
 
@@ -99,7 +99,7 @@ export default function WhatIsMundaManager({ userCount, gangCount, campaignCount
           <div className="flex items-start space-x-3">
             <div className="w-2 h-2 bg-red-800 rounded-full mt-2 shrink-0"></div>
             <p className="text-muted-foreground">
-              <strong>Advanced Features:</strong> Vehicle rules, custom equipment creation, gang mechanics like Chem-Alchemy and Gene-smithing, plus comprehensive campaign management with battle logs and territory tracking.
+              <strong>Advanced Features:</strong> Vehicle rules, custom equipment creation, gang mechanics like Chem-alchemy and Gene-smithing, plus comprehensive campaign management with battle logs and territory tracking.
             </p>
           </div>
           <div className="flex items-start space-x-3">

--- a/components/user-guide/user-guide-n23.tsx
+++ b/components/user-guide/user-guide-n23.tsx
@@ -17,7 +17,7 @@ export function UserGuideN23() {
               <li><a href="#gang-card-presentation" className="underline hover:text-red-800">Gang Card Presentation</a></li>
               <li><a href="#reorder-fighter-cards" className="underline hover:text-red-800">Reorder Fighter Cards</a></li>
               <li><a href="#gang-notes" className="underline hover:text-red-800">Gang Notes</a></li>
-              <li><a href="#house-escher-chem-alchemy" className="underline hover:text-red-800">House Escher: Chem-Alchemy</a></li>
+              <li><a href="#house-escher-chem-alchemy" className="underline hover:text-red-800">House Escher: Chem-alchemy</a></li>
               <li><a href="#house-goliath-gene-smithing" className="underline hover:text-red-800">House Goliath: Gene-Smithing</a></li>
               <li><a href="#house-van-saar-archaeo-cyberteknika" className="underline hover:text-red-800">House Van Saar: Archaeo-Cyberteknika</a></li>
               <li><a href="#spyre-hunting-party-spyrer-equipment-augmentations" className="underline hover:text-red-800">Spyre Hunting Party: Spyrer Equipment Augmentations</a></li>
@@ -151,16 +151,16 @@ export function UserGuideN23() {
 
           <h3 id="house-escher-chem-alchemy" className="text-lg font-semibold text-foreground mt-6 mb-1 scroll-mt-24">
             <a href="#house-escher-chem-alchemy" className="inline-flex items-center hover:text-red-800 transition-colors after:content-['#'] after:ml-2 after:text-sm after:text-muted-foreground after:opacity-0 hover:after:opacity-100 focus-visible:after:opacity-100 after:transition-opacity">
-              House Escher: Chem-Alchemy
+              House Escher: Chem-alchemy
             </a>
           </h3>
             <p className="text-muted-foreground mb-2">
-              For Escher gangs, Munda Manager supports Chem-Alchemy. You can create custom chems in the Stash and click on the Chem-Alchemy button.
+              For Escher gangs, Munda Manager supports Chem-alchemy. You can create custom chems in the Stash and click on the Chem-alchemy button.
             </p>
             <div className="my-4 flex justify-center">
               <img
                 src="https://iojoritxhpijprgkjfre.supabase.co/storage/v1/object/public/site-images/user-guide/chem-alchemy.webp"
-                alt="House Escher Chem-Alchemy feature in Munda Manager showing custom chem creation and management interface"
+                alt="House Escher Chem-alchemy feature in Munda Manager showing custom chem creation and management interface"
                 className="rounded-lg"
                 style={{ maxWidth: '100%', height: 'auto' }}
               />

--- a/utils/equipmentCategoryRankN26.ts
+++ b/utils/equipmentCategoryRankN26.ts
@@ -13,6 +13,7 @@ export interface EquipmentCategoryN26Entry {
 }
 
 export const equipmentCategoriesN26: EquipmentCategoryN26Entry[] = [
+  /** Close Combat Weapons */
   { category_name: "Aranthian Weapons (Close Combat Weapons)", super_category_name: "Close Combat Weapons" },
   { category_name: "Augmetic Weapons (Close Combat Weapons)", super_category_name: "Close Combat Weapons" },
   { category_name: "Cawdor Polearms", super_category_name: "Close Combat Weapons" },
@@ -37,6 +38,8 @@ export const equipmentCategoriesN26: EquipmentCategoryN26Entry[] = [
   { category_name: "Toxin Weapons (Close Combat Weapons)", super_category_name: "Close Combat Weapons" },
   { category_name: "Vehicle Weapons", super_category_name: "Close Combat Weapons" },
   { category_name: "Web Weapons (Close Combat Weapons)", super_category_name: "Close Combat Weapons" },
+
+  /** Ranged Weapons */
   { category_name: "Ammunition", super_category_name: "Ranged Weapons" },
   { category_name: "Aranthian Weapons (Ranged Weapons)", super_category_name: "Ranged Weapons" },
   { category_name: "Augmetic Weapons (Ranged Weapons)", super_category_name: "Ranged Weapons" },
@@ -72,6 +75,8 @@ export const equipmentCategoriesN26: EquipmentCategoryN26Entry[] = [
   { category_name: "Orrus Close Combat Weapons", super_category_name: "Spyrer Weapons" },
   { category_name: "Orrus Ranged Weapons", super_category_name: "Spyrer Weapons" },
   { category_name: "Yeld Weapons", super_category_name: "Spyrer Weapons" },
+
+  /** Wargear */
   { category_name: "Armour & Field Armour", super_category_name: "Wargear" },
   { category_name: "Gang Equipment", super_category_name: "Wargear" },
   { category_name: "Mounts", super_category_name: "Wargear" },
@@ -79,6 +84,11 @@ export const equipmentCategoriesN26: EquipmentCategoryN26Entry[] = [
   { category_name: "Pets", super_category_name: "Wargear" },
   { category_name: "Ridgehauler Upgrades", super_category_name: "Wargear" },
   { category_name: "Weapon Accessories", super_category_name: "Wargear" },
+
+  /** Chem-alchemy */
+  { category_name: "Gaseous Ammo (Chem-alchemy)", super_category_name: "Chem-alchemy" },
+  { category_name: "Poisons (Chem-alchemy)", super_category_name: "Chem-alchemy" },
+  { category_name: "Stimms (Chem-alchemy)", super_category_name: "Chem-alchemy" },
 ];
 
 /** Category sort order keyed by lowercased category_name. */
@@ -108,13 +118,14 @@ export const equipmentCategoryToSuperCategoryN26: { [key: string]: string } = Ob
 );
 
 /**
- * Display-only: strip parenthetical weapon-type suffixes from N26 category names.
+ * Display-only: strip parenthetical super-category suffixes from N26 category names.
  * Does not change the underlying database category_name values.
  */
 export function getEquipmentCategoryDisplayNameN26(categoryName: string): string {
   return categoryName
     .replace(/ \(Close Combat Weapons\)$/, '')
-    .replace(/ \(Ranged Weapons\)$/, '');
+    .replace(/ \(Ranged Weapons\)$/, '')
+    .replace(/ \(Chem-alchemy\)$/, '');
 }
 
 export function getEquipmentSuperCategoryN26(categoryName: string): string | undefined {

--- a/utils/equipmentCategoryRankN26.ts
+++ b/utils/equipmentCategoryRankN26.ts
@@ -123,9 +123,9 @@ export const equipmentCategoryToSuperCategoryN26: { [key: string]: string } = Ob
  */
 export function getEquipmentCategoryDisplayNameN26(categoryName: string): string {
   return categoryName
+    .replace(/ \(Chem-alchemy\)$/, '')
     .replace(/ \(Close Combat Weapons\)$/, '')
-    .replace(/ \(Ranged Weapons\)$/, '')
-    .replace(/ \(Chem-alchemy\)$/, '');
+    .replace(/ \(Ranged Weapons\)$/, '');
 }
 
 export function getEquipmentSuperCategoryN26(categoryName: string): string | undefined {


### PR DESCRIPTION
Rank the N26 Chem-alchemy categories under their own super-category and strip the parenthetical suffix from display names. Align user-facing Chem-alchemy spelling.

## Summary
- Rank N26 Gaseous Ammo, Poisons, and Stimms under a Chem-alchemy super-category in the equipment modal
- Strip ``(Chem-alchemy)`` from category display names, matching the existing weapon-suffix behaviour
- Align user-facing Chem-alchemy spelling in the stash button, user guide, and related copy

## Test plan
- [x] On an N26 gang, open the trading post / equipment modal and confirm Chem-alchemy categories group under a Chem-alchemy header
- [x] Confirm those category labels show as Gaseous Ammo, Poisons, and Stimms (no parenthetical suffix)
- [x] Confirm N23 Chem-alchemy copy (stash button, user guide, landing page) uses Chem-alchemy

