### PR TITLE
Leader advancement deducation fix

### DIFF
--- a/app/lib/fighter-advancements.ts
+++ b/app/lib/fighter-advancements.ts
@@ -40,10 +40,7 @@ export const getGangFighters = async (gangId: string, supabase: any) => {
     id: f.id,
     fighter_name: f.fighter_name,
     fighter_type: f.fighter_type,
-    fighter_subtypes: Array.isArray(f.fighter_subtypes) ? f.fighter_subtypes : [],
-    fighter_type_subtypes: Array.isArray(f.fighter_types?.fighter_subtypes)
-      ? f.fighter_types.fighter_subtypes
-      : [],
+    fighter_specialisation_id: f.fighter_specialisation_id ?? null,
     xp: f.xp,
     starting_xp: f.starting_xp ?? null,
     advancements_taken: countAdvancementsTaken(

--- a/app/lib/shared/gang-assembly.ts
+++ b/app/lib/shared/gang-assembly.ts
@@ -677,9 +677,6 @@ export function assembleGangFighters(
           label: fighter.label,
           fighter_type: fighter.fighter_type || fighterTypeInfo.fighter_type || 'Unknown',
           fighter_subtypes: fighter.fighter_subtypes || [],
-          fighter_type_subtypes: Array.isArray(fighterTypeInfo.fighter_subtypes)
-            ? fighterTypeInfo.fighter_subtypes
-            : [],
           fighter_specialisation: fighterSpecialisationInfo ? {
             fighter_specialisation: fighterSpecialisationInfo.specialisation_name,
             fighter_specialisation_id: fighterSpecialisationInfo.id

--- a/app/lib/shared/gang-data.ts
+++ b/app/lib/shared/gang-data.ts
@@ -137,12 +137,6 @@ export interface GangFighter {
   label?: string;
   fighter_type: string;
   fighter_subtypes: string[];
-  /**
-   * Catalog subtypes on the fighter_type row. Kept-type promotion
-   * (Prospect→Ganger/Specialist) leaves this on the origin type while live
-   * `fighter_subtypes` flip; it is the stable signal for "was recruited as X".
-   */
-  fighter_type_subtypes?: string[];
   fighter_specialisation?: {
     fighter_specialisation: string;
     fighter_specialisation_id: string;

--- a/components/fighter/fighter-advancement-list.tsx
+++ b/components/fighter/fighter-advancement-list.tsx
@@ -189,13 +189,6 @@ interface AdvancementsListProps {
   fighterId: string;
   editionSlug?: string | null;
   fighterSubtypes: string[];
-  /**
-   * Catalog subtypes on the fighter's fighter_type row. Distinct from live
-   * `fighterSubtypes` because N26 keep-type promotion leaves the catalog on
-   * Prospect while live subtypes flip to Ganger+Specialist — needed for the
-   * count exclusion to hold across pre- and post-promotion.
-   */
-  fighterCatalogSubtypes?: string[];
   advancements: Array<FighterEffectType>;
   skills: FighterSkills;
   userPermissions: UserPermissions;
@@ -2901,7 +2894,6 @@ export function AdvancementsList({
   fighterId,
   editionSlug = null,
   fighterSubtypes,
-  fighterCatalogSubtypes = [],
   advancements = [],
   skills = {},
   userPermissions,
@@ -3327,8 +3319,7 @@ export function AdvancementsList({
 
   const prospectPromotionConsumed = hasN26ProspectPromotionOccurred(
     editionSlug,
-    fighterCatalogSubtypes,
-    fighterSubtypes,
+    fighterSpecialisationId,
   );
 
   const openAdvancements = openAdvancementsFor(

--- a/components/fighter/fighter-page.tsx
+++ b/components/fighter/fighter-page.tsx
@@ -41,8 +41,7 @@ interface FighterPageProps {
     id: string;
     fighter_name: string;
     fighter_type: string;
-    fighter_subtypes?: string[];
-    fighter_type_subtypes?: string[];
+    fighter_specialisation_id?: string | null;
     xp: number | null;
     starting_xp?: number | null;
     advancements_taken?: number;
@@ -170,8 +169,7 @@ interface FighterPageState {
     id: string;
     fighter_name: string;
     fighter_type: string;
-    fighter_subtypes?: string[];
-    fighter_type_subtypes?: string[];
+    fighter_specialisation_id?: string | null;
     xp: number | null;
     starting_xp?: number | null;
     advancements_taken?: number;
@@ -653,8 +651,7 @@ export default function FighterPage({
             {
               prospectPromotionConsumed: hasN26ProspectPromotionOccurred(
                 editionSlug,
-                f.fighter_type_subtypes,
-                f.fighter_subtypes,
+                f.fighter_specialisation_id,
               ),
             },
           )
@@ -955,7 +952,6 @@ export default function FighterPage({
             fighterId={fighterData.fighter?.id || ''}
             editionSlug={fighterData.gang?.edition_slug ?? fighterData.fighter?.edition_slug ?? null}
             fighterSubtypes={fighterData.fighter?.fighter_subtypes || []}
-            fighterCatalogSubtypes={fighterData.fighter?.fighter_type?.fighter_subtypes || []}
             advancements={fighterData.fighter?.effects?.advancements || []}
             skills={fighterData.fighter?.skills || {}}
             userPermissions={userPermissions}

--- a/components/gang/fighter-card.tsx
+++ b/components/gang/fighter-card.tsx
@@ -137,7 +137,6 @@ const FighterCard = memo(function FighterCard({
   type,
   label,
   fighter_subtypes,
-  fighter_type_subtypes,
   fighter_specialisation,
   fighter_variant,
   alliance_crew_name,
@@ -472,12 +471,11 @@ const FighterCard = memo(function FighterCard({
       {
         prospectPromotionConsumed: hasN26ProspectPromotionOccurred(
           edition_slug,
-          fighter_type_subtypes,
-          fighter_subtypes,
+          fighter_specialisation?.fighter_specialisation_id,
         ),
       },
     ),
-    [edition_slug, starting_xp, xp, effects, skills, fighter_type_subtypes, fighter_subtypes]
+    [edition_slug, starting_xp, xp, effects, skills, fighter_specialisation?.fighter_specialisation_id]
   );
 
   // Determine a unique and valid id for the fighter card based on its status.

--- a/types/fighter.ts
+++ b/types/fighter.ts
@@ -183,12 +183,6 @@ export interface FighterProps {
   captured_by_gang_name?: string;
   free_skill?: boolean;
   fighter_subtypes: string[];
-  /**
-   * Catalog subtypes on the fighter's fighter_type row. Kept-type promotion
-   * (Prospect→Ganger/Specialist) leaves this on the origin type, so it is the
-   * stable signal for "was originally a Prospect".
-   */
-  fighter_type_subtypes?: string[];
   note?: string;
   effects: {
     injuries: FighterEffect[];

--- a/utils/keepTypePromotionN26.ts
+++ b/utils/keepTypePromotionN26.ts
@@ -45,9 +45,14 @@ export function shouldClearSpecialisationForSubtypes(
 }
 
 /**
- * True when the fighter went through the N26 Prospect keep-type promotion —
- * catalog fighter_type is still Prospect (keep-type preserves the catalog) but
- * live subtypes no longer include Prospect (they now include Ganger+Specialist).
+ * True when the fighter went through the N26 Prospect promotion — signalled by
+ * one of the eight Prospect specialisation ids being set on
+ * fighters.fighter_specialisation_id. Those ids are only ever written by the
+ * Prospect promotion action, are preserved across every downstream promotion
+ * (keep-type Ganger→Champion, type-change Champion→Leader — the Leader recipe
+ * keeps the Specialist subtype so the specialisation stays too), and are
+ * cleared by the promotion-undo flow. Catalog subtypes are not a reliable
+ * signal because Champion→Leader rewrites fighter_type_id.
  *
  * RAW, the 13-XP Advancement roll is what a Prospect trades in to become a
  * Ganger+Specialist; the roll itself remains a normal Advancement (a CGC
@@ -57,12 +62,11 @@ export function shouldClearSpecialisationForSubtypes(
  */
 export function hasN26ProspectPromotionOccurred(
   editionSlug?: string | null,
-  catalogSubtypes?: string[] | null,
-  currentSubtypes?: string[] | null
+  fighterSpecialisationId?: string | null
 ): boolean {
-  return hasProspectSpecialisationPromotion(editionSlug)
-    && (catalogSubtypes ?? []).includes('Prospect')
-    && !(currentSubtypes ?? []).includes('Prospect');
+  if (!hasProspectSpecialisationPromotion(editionSlug)) return false;
+  if (!fighterSpecialisationId) return false;
+  return N26_PROSPECT_SPECIALISATIONS.some((s) => s.id === fighterSpecialisationId);
 }
 
 /** Catalog ids for the eight houseless specialisations offered on Prospect promotion. */


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? -->
Follow on from previous pr #2094 

**Tizdale reported:**
> Found an oddity on "fighter type change" 
> 
> Add a Prospect -> Add 40XP
> Promote to Ganger, Specialist -> 7 Advancements goes to 6.
> Promote to Champ, Advancements remain at 6. 
> Promote to Leader via Promote (Death of a Leader) 
> Type changes due to this, Promotions jump up to 7

this PR replaces `fighter_type.fighter_subtypes` with `fighters.fighter_specialisation_id` which is a much better signal for this work, as it persists all the way through to the Leader sub-type

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Schema / migration

## How I tested

<!-- What you tested before opening this PR. Example: Opened gang X → bought equipment → credits/rating updated -->

- [x] local dev env


https://github.com/user-attachments/assets/1ce00cdd-d137-4041-8df6-40e1b03fcb9d

**Prospect manual edit to Champion** 

https://github.com/user-attachments/assets/93d7c078-a769-4791-9ff3-1f400af635a8




## Risk / rollout
- Low
