### PR TITLE
Added support for tactics cards packs

### DIFF
--- a/app/actions/gang-tactics-cards.ts
+++ b/app/actions/gang-tactics-cards.ts
@@ -15,6 +15,7 @@ import {
   GANG_TACTICS_CARD_SELECT,
   normaliseTacticsDescription,
   TACTICS_DESCRIPTION_CHAR_LIMIT,
+  tacticsCardsPackFilter,
   toGangTacticsCard,
   type GangTacticsCard
 } from '@/types/tactics-card';
@@ -30,13 +31,17 @@ interface AddGangTacticsCardsResult extends GangTacticsResult {
 }
 
 interface GangTacticsContext {
-  editionId: string | null;
+  /** Every pack this gang may draw from, core included. */
+  availablePackIds: string[];
+  /** The pack the picker falls back to when none is chosen. */
+  corePackId: string | null;
 }
 
 /**
  * Authenticate, confirm the caller may edit this gang, and confirm the edition
  * has Gang Tactics. RLS enforces the first two again, but failing here returns
- * a usable message instead of a raw error.
+ * a usable message instead of a raw error. Resolves the gang's packs too, so
+ * neither caller has to repeat the scoping.
  */
 async function authoriseGangTactics(
   supabase: any,
@@ -49,7 +54,7 @@ async function authoriseGangTactics(
     .select(`
       id,
       user_id,
-      gang_types!gang_type_id ( editions:edition_id ( id, slug ) ),
+      gang_types!gang_type_id ( gang_type_id, parent_gang_type_id, editions:edition_id ( id, slug ) ),
       custom_gang_types!custom_gang_type_id ( editions:edition_id ( id, slug ) )
     `)
     .eq('id', gangId)
@@ -64,11 +69,27 @@ async function authoriseGangTactics(
     return { error: 'Access denied' };
   }
 
-  if (!hasGangTacticsCards(gangEditionSlug(gang))) {
+  const editionId = gangEditionJoin(gang)?.id;
+  if (!editionId || !hasGangTacticsCards(gangEditionSlug(gang))) {
     return { error: 'Gang Tactics are not available for this edition' };
   }
 
-  return { context: { editionId: gangEditionJoin(gang)?.id ?? null } };
+  const gangType = Array.isArray(gang.gang_types) ? gang.gang_types[0] : gang.gang_types;
+
+  const { data: packs, error: packsError } = await supabase
+    .from('tactics_cards_packs')
+    .select('id, gang_type_id')
+    .eq('edition_id', editionId)
+    .or(tacticsCardsPackFilter(gangType?.gang_type_id, gangType?.parent_gang_type_id));
+
+  if (packsError) throw packsError;
+
+  return {
+    context: {
+      availablePackIds: (packs ?? []).map((pack: any) => pack.id),
+      corePackId: (packs ?? []).find((pack: any) => pack.gang_type_id === null)?.id ?? null
+    }
+  };
 }
 
 export async function addGangTacticsCards(params: {
@@ -86,17 +107,14 @@ export async function addGangTacticsCards(params: {
       return { success: false, error: 'No tactics cards selected' };
     }
 
-    // The browser can post any uuid, so don't trust what the picker sent.
-    let catalogueQuery = supabase
+    // The browser can post any uuid, so don't trust what the picker sent. A pack
+    // belongs to one edition, so scoping to the gang's packs covers both checks.
+    const { data: catalogue, error: catalogueError } = await supabase
       .from('tactics_cards')
       .select('id')
-      .in('id', tacticsCardIds);
+      .in('id', tacticsCardIds)
+      .in('tactics_cards_pack_id', auth.context.availablePackIds);
 
-    if (auth.context.editionId) {
-      catalogueQuery = catalogueQuery.eq('edition_id', auth.context.editionId);
-    }
-
-    const { data: catalogue, error: catalogueError } = await catalogueQuery;
     if (catalogueError) throw catalogueError;
 
     if ((catalogue?.length ?? 0) !== tacticsCardIds.length) {
@@ -135,6 +153,8 @@ export async function verifyAndLogRolledTacticsCard(params: {
   gangId: string;
   total: number;
   dice: number[];
+  /** The deck the roller was on. Null rolls on the gang's core deck. */
+  tacticsCardsPackId?: string | null;
 }): Promise<GangLogActionResult> {
   try {
     const supabase = await createClient();
@@ -142,19 +162,23 @@ export async function verifyAndLogRolledTacticsCard(params: {
     const auth = await authoriseGangTactics(supabase, params.gangId);
     if ('error' in auth) return { success: false, error: auth.error };
 
-    // Resolved from the dice rather than a posted id, so a roll can't be
-    // credited to a card it didn't produce.
-    let query = supabase
-      .from('tactics_cards')
-      .select('name')
-      .lte('d66_min', params.total)
-      .gte('d66_max', params.total);
-
-    if (auth.context.editionId) {
-      query = query.eq('edition_id', auth.context.editionId);
+    // Every pack is its own D66 table, so the roll only resolves once narrowed
+    // to one of them.
+    const packId = params.tacticsCardsPackId ?? auth.context.corePackId;
+    if (!packId || !auth.context.availablePackIds.includes(packId)) {
+      return { success: false, error: 'That tactics card pack is not available for this gang' };
     }
 
-    const { data: card, error } = await query.maybeSingle();
+    // Resolved from the dice rather than a posted id, so a roll can't be
+    // credited to a card it didn't produce.
+    const { data: card, error } = await supabase
+      .from('tactics_cards')
+      .select('name')
+      .eq('tactics_cards_pack_id', packId)
+      .lte('d66_min', params.total)
+      .gte('d66_max', params.total)
+      .maybeSingle();
+
     if (error) throw error;
     if (!card) return { success: false, error: 'No tactics card matches that roll' };
 

--- a/app/api/tactics-cards/route.ts
+++ b/app/api/tactics-cards/route.ts
@@ -1,12 +1,18 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
 import { getUserIdFromClaims } from '@/utils/auth';
-import { withEditionSlug } from '@/types/edition';
-import { compareTacticsCards } from '@/types/tactics-card';
+import { gangEditionJoin } from '@/types/edition';
+import {
+  compareTacticsCards,
+  tacticsCardsPackFilter,
+  type TacticsCard,
+  type TacticsCardsPack
+} from '@/types/tactics-card';
 
 /**
- * The Gang Tactics catalogue for one edition, for the "Add Gang Tactics" picker.
- * The caller passes the slug it already holds, so this never resolves a gang.
+ * Every Gang Tactics deck a gang may draw from, each with its cards, for the
+ * "Add Gang Tactics" picker. Returned in one response so ticking a pack needs
+ * no refetch.
  */
 export async function GET(request: Request) {
   const supabase = await createClient();
@@ -17,22 +23,55 @@ export async function GET(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const editionSlug = new URL(request.url).searchParams.get('edition_slug');
-    if (!editionSlug) {
+    const gangId = new URL(request.url).searchParams.get('gang_id');
+    if (!gangId) {
       return NextResponse.json(
-        { error: 'Missing edition', details: 'edition_slug is required' },
+        { error: 'Missing gang', details: 'gang_id is required' },
         { status: 400 }
       );
     }
 
-    const { data, error } = await supabase
-      .from('tactics_cards')
-      .select('id, name, d66_min, d66_max, editions!inner ( slug )')
-      .eq('editions.slug', editionSlug);
+    const { data: gang, error: gangError } = await supabase
+      .from('gangs')
+      .select(`
+        gang_types!gang_type_id ( gang_type_id, parent_gang_type_id, editions:edition_id ( id ) ),
+        custom_gang_types!custom_gang_type_id ( editions:edition_id ( id ) )
+      `)
+      .eq('id', gangId)
+      .maybeSingle();
 
-    if (error) throw error;
+    if (gangError) throw gangError;
 
-    return NextResponse.json((data ?? []).map(withEditionSlug).sort(compareTacticsCards));
+    const editionId = gangEditionJoin(gang)?.id;
+    if (!gang || !editionId) return NextResponse.json([]);
+
+    const gangType = Array.isArray(gang.gang_types) ? gang.gang_types[0] : gang.gang_types;
+
+    // tactics_cards reaches packs through two FKs, so the embed names the one it means.
+    const { data: packs, error: packsError } = await supabase
+      .from('tactics_cards_packs')
+      .select(`
+        id,
+        name,
+        gang_type_id,
+        tactics_cards!tactics_cards_tactics_cards_pack_id_fkey ( id, name, d66_min, d66_max )
+      `)
+      .eq('edition_id', editionId)
+      .or(tacticsCardsPackFilter(gangType?.gang_type_id, gangType?.parent_gang_type_id));
+
+    if (packsError) throw packsError;
+
+    const result: TacticsCardsPack[] = (packs ?? [])
+      .map((pack: any) => ({
+        id: pack.id,
+        name: pack.name,
+        is_core: pack.gang_type_id === null,
+        cards: ((pack.tactics_cards ?? []) as TacticsCard[]).sort(compareTacticsCards)
+      }))
+      // The client splits core off, so this is the checkbox row's order.
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    return NextResponse.json(result);
   } catch (error) {
     console.error('Error in GET /api/tactics-cards:', error);
     return NextResponse.json(

--- a/components/gang/gang-page-content.tsx
+++ b/components/gang/gang-page-content.tsx
@@ -739,7 +739,6 @@ export default function GangPageContent({
             <div className="bg-card shadow-md rounded-lg p-4">
               <GangTacticsCards
                 gangId={gangId}
-                editionSlug={gangData.processedData.edition_slug}
                 tacticsCards={gangData.processedData.tacticsCards || []}
                 onTacticsCardsUpdate={handleTacticsCardsUpdate}
                 userPermissions={userPermissions}

--- a/components/gang/gang-tactics-cards.tsx
+++ b/components/gang/gang-tactics-cards.tsx
@@ -20,7 +20,8 @@ import {
   normaliseTacticsDescription,
   TACTICS_DESCRIPTION_CHAR_LIMIT,
   type GangTacticsCard,
-  type TacticsCard
+  type TacticsCard,
+  type TacticsCardsPack
 } from '@/types/tactics-card';
 import {
   addGangTacticsCards,
@@ -31,7 +32,6 @@ import {
 
 interface GangTacticsCardsProps {
   gangId: string;
-  editionSlug?: string | null;
   tacticsCards: GangTacticsCard[];
   /** Tab bodies unmount on switch, so the list itself lives in the page. */
   onTacticsCardsUpdate: (cards: GangTacticsCard[]) => void;
@@ -42,13 +42,13 @@ const TOOLTIP_ID = 'gang-tactics-description-tooltip';
 
 export default function GangTacticsCards({
   gangId,
-  editionSlug,
   tacticsCards,
   onTacticsCardsUpdate,
   userPermissions
 }: GangTacticsCardsProps) {
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [selectedCardIds, setSelectedCardIds] = useState<Set<string>>(new Set());
+  const [selectedPackId, setSelectedPackId] = useState<string | null>(null);
   const [editCard, setEditCard] = useState<GangTacticsCard | null>(null);
   const [editDescription, setEditDescription] = useState('');
   const [deleteCard, setDeleteCard] = useState<GangTacticsCard | null>(null);
@@ -62,23 +62,36 @@ export default function GangTacticsCards({
     [tacticsCards]
   );
 
-  // Only fetched once the Add modal is opened.
-  const { data: catalogue = [], isLoading: isLoadingCatalogue, error: catalogueError } = useQuery<TacticsCard[]>({
-    queryKey: ['tactics-cards', editionSlug],
+  // Only fetched once the Add modal is opened. Every pack arrives with its
+  // cards, so switching pack is local.
+  const { data: packs = [], isLoading: isLoadingPacks, error: packsError } = useQuery<TacticsCardsPack[]>({
+    queryKey: ['tactics-cards', gangId],
     queryFn: async () => {
-      const response = await fetch(`/api/tactics-cards?edition_slug=${editionSlug}`);
+      const response = await fetch(`/api/tactics-cards?gang_id=${gangId}`);
       if (!response.ok) throw new Error('Failed to fetch tactics cards');
       return response.json();
     },
     staleTime: 5 * 60 * 1000,
-    enabled: isAddModalOpen && !!editionSlug
+    enabled: isAddModalOpen && !!gangId
   });
+
+  const corePack = packs.find(pack => pack.is_core);
+  const selectablePacks = packs.filter(pack => !pack.is_core);
+  // Each pack is its own D66 table, so one is active at a time and the roller
+  // follows it.
+  const activePack = selectedPackId ? packs.find(pack => pack.id === selectedPackId) : corePack;
+  const catalogue = activePack?.cards ?? [];
 
   const hasRollableCard = catalogue.some(card => card.d66_min != null && !ownedCardIds.has(card.id));
 
   const logRollMutation = useMutation({
     mutationFn: (outcome: RollOutcome) =>
-      verifyAndLogRolledTacticsCard({ gangId, total: outcome.total, dice: outcome.dice })
+      verifyAndLogRolledTacticsCard({
+        gangId,
+        total: outcome.total,
+        dice: outcome.dice,
+        tacticsCardsPackId: activePack?.id ?? null
+      })
   });
 
   const logRollWithCooldown = (outcome: RollOutcome) => {
@@ -109,7 +122,15 @@ export default function GangTacticsCards({
 
   const handleOpenAddModal = () => {
     setSelectedCardIds(new Set());
+    setSelectedPackId(null);
     setIsAddModalOpen(true);
+  };
+
+  // Assigning one id is what makes "only one pack at a time" true. The card
+  // selection goes with the list it was made in.
+  const selectPack = (packId: string | null) => {
+    setSelectedPackId(packId);
+    setSelectedCardIds(new Set());
   };
 
   const toggleCard = (cardId: string) => {
@@ -279,6 +300,22 @@ export default function GangTacticsCards({
           helper="Pick the tactics cards this gang holds."
           content={
             <div>
+              {selectablePacks.length > 0 && (
+                <div className="mb-3 flex flex-wrap gap-x-4 gap-y-2">
+                  {selectablePacks.map(pack => (
+                    <div key={pack.id} className="flex items-center space-x-2">
+                      <Checkbox
+                        id={`tactics-pack-${pack.id}`}
+                        checked={selectedPackId === pack.id}
+                        onCheckedChange={(checked) => selectPack(checked ? pack.id : null)}
+                      />
+                      <label htmlFor={`tactics-pack-${pack.id}`} className="text-sm cursor-pointer">
+                        {pack.name}
+                      </label>
+                    </div>
+                  ))}
+                </div>
+              )}
               <div className="mb-3">
                 <DiceRoller<TacticsCard>
                   items={catalogue}
@@ -291,7 +328,7 @@ export default function GangTacticsCards({
                   inline
                   rollFn={rollUnownedD66}
                   buttonText="Roll D66"
-                  disabled={isLoadingCatalogue || !hasRollableCard}
+                  disabled={isLoadingPacks || !hasRollableCard}
                   onRolled={(rolled) => {
                     const result = rolled[0];
                     const card = result?.item;
@@ -304,9 +341,9 @@ export default function GangTacticsCards({
                   }}
                 />
               </div>
-              {isLoadingCatalogue ? (
+              {isLoadingPacks ? (
                 <p className="text-muted-foreground italic text-center py-4">Loading tactics cards...</p>
-              ) : catalogueError ? (
+              ) : packsError ? (
                 <p className="text-muted-foreground italic text-center py-4">Failed to load tactics cards.</p>
               ) : catalogue.length === 0 ? (
                 <p className="text-muted-foreground italic text-center py-4">No tactics cards available.</p>

--- a/supabase/migrations/20260905120000_create_tactics_cards_packs.sql
+++ b/supabase/migrations/20260905120000_create_tactics_cards_packs.sql
@@ -1,0 +1,162 @@
+BEGIN;
+
+-- ============================================================================
+-- TACTICS CARDS PACKS
+-- A Gang Tactics deck. Each pack is its own D66 table, so bands overlap
+-- between packs by design and every lookup must be scoped to one pack.
+--
+-- gang_type_id NULL = the edition's core deck: offered to every gang, and
+-- shown without a checkbox because it is what the picker falls back to.
+-- A value restricts the pack to that gang type. Alternate house lists reach
+-- their house's pack through gang_types.parent_gang_type_id, so House Escher
+-- needs one pack row, not one per replacement list.
+-- ============================================================================
+
+CREATE TABLE public.tactics_cards_packs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL PRIMARY KEY,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone,
+    edition_id uuid NOT NULL,
+    gang_type_id uuid,
+    name text NOT NULL,
+
+    CONSTRAINT tactics_cards_packs_edition_id_fkey
+        FOREIGN KEY (edition_id)
+        REFERENCES public.editions(id)
+        ON DELETE RESTRICT,
+
+    CONSTRAINT tactics_cards_packs_gang_type_id_fkey
+        FOREIGN KEY (gang_type_id)
+        REFERENCES public.gang_types(gang_type_id)
+        ON DELETE CASCADE,
+
+    -- Locks a pack to its gang type's edition. MATCH SIMPLE, so a core pack
+    -- (null gang type) is left unchecked, which is what we want.
+    CONSTRAINT tactics_cards_packs_gang_type_edition_fkey
+        FOREIGN KEY (gang_type_id, edition_id)
+        REFERENCES public.gang_types (gang_type_id, edition_id)
+        ON UPDATE CASCADE,
+
+    CONSTRAINT tactics_cards_packs_edition_id_name_key
+        UNIQUE (edition_id, name),
+
+    -- Target for the tactics_cards composite FK below.
+    CONSTRAINT tactics_cards_packs_id_edition_id_key
+        UNIQUE (id, edition_id)
+);
+
+COMMENT ON COLUMN public.tactics_cards_packs.gang_type_id IS
+    'Gang type this deck belongs to. NULL is the edition''s core deck, offered '
+    'to every gang and used when no pack is picked. A value also covers that '
+    'type''s alternate lists via gang_types.parent_gang_type_id.';
+
+-- At most one core deck per edition, so "the default" is never ambiguous.
+CREATE UNIQUE INDEX tactics_cards_packs_edition_core_uidx
+    ON public.tactics_cards_packs (edition_id)
+    WHERE gang_type_id IS NULL;
+
+-- gang_type_id is an ON DELETE CASCADE path.
+CREATE INDEX tactics_cards_packs_gang_type_id_idx
+    ON public.tactics_cards_packs (gang_type_id);
+
+
+-- ============================================================================
+-- RLS: TACTICS CARDS PACKS
+-- Same shape as tactics_cards: readable by any authenticated user, written by
+-- admins only.
+-- ============================================================================
+
+ALTER TABLE public.tactics_cards_packs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow authenticated users to view tactic card packs"
+    ON public.tactics_cards_packs
+    FOR SELECT
+    TO authenticated
+    USING (true);
+
+CREATE POLICY "Only admin can create tactic card packs"
+    ON public.tactics_cards_packs
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (
+        (SELECT private.is_admin())
+    );
+
+CREATE POLICY "Only admin can update tactic card packs"
+    ON public.tactics_cards_packs
+    FOR UPDATE
+    TO authenticated
+    USING (
+        (SELECT private.is_admin())
+    )
+    WITH CHECK (
+        (SELECT private.is_admin())
+    );
+
+CREATE POLICY "Only admin can delete tactic card packs"
+    ON public.tactics_cards_packs
+    FOR DELETE
+    TO authenticated
+    USING (
+        (SELECT private.is_admin())
+    );
+
+
+-- ============================================================================
+-- TACTICS CARDS -> PACK
+-- Added nullable, seeded with the one core pack the existing rows belong to,
+-- backfilled, then made NOT NULL. Every card has a pack afterwards, so "core"
+-- is exactly "the pack has no gang type" -- one rule, no second null case.
+-- ============================================================================
+
+ALTER TABLE public.tactics_cards
+    ADD COLUMN tactics_cards_pack_id uuid;
+
+INSERT INTO public.tactics_cards_packs (edition_id, gang_type_id, name)
+SELECT e.id, NULL, 'Core Gang Tactics'
+FROM public.editions e
+WHERE e.slug = 'n26'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM public.tactics_cards_packs existing
+      WHERE existing.edition_id = e.id
+        AND existing.gang_type_id IS NULL
+  );
+
+UPDATE public.tactics_cards c
+SET tactics_cards_pack_id = p.id
+FROM public.tactics_cards_packs p
+WHERE p.edition_id = c.edition_id
+  AND p.gang_type_id IS NULL
+  AND c.tactics_cards_pack_id IS NULL;
+
+ALTER TABLE public.tactics_cards
+    ALTER COLUMN tactics_cards_pack_id SET NOT NULL;
+
+ALTER TABLE public.tactics_cards
+    ADD CONSTRAINT tactics_cards_tactics_cards_pack_id_fkey
+        FOREIGN KEY (tactics_cards_pack_id)
+        REFERENCES public.tactics_cards_packs(id)
+        ON DELETE RESTRICT;
+
+-- Keeps a card and its pack in the same edition.
+ALTER TABLE public.tactics_cards
+    ADD CONSTRAINT tactics_cards_pack_edition_fkey
+        FOREIGN KEY (tactics_cards_pack_id, edition_id)
+        REFERENCES public.tactics_cards_packs (id, edition_id)
+        ON UPDATE CASCADE;
+
+CREATE INDEX tactics_cards_tactics_cards_pack_id_idx
+    ON public.tactics_cards (tactics_cards_pack_id);
+
+-- (edition_id, name) would stop two packs in one edition both carrying a card
+-- named "Rapid Fire". A pack implies its edition, so the pack is the right
+-- scope for the name.
+ALTER TABLE public.tactics_cards
+    DROP CONSTRAINT tactics_cards_edition_id_name_key;
+
+ALTER TABLE public.tactics_cards
+    ADD CONSTRAINT tactics_cards_tactics_cards_pack_id_name_key
+        UNIQUE (tactics_cards_pack_id, name);
+
+COMMIT;

--- a/types/tactics-card.ts
+++ b/types/tactics-card.ts
@@ -1,13 +1,21 @@
-// `tactics_cards` is the global, edition-scoped catalogue; `gang_tactics_cards`
-// is the per-gang row carrying the user's description. Kept dependency-free so
-// client components can import it.
+// `tactics_cards` is the global catalogue, grouped into decks by
+// `tactics_cards_packs`; `gang_tactics_cards` is the per-gang row carrying the
+// user's description. Kept dependency-free so client components can import it.
 
 export interface TacticsCard {
   id: string;
   name: string;
   d66_min: number | null;
   d66_max: number | null;
-  edition_slug: string | null;
+}
+
+/** One deck, with the cards the picker lists when it is the active one. */
+export interface TacticsCardsPack {
+  id: string;
+  name: string;
+  /** The edition's default deck. Always offered, and shown without a checkbox. */
+  is_core: boolean;
+  cards: TacticsCard[];
 }
 
 export interface GangTacticsCard {
@@ -21,6 +29,20 @@ export interface GangTacticsCard {
 }
 
 export const TACTICS_DESCRIPTION_CHAR_LIMIT = 1500;
+
+/**
+ * The packs a gang may draw from: the edition's core deck, plus any naming its
+ * gang type or the parent house that type belongs to. Pass to `.or()` alongside
+ * an `.eq('edition_id', ...)`.
+ */
+export function tacticsCardsPackFilter(
+  gangTypeId?: string | null,
+  parentGangTypeId?: string | null
+): string {
+  const typeIds = [gangTypeId, parentGangTypeId].filter(Boolean);
+  const core = 'gang_type_id.is.null';
+  return typeIds.length ? `${core},gang_type_id.in.(${typeIds.join(',')})` : core;
+}
 
 /** The gang_tactics_cards select every fetcher of these rows uses. */
 export const GANG_TACTICS_CARD_SELECT = `


### PR DESCRIPTION
## Summary

Added tactics cards packs to enable expansion beyond the core tactics cards
-

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [x] Schema / migration

## How I tested

Tested on local after adding the Goliath and Escher packs. 

- Further testing needed with "sub gang types" 
- No actual new tactics cards added

## Database

<!-- Delete this section if not applicable. Migrations are not auto-applied — a maintainer must apply them before this PR is merged. -->

- [x] Migration added under `supabase/migrations/`
- [ ] RPC/SQL function changed: updated both `supabase/migrations/` and the matching file under `supabase/functions/`

### Migration status

<!-- Check one. Migrations are not auto-applied. -->

- [ ] Needs maintainer to apply the migration before merge
- [x] Migration already applied

## Risk / rollout

<!-- e.g. Low / Medium — any deploy notes beyond database (env vars, feature flags, etc.). -->

- Not yet tested with tactics cards as there's no data added yet
- Not yet tested with sub gang types/archetypes
