### PR TITLE
Rename gang variants to gang subtypes in the database and app.

### DIFF
--- a/app/actions/copy-gang.ts
+++ b/app/actions/copy-gang.ts
@@ -69,7 +69,7 @@ export async function copyGang(params: CopyGangInput): Promise<CopyGangResult> {
         credits: sourceGang.credits,
         reputation: sourceGang.reputation,
         trade_points: sourceGang.trade_points ?? 0,
-        gang_variants: sourceGang.gang_variants,
+        gang_subtypes: sourceGang.gang_subtypes,
         note: sourceGang.note,
         note_backstory: sourceGang.note_backstory,
         positioning: null, // Will be updated after fighters are copied

--- a/app/actions/create-gang.ts
+++ b/app/actions/create-gang.ts
@@ -55,7 +55,6 @@ export async function createGang({
     }
 
     // Insert the new gang (exclusive arc: gang_type_id or custom_gang_type_id, never both)
-    // DB column remains gang_variants
     const { data, error } = await supabase
       .from('gangs')
       .insert([{
@@ -71,7 +70,7 @@ export async function createGang({
         alignment,
         gang_affiliation_id: gangAffiliationId || null,
         gang_origin_id: gangOriginId || null,
-        gang_variants: gangSubtypes.length > 0 ? gangSubtypes : null,
+        gang_subtypes: gangSubtypes.length > 0 ? gangSubtypes : null,
         default_gang_image: defaultGangImage
       }])
       .select();

--- a/app/actions/customise/custom-trading-posts.ts
+++ b/app/actions/customise/custom-trading-posts.ts
@@ -254,7 +254,7 @@ export interface CustomTPAvailabilityRule {
   gang_type_id: string | null;
   custom_gang_type_id: string | null;
   gang_origin_id: string | null;
-  gang_variant_id: string | null;
+  gang_subtype_id: string | null;
   campaign_type_allegiance_id: string | null;
   alignment: string | null;
   availability: string | null;
@@ -464,13 +464,13 @@ export async function getAvailabilityRules(
         gang_type_id,
         custom_gang_type_id,
         gang_origin_id,
-        gang_variant_id,
+        gang_subtype_id,
         campaign_type_allegiance_id,
         alignment,
         availability,
         custom_gang_types (gang_type),
         gang_origins (origin_name),
-        gang_variant_types (variant),
+        gang_subtype_types (subtype),
         campaign_type_allegiances (allegiance_name)
       `)
       .eq('custom_trading_post_equipment_id', equipmentItemId)
@@ -490,7 +490,7 @@ export async function getAvailabilityRules(
       gang_type_id: row.gang_type_id,
       custom_gang_type_id: row.custom_gang_type_id,
       gang_origin_id: row.gang_origin_id,
-      gang_variant_id: row.gang_variant_id,
+      gang_subtype_id: row.gang_subtype_id,
       campaign_type_allegiance_id: row.campaign_type_allegiance_id,
       alignment: row.alignment,
       availability: row.availability,
@@ -498,7 +498,7 @@ export async function getAvailabilityRules(
         ? gangTypeNames[row.gang_type_id] || null
         : row.custom_gang_types?.gang_type || null,
       gang_origin_name: row.gang_origins?.origin_name || null,
-      gang_subtype_name: row.gang_variant_types?.variant || null,
+      gang_subtype_name: row.gang_subtype_types?.subtype || null,
       allegiance_name: row.campaign_type_allegiances?.allegiance_name || null,
     }));
 
@@ -515,7 +515,7 @@ export async function addAvailabilityRule(
     gang_type_id?: string | null;
     custom_gang_type_id?: string | null;
     gang_origin_id?: string | null;
-    gang_variant_id?: string | null;
+    gang_subtype_id?: string | null;
     campaign_type_allegiance_id?: string | null;
     alignment?: string | null;
     availability?: string | null;
@@ -533,7 +533,7 @@ export async function addAvailabilityRule(
         gang_type_id: data.gang_type_id || null,
         custom_gang_type_id: data.custom_gang_type_id || null,
         gang_origin_id: data.gang_origin_id || null,
-        gang_variant_id: data.gang_variant_id || null,
+        gang_subtype_id: data.gang_subtype_id || null,
         campaign_type_allegiance_id: data.campaign_type_allegiance_id || null,
         alignment: data.alignment || null,
         availability: data.availability || null,
@@ -711,7 +711,7 @@ export async function saveEquipmentRules(
     gang_type_id?: string | null;
     custom_gang_type_id?: string | null;
     gang_origin_id?: string | null;
-    gang_variant_id?: string | null;
+    gang_subtype_id?: string | null;
     campaign_type_allegiance_id?: string | null;
     alignment?: string | null;
     availability?: string | null;
@@ -754,7 +754,7 @@ export async function saveEquipmentRules(
             gang_type_id: r.gang_type_id || null,
             custom_gang_type_id: r.custom_gang_type_id || null,
             gang_origin_id: r.gang_origin_id || null,
-            gang_variant_id: r.gang_variant_id || null,
+            gang_subtype_id: r.gang_subtype_id || null,
             campaign_type_allegiance_id: r.campaign_type_allegiance_id || null,
             alignment: r.alignment || null,
             availability: r.availability || null,

--- a/app/actions/update-gang.ts
+++ b/app/actions/update-gang.ts
@@ -175,9 +175,9 @@ export async function updateGang(params: UpdateGangParams): Promise<UpdateGangRe
       tradePointsChanged = true;
     }
 
-    // Handle gang subtypes - store as JSONB array (DB column: gang_variants)
+    // Handle gang subtypes - store as JSONB array
     if (params.gang_subtypes !== undefined) {
-      updates.gang_variants = params.gang_subtypes;
+      updates.gang_subtypes = params.gang_subtypes;
     }
 
     // Perform the gang update
@@ -345,14 +345,14 @@ export async function updateGang(params: UpdateGangParams): Promise<UpdateGangRe
     let gangSubtypes: Array<{id: string, subtype: string}> = [];
     if (params.gang_subtypes !== undefined && params.gang_subtypes.length > 0) {
       const { data: subtypesData, error: subtypesError } = await supabase
-        .from('gang_variant_types')
-        .select('id, variant')
+        .from('gang_subtype_types')
+        .select('id, subtype')
         .in('id', params.gang_subtypes);
 
       if (!subtypesError && subtypesData) {
-        gangSubtypes = subtypesData.map((row: { id: string; variant: string }) => ({
+        gangSubtypes = subtypesData.map((row: { id: string; subtype: string }) => ({
           id: row.id,
-          subtype: row.variant
+          subtype: row.subtype
         }));
       }
     }
@@ -414,7 +414,7 @@ export async function updateGang(params: UpdateGangParams): Promise<UpdateGangRe
       invalidateGangCampaignMembership(params.gang_id);
     }
     
-    // If gang subtypes were updated, invalidate basic gang data (stored in gang_variants column)
+    // If gang subtypes were updated, invalidate basic gang data
     if (params.gang_subtypes !== undefined) {
       invalidateGang(params.gang_id);
     }

--- a/app/api/admin/equipment/route.ts
+++ b/app/api/admin/equipment/route.ts
@@ -121,18 +121,18 @@ export async function GET(request: Request) {
         console.warn('Error fetching origin availabilities from equipment_availability:', originAvailabilitiesError);
       }
 
-      // Fetch equipment subtype availabilities (gang subtype-based; DB column gang_variant_id)
+      // Fetch equipment subtype availabilities (gang subtype-based)
       const { data: subtypeAvailabilities, error: subtypeAvailabilitiesError } = await supabase
         .from('equipment_availability')
         .select(`
           availability,
-          gang_variant_id,
-          gang_variant_types!gang_variant_id (
-            variant
+          gang_subtype_id,
+          gang_subtype_types!gang_subtype_id (
+            subtype
           )
         `)
         .eq('equipment_id', id)
-        .not('gang_variant_id', 'is', null);
+        .not('gang_subtype_id', 'is', null);
 
       // Don't throw error if the query fails or returns empty, just log it
       if (subtypeAvailabilitiesError) {
@@ -224,18 +224,18 @@ export async function GET(request: Request) {
           availability: a.availability
         }));
 
-      // Format the subtype availabilities (map DB variant column → app subtype)
+      // Format the subtype availabilities
       interface SubtypeAvailabilityData {
         availability: string;
-        gang_variant_id: string | null;
-        gang_variant_types: { variant: string } | null;
+        gang_subtype_id: string | null;
+        gang_subtype_types: { subtype: string } | null;
       }
 
       const formattedSubtypeAvailabilities = (subtypeAvailabilities || [])
-        .filter((a: any) => a && a.gang_variant_id !== null && a.gang_variant_types)
+        .filter((a: any) => a && a.gang_subtype_id !== null && a.gang_subtype_types)
         .map((a: any) => ({
-          subtype: a.gang_variant_types.variant,
-          gang_variant_id: a.gang_variant_id,
+          subtype: a.gang_subtype_types.subtype,
+          gang_subtype_id: a.gang_subtype_id,
           availability: a.availability
         }));
 
@@ -362,7 +362,7 @@ export async function GET(request: Request) {
             scopeToFighterTypeGrants(
               supabase
                 .from('fighter_type_equipment')
-                .select('fighter_type_id, gang_origin_id, gang_variant_id, fighter_subtype')
+                .select('fighter_type_id, gang_origin_id, gang_subtype_id, fighter_subtype')
                 .eq('equipment_id', id)
             )
               .order('fighter_type_id')
@@ -730,12 +730,12 @@ export async function PATCH(request: Request) {
             fighter_type_id: grant.fighter_type_id ?? null,
             equipment_id: id,
             gang_origin_id: grant.gang_origin_id ?? null,
-            gang_variant_id: grant.gang_variant_id ?? null,
+            gang_subtype_id: grant.gang_subtype_id ?? null,
             fighter_subtype: grant.fighter_subtype ?? null,
             updated_at: new Date().toISOString()
           }))
           .filter(record => {
-            const key = `${record.fighter_type_id ?? ''}|${record.gang_origin_id ?? ''}|${record.gang_variant_id ?? ''}|${record.fighter_subtype ?? ''}`;
+            const key = `${record.fighter_type_id ?? ''}|${record.gang_origin_id ?? ''}|${record.gang_subtype_id ?? ''}|${record.fighter_subtype ?? ''}`;
             if (seen.has(key)) return false;
             seen.add(key);
             return true;
@@ -893,14 +893,14 @@ export async function PATCH(request: Request) {
       }
     }
 
-    // Handle equipment subtype availabilities (DB column gang_variant_id)
+    // Handle equipment subtype availabilities
     if (equipment_subtype_availabilities !== undefined) {
       // First, delete all existing gang subtype availabilities for this equipment
       const { error: deleteError } = await supabase
         .from('equipment_availability')
         .delete()
         .eq('equipment_id', id)
-        .not('gang_variant_id', 'is', null);
+        .not('gang_subtype_id', 'is', null);
 
       // Log but don't throw on delete error
       if (deleteError) {
@@ -909,9 +909,9 @@ export async function PATCH(request: Request) {
 
       // If there are new subtype availabilities to add
       if (Array.isArray(equipment_subtype_availabilities) && equipment_subtype_availabilities.length > 0) {
-        const subtypeAvailabilityRecords = equipment_subtype_availabilities.map((avail: Pick<EquipmentSubtypeAvailability, 'gang_variant_id' | 'availability'>) => ({
+        const subtypeAvailabilityRecords = equipment_subtype_availabilities.map((avail: Pick<EquipmentSubtypeAvailability, 'gang_subtype_id' | 'availability'>) => ({
           equipment_id: id,
-          gang_variant_id: avail.gang_variant_id,
+          gang_subtype_id: avail.gang_subtype_id,
           availability: avail.availability.trimEnd(),
           gang_type_id: null,
           gang_origin_id: null

--- a/app/api/admin/fighter-types/route.ts
+++ b/app/api/admin/fighter-types/route.ts
@@ -15,7 +15,7 @@ function isNonEmptyArray(value: unknown): boolean {
  * applied to the reads and the delete alike.
  */
 function scopeToUnscopedGrants<T>(query: T): T {
-  return ['gang_origin_id', 'gang_variant_id', 'gang_type_id', 'fighter_subtype']
+  return ['gang_origin_id', 'gang_subtype_id', 'gang_type_id', 'fighter_subtype']
     .reduce((q, column) => q.is(column, null), query as any)
     .eq('excluded', false) as T;
 }

--- a/app/api/fighter-types/route.ts
+++ b/app/api/fighter-types/route.ts
@@ -6,10 +6,10 @@ import { withEditionSlug } from '@/types/edition';
 
 type SupabaseServerClient = Awaited<ReturnType<typeof createClient>>;
 
-const variantGangTypeName = (variant: string) => `Variant: ${variant}`;
+const subtypeGangTypeName = (name: string) => `Subtype: ${name}`;
 
-// Keyed by name so a later edition's re-issue of the variant inherits the rule.
-const variantsWithoutLeaders = new Set(['secundan incursion']);
+// Keyed by name so a later edition's re-issue of the subtype inherits the rule.
+const subtypesWithoutLeaders = new Set(['secundan incursion']);
 
 // Fetch the user's own custom fighters plus any shared with them through campaigns,
 // de-duplicated by id.
@@ -364,10 +364,10 @@ export async function GET(request: Request) {
     let gangSubtypes: Array<{id: string, subtype: string, edition_id: string | null}> = [];
     if (!isGangAddition) {
       try {
-        // Get gang data including gang_variants
+        // Get gang data including gang_subtypes
         const { data: gangData, error: gangError } = await supabase
           .from('gangs')
-          .select('gang_variants')
+          .select('gang_subtypes')
           .eq('id', gangId)
           .single();
 
@@ -377,20 +377,20 @@ export async function GET(request: Request) {
         }
 
         // If gang has subtypes, fetch the subtype details
-        if (gangData.gang_variants && Array.isArray(gangData.gang_variants) && gangData.gang_variants.length > 0) {
+        if (gangData.gang_subtypes && Array.isArray(gangData.gang_subtypes) && gangData.gang_subtypes.length > 0) {
           const { data: subtypeDetails, error: subtypeError } = await supabase
-            .from('gang_variant_types')
-            .select('id, variant, edition_id')
-            .in('id', gangData.gang_variants);
+            .from('gang_subtype_types')
+            .select('id, subtype, edition_id')
+            .in('id', gangData.gang_subtypes);
 
           if (subtypeError) {
             console.error('Error fetching subtype details:', subtypeError);
             throw subtypeError;
           }
 
-          gangSubtypes = (subtypeDetails || []).map((row: { id: string; variant: string; edition_id: string | null }) => ({
+          gangSubtypes = (subtypeDetails || []).map((row: { id: string; subtype: string; edition_id: string | null }) => ({
             id: row.id,
-            subtype: row.variant,
+            subtype: row.subtype,
             edition_id: row.edition_id,
           }));
         }
@@ -401,31 +401,31 @@ export async function GET(request: Request) {
 
       if (gangSubtypes.length > 0) {
         // Match on edition too — "Malstrain Corrupted" exists in both N23 and N26.
-        const { data: variantGangTypes, error: variantGangTypesError } = await supabase
+        const { data: subtypeGangTypes, error: subtypeGangTypesError } = await supabase
           .from('gang_types')
           .select('gang_type_id, gang_type, edition_id')
-          .in('gang_type', gangSubtypes.map(v => variantGangTypeName(v.subtype)));
+          .in('gang_type', gangSubtypes.map(v => subtypeGangTypeName(v.subtype)));
 
         // Falling through to "no subtype fighters" is a fine degradation, but a failure here
         // looks identical to a subtype having no pool, so say so rather than vanish silently.
-        if (variantGangTypesError) {
-          console.error('Error fetching variant gang types:', variantGangTypesError);
+        if (subtypeGangTypesError) {
+          console.error('Error fetching subtype gang types:', subtypeGangTypesError);
         }
 
         for (const subtype of gangSubtypes) {
-          if (variantsWithoutLeaders.has(subtype.subtype.toLowerCase())) {
+          if (subtypesWithoutLeaders.has(subtype.subtype.toLowerCase())) {
             data = data.filter((type: any) => !(type.fighter_subtypes ?? []).includes('Leader'));
           }
 
-          const variantGangTypeId = (variantGangTypes ?? []).find(gt =>
-            gt.gang_type === variantGangTypeName(subtype.subtype) &&
+          const subtypeGangTypeId = (subtypeGangTypes ?? []).find(gt =>
+            gt.gang_type === subtypeGangTypeName(subtype.subtype) &&
             gt.edition_id === subtype.edition_id
           )?.gang_type_id;
-          if (!variantGangTypeId) continue;
+          if (!subtypeGangTypeId) continue;
 
           // Fetch subtype-specific fighter types and merge
           const { data: subtypeData, error: subtypeError } = await supabase.rpc('get_fighter_types_with_cost', {
-            p_gang_type_id: variantGangTypeId,
+            p_gang_type_id: subtypeGangTypeId,
             p_gang_affiliation_id: null,
             p_is_gang_addition: false
           });

--- a/app/api/gang-subtype-types/route.ts
+++ b/app/api/gang-subtype-types/route.ts
@@ -5,7 +5,7 @@ import { editionSlugFromJoin } from "@/types/edition";
 
 interface DbGangSubtypeTypeRow {
     id: string;
-    variant: string;
+    subtype: string;
     edition_id?: string | null;
     editions?: { slug: string } | { slug: string }[] | null;
 }
@@ -21,18 +21,17 @@ export async function GET(request: Request) {
         }
 
         let query = supabase
-            .from('gang_variant_types')
-            .select('id, variant, edition_id, editions:edition_id (slug)')
-            .order('variant')
+            .from('gang_subtype_types')
+            .select('id, subtype, edition_id, editions:edition_id (slug)')
+            .order('subtype')
 
         const { data, error } = await query;
 
         if (error) throw error;
 
-        // Map DB column `variant` → app field `subtype`
         const modelData = data.map((row: DbGangSubtypeTypeRow) => ({
             id: row.id,
-            subtype: row.variant,
+            subtype: row.subtype,
             // Slug for the player-side callers; id for the admin editor, which saves one
             edition_id: row.edition_id ?? null,
             edition_slug: editionSlugFromJoin(row.editions),

--- a/app/api/gangs/[id]/route.ts
+++ b/app/api/gangs/[id]/route.ts
@@ -14,7 +14,7 @@ export async function GET(request: Request, props: { params: Promise<{ id: strin
   const supabase = await createClient();
 
   try {
-    // Get gang data (no join on gang_variants DB column)
+    // Get gang data (no join on gang_subtypes DB column)
     const { data: gangData, error: gangError } = await supabase
       .from('gangs')
       .select('*')
@@ -30,17 +30,17 @@ export async function GET(request: Request, props: { params: Promise<{ id: strin
       );
     }
 
-    // Fetch subtype details if gang_variants is present and is an array
+    // Fetch subtype details if gang_subtypes is present and is an array
     let subtypeDetails: Array<{ id: string; subtype: string }> = [];
-    if (gangData.gang_variants && Array.isArray(gangData.gang_variants)) {
+    if (gangData.gang_subtypes && Array.isArray(gangData.gang_subtypes)) {
       const { data: subtypes, error: subtypesError } = await supabase
-        .from('gang_variant_types')
-        .select('id, variant')
-        .in('id', gangData.gang_variants);
+        .from('gang_subtype_types')
+        .select('id, subtype')
+        .in('id', gangData.gang_subtypes);
       if (subtypesError) throw subtypesError;
-      subtypeDetails = (subtypes || []).map((row: { id: string; variant: string }) => ({
+      subtypeDetails = (subtypes || []).map((row: { id: string; subtype: string }) => ({
         id: row.id,
-        subtype: row.variant,
+        subtype: row.subtype,
       }));
     }
 
@@ -70,10 +70,10 @@ export async function GET(request: Request, props: { params: Promise<{ id: strin
     }
 
     // Return gang with subtype details and campaigns (app field: gang_subtypes)
-    const { gang_variants: _gangVariantIds, ...gangWithoutVariants } = gangData;
+    const { gang_subtypes: _gangSubtypeIds, ...gangWithoutSubtypes } = gangData;
     return NextResponse.json({
       gang: {
-        ...gangWithoutVariants,
+        ...gangWithoutSubtypes,
         gang_subtypes: subtypeDetails,
         campaigns,
       }
@@ -236,7 +236,7 @@ export async function PATCH(request: Request, props: { params: Promise<{ id: str
     }
 
     if (gang_subtypes !== undefined) {
-      updates.gang_variants = gang_subtypes;
+      updates.gang_subtypes = gang_subtypes;
     }
 
     // Perform the update

--- a/app/fighter/[id]/page.tsx
+++ b/app/fighter/[id]/page.tsx
@@ -58,7 +58,7 @@ export default async function FighterPageServer({ params }: FighterPageProps) {
 
     const [userPermissions, gangSubtypesResolved] = await Promise.all([
       checkPermissionCached(user.id, fighterBasic.gang_id, gangBasic.user_id),
-      getGangSubtypes(gangBasic.gang_variants || [], supabase)
+      getGangSubtypes(gangBasic.gang_subtypes || [], supabase)
     ]);
 
     // Permissions: All authenticated users can view fighters (canView is always true)

--- a/app/gang/[id]/page.tsx
+++ b/app/gang/[id]/page.tsx
@@ -74,7 +74,7 @@ export default async function GangPage(props: { params: Promise<{ id: string }> 
       getGangVehicles(params.id, supabase),
       getGangStash(params.id, supabase),
       getGangCampaigns(params.id, supabase),
-      getGangSubtypes(gangBasic.gang_variants || [], supabase),
+      getGangSubtypes(gangBasic.gang_subtypes || [], supabase),
       getUserProfile(gangBasic.user_id, supabase),
       checkPermissionCached(user.id, params.id, gangBasic.user_id),
       getGangBattleSessionsCached(params.id, supabase),

--- a/app/gang/[id]/print/page.tsx
+++ b/app/gang/[id]/print/page.tsx
@@ -73,7 +73,7 @@ export default async function PrintGangPage(props: {
       getGangType(gangBasic, supabase),
       getGangFightersList(params.id, supabase, { expandLoadoutsForPrint: true }),
       getGangCampaigns(params.id, supabase),
-      getGangSubtypes(gangBasic.gang_variants || [], supabase),
+      getGangSubtypes(gangBasic.gang_subtypes || [], supabase),
       getGangStash(params.id, supabase),
       getUserProfile(gangBasic.user_id, supabase),
     ]);

--- a/app/lib/get-user-gangs.ts
+++ b/app/lib/get-user-gangs.ts
@@ -69,7 +69,7 @@ export const getUserGangs = async (userId: string, supabase: any): Promise<Gang[
             rating,
             created_at,
             last_updated,
-            gang_variants,
+            gang_subtypes,
             is_favourite,
             favourite_order,
             gang_types!gang_type_id(
@@ -98,14 +98,14 @@ export const getUserGangs = async (userId: string, supabase: any): Promise<Gang[
         // campaigns query PER GANG) into two .in() queries.
         const gangIds = data.map((g: any) => g.id);
         const allSubtypeIds = Array.from(new Set(
-          data.flatMap((g: any) => (Array.isArray(g.gang_variants) ? g.gang_variants : []))
+          data.flatMap((g: any) => (Array.isArray(g.gang_subtypes) ? g.gang_subtypes : []))
         ));
 
         const [subtypesRes, campaignGangsRes] = await Promise.all([
           allSubtypeIds.length > 0
             ? supabase
-                .from('gang_variant_types')
-                .select('id, variant')
+                .from('gang_subtype_types')
+                .select('id, subtype')
                 .in('id', allSubtypeIds)
             : Promise.resolve({ data: [] }),
           supabase
@@ -119,8 +119,8 @@ export const getUserGangs = async (userId: string, supabase: any): Promise<Gang[
         ]);
 
         const subtypeById = new Map<string, { id: string; subtype: string }>();
-        (subtypesRes.data || []).forEach((row: { id: string; variant: string }) => {
-          subtypeById.set(row.id, { id: row.id, subtype: row.variant });
+        (subtypesRes.data || []).forEach((row: { id: string; subtype: string }) => {
+          subtypeById.set(row.id, { id: row.id, subtype: row.subtype });
         });
 
         const campaignsByGang = new Map<string, Array<{ campaign_id: string; campaign_name: string }>>();
@@ -146,7 +146,7 @@ export const getUserGangs = async (userId: string, supabase: any): Promise<Gang[
           rating: gang.rating || 0,
           created_at: gang.created_at,
           last_updated: gang.last_updated,
-          gang_subtypes: (Array.isArray(gang.gang_variants) ? gang.gang_variants : [])
+          gang_subtypes: (Array.isArray(gang.gang_subtypes) ? gang.gang_subtypes : [])
             .map((id: string) => subtypeById.get(id))
             .filter(Boolean) as Array<{ id: string; subtype: string }>,
           campaigns: campaignsByGang.get(gang.id) || [],

--- a/app/lib/shared/gang-data.ts
+++ b/app/lib/shared/gang-data.ts
@@ -35,7 +35,7 @@ export interface GangBasic {
   created_at: string;
   last_updated: string;
   alliance_id?: string;
-  gang_variants?: string[];
+  gang_subtypes?: string[];
   user_id: string;
   gang_affiliation_id?: string | null;
   gang_affiliation?: {
@@ -237,7 +237,7 @@ export const getGangCore = async (gangId: string, supabase: any): Promise<GangCo
             alliance_name,
             alliance_type
           ),
-          gang_variants,
+          gang_subtypes,
           user_id,
           gang_affiliation_id,
           gang_affiliation:gang_affiliation_id (
@@ -486,7 +486,6 @@ export const getGangTypeConfig = (gangBasic: GangBasic) =>
 /**
  * Get gang subtypes
  * Cache: GLOBAL_GANG_TYPES (shared since subtypes rarely change)
- * DB table/column names remain gang_variant_types / variant; mapped to app subtype.
  */
 export const getGangSubtypes = async (gangSubtypeIds: string[], supabase: any): Promise<GangSubtype[]> => {
   if (!gangSubtypeIds || gangSubtypeIds.length === 0) return [];
@@ -494,15 +493,12 @@ export const getGangSubtypes = async (gangSubtypeIds: string[], supabase: any): 
   return unstable_cache(
     async () => {
       const { data, error } = await supabase
-        .from('gang_variant_types')
-        .select('id, variant')
+        .from('gang_subtype_types')
+        .select('id, subtype')
         .in('id', gangSubtypeIds);
 
       if (error) return [];
-      return (data || []).map((row: { id: string; variant: string }) => ({
-        id: row.id,
-        subtype: row.variant,
-      }));
+      return data || [];
     },
     [`gang-subtypes-${gangSubtypeIds.join('-')}`],
     {

--- a/components/admin/admin-edit-equipment.tsx
+++ b/components/admin/admin-edit-equipment.tsx
@@ -50,7 +50,7 @@ const fighterTypeLabel = (ft: FighterType) => {
 };
 
 const grantKey = (grant: FighterTypeEquipmentGrant) =>
-  [grant.fighter_type_id, grant.gang_origin_id, grant.gang_variant_id, grant.fighter_subtype]
+  [grant.fighter_type_id, grant.gang_origin_id, grant.gang_subtype_id, grant.fighter_subtype]
     .map(part => part ?? '')
     .join('|');
 
@@ -357,7 +357,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
       if (equipmentDetails.equipment_subtype_availabilities) {
         setEquipmentSubtypeAvailabilities(equipmentDetails.equipment_subtype_availabilities.map((a: any) => ({
           subtype: a.subtype,
-          gang_variant_id: a.gang_variant_id,
+          gang_subtype_id: a.gang_subtype_id,
           availability: a.availability
         })));
       }
@@ -386,7 +386,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
         setFighterTypeGrants(equipmentDetails.fighter_types_with_equipment.map((ft: any) => ({
           fighter_type_id: ft.fighter_type_id ?? null,
           gang_origin_id: ft.gang_origin_id ?? null,
-          gang_variant_id: ft.gang_variant_id ?? null,
+          gang_subtype_id: ft.gang_subtype_id ?? null,
           fighter_subtype: ft.fighter_subtype ?? null
         })));
       }
@@ -566,7 +566,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
           if (ft && ft.edition_id !== newEditionId) return false;
           const origin = gangOriginList.find(o => o.id === grant.gang_origin_id);
           if (origin && origin.edition_id !== newEditionId) return false;
-          const subtype = gangSubtypeList.find(v => v.id === grant.gang_variant_id);
+          const subtype = gangSubtypeList.find(v => v.id === grant.gang_subtype_id);
           if (subtype && subtype.edition_id !== newEditionId) return false;
           return true;
         })
@@ -593,7 +593,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
       );
       setEquipmentSubtypeAvailabilities(prev =>
         prev.filter(avail => {
-          const subtype = gangSubtypeList.find(v => v.id === avail.gang_variant_id);
+          const subtype = gangSubtypeList.find(v => v.id === avail.gang_subtype_id);
           return !subtype || subtype.edition_id === newEditionId;
         })
       );
@@ -732,7 +732,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
           : [],
         equipment_subtype_availabilities: showAvailability
           ? equipmentSubtypeAvailabilities.map(a => ({
-              gang_variant_id: a.gang_variant_id,
+              gang_subtype_id: a.gang_subtype_id,
               availability: a.availability
             }))
           : [],
@@ -1688,7 +1688,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                             const combined = combineAvailability(variantAvailValueLetter, variantAvailValueNumber);
                             if (selectedAvailabilityGangSubtype && combined) {
                               const alreadyExists = equipmentSubtypeAvailabilities.some(
-                                a => a.gang_variant_id === selectedAvailabilityGangSubtype
+                                a => a.gang_subtype_id === selectedAvailabilityGangSubtype
                               );
                               if (alreadyExists) {
                                 toast.error('This subtype already has an availability set');
@@ -1701,7 +1701,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                                   ...prev,
                                   {
                                     subtype: selectedSubtype.subtype,
-                                    gang_variant_id: selectedSubtype.id,
+                                    gang_subtype_id: selectedSubtype.id,
                                     availability: combined
                                   }
                                 ]);
@@ -1776,7 +1776,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                       if (value) {
                         setFighterTypeGrants([
                           ...fighterTypeGrants,
-                          { fighter_type_id: value, gang_origin_id: null, gang_variant_id: null, fighter_subtype: null }
+                          { fighter_type_id: value, gang_origin_id: null, gang_subtype_id: null, fighter_subtype: null }
                         ]);
                       }
                       e.target.value = "";
@@ -1788,7 +1788,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                     {filteredFighterTypes
                       .filter(ft => !fighterTypeGrants.some(
                         g => g.fighter_type_id === ft.id
-                          && !g.gang_origin_id && !g.gang_variant_id && !g.fighter_subtype
+                          && !g.gang_origin_id && !g.gang_subtype_id && !g.fighter_subtype
                       ))
                       .map((ft) => (
                         <option key={ft.id} value={ft.id}>
@@ -1808,8 +1808,8 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                         grant.gang_origin_id
                           ? `Origin: ${gangOriginList.find(o => o.id === grant.gang_origin_id)?.origin_name ?? '…'}`
                           : null,
-                        grant.gang_variant_id
-                          ? `Gang subtype: ${gangSubtypeList.find(v => v.id === grant.gang_variant_id)?.subtype ?? '…'}`
+                        grant.gang_subtype_id
+                          ? `Gang subtype: ${gangSubtypeList.find(v => v.id === grant.gang_subtype_id)?.subtype ?? '…'}`
                           : null,
                         grant.fighter_subtype ? `Subtype: ${grant.fighter_subtype}` : null
                       ].filter(Boolean).join(', ');
@@ -1850,7 +1850,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                         const grant: FighterTypeEquipmentGrant = {
                           fighter_type_id: scopedGrantFighterType || null,
                           gang_origin_id: scopedGrantOrigin || null,
-                          gang_variant_id: scopedGrantGangSubtype || null,
+                          gang_subtype_id: scopedGrantGangSubtype || null,
                           fighter_subtype: scopedGrantSubtype || null
                         };
                         if (fighterTypeGrants.some(g => grantKey(g) === grantKey(grant))) {

--- a/components/customise/custom-trading-posts.tsx
+++ b/components/customise/custom-trading-posts.tsx
@@ -381,7 +381,7 @@ export function CustomiseTradingPosts({
                     gang_type_id: r.gang_type_id,
                     custom_gang_type_id: r.custom_gang_type_id,
                     gang_origin_id: r.gang_origin_id,
-                    gang_variant_id: r.gang_variant_id,
+                    gang_subtype_id: r.gang_subtype_id,
                     campaign_type_allegiance_id: r.campaign_type_allegiance_id,
                     alignment: r.alignment,
                     availability: r.availability,
@@ -467,7 +467,7 @@ export function CustomiseTradingPosts({
                   gang_type_id: r.gang_type_id,
                   custom_gang_type_id: r.custom_gang_type_id,
                   gang_origin_id: r.gang_origin_id,
-                  gang_variant_id: r.gang_variant_id,
+                  gang_subtype_id: r.gang_subtype_id,
                   campaign_type_allegiance_id: r.campaign_type_allegiance_id,
                   alignment: r.alignment,
                   availability: r.availability,
@@ -1690,7 +1690,7 @@ function AddAvailabilityRuleModal({
   const [gangOriginId, setGangOriginId] = useState(initialRule?.gang_origin_id || '');
   const [gangTypeName, setGangTypeName] = useState<string | null>(initialRule?.gang_type_name ?? null);
   const [gangOriginName, setGangOriginName] = useState<string | null>(initialRule?.gang_origin_name ?? null);
-  const [gangSubtypeId, setGangSubtypeId] = useState(initialRule?.gang_variant_id || '');
+  const [gangSubtypeId, setGangSubtypeId] = useState(initialRule?.gang_subtype_id || '');
   const [allegiance, setAllegiance] = useState(initialRule?.campaign_type_allegiance_id || '');
   const [alignment, setAlignment] = useState(initialRule?.alignment || '');
   const [availLetter, setAvailLetter] = useState(parsedAvail.letter);
@@ -1728,7 +1728,7 @@ function AddAvailabilityRuleModal({
       gang_type_id: !isCustomGangType && gangTypeId ? gangTypeId : null,
       custom_gang_type_id: isCustomGangType && gangTypeId ? gangTypeId : null,
       gang_origin_id: gangOriginId || null,
-      gang_variant_id: gangSubtypeId || null,
+      gang_subtype_id: gangSubtypeId || null,
       campaign_type_allegiance_id: allegiance || null,
       alignment: alignment || null,
       availability: combineAvailability(availLetter, availNumber),

--- a/components/gang/gang.tsx
+++ b/components/gang/gang.tsx
@@ -754,10 +754,10 @@ export default function Gang({
       if (!response.ok) throw new Error('Failed to fetch subtypes');
       const data = await response.json();
       setAvailableSubtypes(
-        (data as Array<{ id: string; subtype?: string; variant?: string; edition_slug?: string | null }>).map(
+        (data as Array<{ id: string; subtype?: string; edition_slug?: string | null }>).map(
           (item) => ({
             id: item.id,
-            subtype: item.subtype ?? item.variant ?? 'Unknown',
+            subtype: item.subtype ?? 'Unknown',
             edition_slug: item.edition_slug,
           })
         )

--- a/supabase/functions/copy_custom_collection.sql
+++ b/supabase/functions/copy_custom_collection.sql
@@ -218,11 +218,11 @@ BEGIN
 
   INSERT INTO public.custom_trading_post_availability (id, created_at, user_id, custom_trading_post_equipment_id,
                                                        gang_type_id, custom_gang_type_id, gang_origin_id,
-                                                       gang_variant_id, campaign_type_allegiance_id, alignment,
+                                                       gang_subtype_id, campaign_type_allegiance_id, alignment,
                                                        availability)
   SELECT gen_random_uuid(), now(), v_user, (v_map_tpe ->> a.custom_trading_post_equipment_id::text)::uuid,
          a.gang_type_id, (v_map_gt ->> a.custom_gang_type_id::text)::uuid, a.gang_origin_id,
-         a.gang_variant_id, a.campaign_type_allegiance_id, a.alignment, a.availability
+         a.gang_subtype_id, a.campaign_type_allegiance_id, a.alignment, a.availability
   FROM public.custom_trading_post_availability a
   WHERE (v_map_tpe ? a.custom_trading_post_equipment_id::text);
 

--- a/supabase/functions/get_equipment_detailed_data.sql
+++ b/supabase/functions/get_equipment_detailed_data.sql
@@ -55,7 +55,7 @@ AS $$
     WITH gang_data AS (
         SELECT
             g.gang_origin_id,
-            g.gang_variants,
+            g.gang_subtypes,
             g.alignment,
             g.custom_gang_type_id,
             cg.campaign_type_allegiance_id,
@@ -240,7 +240,7 @@ AS $$
             AND (a.gang_type_id IS NULL OR a.gang_type_id = $1)
             AND (a.custom_gang_type_id IS NULL OR a.custom_gang_type_id = gd.custom_gang_type_id)
             AND (a.gang_origin_id IS NULL OR a.gang_origin_id = gd.gang_origin_id)
-            AND (a.gang_variant_id IS NULL OR gd.gang_variants ? a.gang_variant_id::text)
+            AND (a.gang_subtype_id IS NULL OR gd.gang_subtypes ? a.gang_subtype_id::text)
             AND (a.campaign_type_allegiance_id IS NULL OR a.campaign_type_allegiance_id = gd.campaign_type_allegiance_id)
             AND (a.alignment IS NULL OR a.alignment = gd.alignment)
         WHERE ctpe.equipment_id IS NOT NULL
@@ -399,8 +399,8 @@ AS $$
         ON e.id = ea.equipment_id AND ea.gang_type_id = $1
     LEFT JOIN equipment_availability ea_var
         ON e.id = ea_var.equipment_id
-        AND ea_var.gang_variant_id IS NOT NULL
-        AND gd.gang_variants ? ea_var.gang_variant_id::text
+        AND ea_var.gang_subtype_id IS NOT NULL
+        AND gd.gang_subtypes ? ea_var.gang_subtype_id::text
     LEFT JOIN equipment_availability ea_origin
         ON e.id = ea_origin.equipment_id
         AND ea_origin.gang_origin_id IS NOT NULL
@@ -423,7 +423,7 @@ AS $$
                  AND fte.custom_fighter_type_id IS NULL
                  AND fte.fighter_subtype IS NOT NULL))
         AND (fte.gang_origin_id IS NULL OR fte.gang_origin_id = gd.gang_origin_id)
-        AND (fte.gang_variant_id IS NULL OR gd.gang_variants ? fte.gang_variant_id::text)
+        AND (fte.gang_subtype_id IS NULL OR gd.gang_subtypes ? fte.gang_subtype_id::text)
         AND (fte.gang_type_id IS NULL OR fte.gang_type_id = $1)
         AND (fte.fighter_subtype IS NULL OR gd.fighter_subtypes ? fte.fighter_subtype)
 
@@ -604,7 +604,7 @@ AS $$
             AND (a.gang_type_id IS NULL OR a.gang_type_id = $1)
             AND (a.custom_gang_type_id IS NULL OR a.custom_gang_type_id = gd.custom_gang_type_id)
             AND (a.gang_origin_id IS NULL OR a.gang_origin_id = gd.gang_origin_id)
-            AND (a.gang_variant_id IS NULL OR gd.gang_variants ? a.gang_variant_id::text)
+            AND (a.gang_subtype_id IS NULL OR gd.gang_subtypes ? a.gang_subtype_id::text)
             AND (a.campaign_type_allegiance_id IS NULL OR a.campaign_type_allegiance_id = gd.campaign_type_allegiance_id)
             AND (a.alignment IS NULL OR a.alignment = gd.alignment)
         WHERE ctpe.custom_equipment_id IS NOT NULL

--- a/supabase/functions/get_gang_details.sql
+++ b/supabase/functions/get_gang_details.sql
@@ -27,7 +27,7 @@ RETURNS TABLE(
     alliance_id uuid,
     alliance_name text,
     alliance_type text,
-    gang_variants json,
+    gang_subtypes json,
     edition_slug text
 )
 LANGUAGE plpgsql
@@ -708,22 +708,22 @@ BEGIN
        WHERE cg.gang_id = p_gang_id
        GROUP BY cg.gang_id
    ),
-   gang_variant_info AS (
+   gang_subtype_info AS (
        SELECT 
            COALESCE(
                json_agg(
                    json_build_object(
-                       'id', gvt.id,
-                       'variant', gvt.variant
+                       'id', gst.id,
+                       'subtype', gst.subtype
                    )
-                   ORDER BY gvt.variant
+                   ORDER BY gst.subtype
                ),
                '[]'::json
-           ) as variant_info
-       FROM gang_variant_types gvt
+           ) as subtype_info
+       FROM gang_subtype_types gst
        JOIN gangs g ON g.id = p_gang_id
-       WHERE gvt.id::text IN (
-           SELECT jsonb_array_elements_text(g.gang_variants)
+       WHERE gst.id::text IN (
+           SELECT jsonb_array_elements_text(g.gang_subtypes)
        )
    ),
    all_fighters_json AS (
@@ -828,7 +828,7 @@ BEGIN
        g.alliance_id,
        a.alliance_name,
        a.alliance_type,
-       (SELECT variant_info FROM gang_variant_info) as gang_variants,
+       (SELECT subtype_info FROM gang_subtype_info) as gang_subtypes,
        ed.slug AS edition_slug
    FROM gangs g
    LEFT JOIN gang_types gt ON gt.gang_type_id = g.gang_type_id

--- a/supabase/migrations/20260906093510_rename_gang_variants_to_gang_subtypes.sql
+++ b/supabase/migrations/20260906093510_rename_gang_variants_to_gang_subtypes.sql
@@ -1,0 +1,104 @@
+-- Rename gang variants → gang subtypes (schema identifiers only).
+--
+-- Mirrors 20260806120000_rename_fighter_classes_to_fighter_subtypes: pure rename,
+-- no UUID/data-shape change. Hard cutover — deploy the Phase 4 app pass and the
+-- updated RPCs in supabase/functions/ in the same window as this migration.
+--
+-- RPC bodies (get_gang_details, get_equipment_detailed_data, copy_custom_collection)
+-- live in supabase/functions/*.sql per repo convention and are applied separately
+-- via the dashboard / your usual RPC deploy path. Apply those AFTER or WITH this
+-- migration so live functions do not reference the old names.
+--
+-- Catalog data: gang_types.gang_type values 'Variant: …' become 'Subtype: …'
+-- (Option B). The app helper subtypeGangTypeName must ship with this.
+
+BEGIN;
+
+-- 1. Reference table
+ALTER TABLE public.gang_variant_types RENAME TO gang_subtype_types;
+ALTER TABLE public.gang_subtype_types RENAME COLUMN variant TO subtype;
+
+ALTER TABLE public.gang_subtype_types
+  RENAME CONSTRAINT gang_variant_types_pkey TO gang_subtype_types_pkey;
+ALTER TABLE public.gang_subtype_types
+  RENAME CONSTRAINT gang_variant_types_edition_id_fkey TO gang_subtype_types_edition_id_fkey;
+
+ALTER INDEX public.gang_variant_types_edition_id_idx
+  RENAME TO gang_subtype_types_edition_id_idx;
+
+-- 2. RLS policies (names only)
+ALTER POLICY "Allow authenticated users to view gang_variant_types"
+  ON public.gang_subtype_types
+  RENAME TO "Allow authenticated users to view gang_subtype_types";
+ALTER POLICY gang_variant_types_admin_insert_policy
+  ON public.gang_subtype_types
+  RENAME TO gang_subtype_types_admin_insert_policy;
+ALTER POLICY gang_variant_types_admin_update_policy
+  ON public.gang_subtype_types
+  RENAME TO gang_subtype_types_admin_update_policy;
+ALTER POLICY gang_variant_types_admin_delete_policy
+  ON public.gang_subtype_types
+  RENAME TO gang_subtype_types_admin_delete_policy;
+
+-- 3. Gangs JSONB column (values are UUID strings; rename only)
+ALTER TABLE public.gangs RENAME COLUMN gang_variants TO gang_subtypes;
+
+-- 4. FK columns on dependent tables
+ALTER TABLE public.equipment_availability
+  RENAME COLUMN gang_variant_id TO gang_subtype_id;
+ALTER TABLE public.equipment_availability
+  RENAME CONSTRAINT equipment_availability_gang_variant_id_fkey
+                 TO equipment_availability_gang_subtype_id_fkey;
+
+ALTER TABLE public.fighter_type_equipment
+  RENAME COLUMN gang_variant_id TO gang_subtype_id;
+ALTER TABLE public.fighter_type_equipment
+  RENAME CONSTRAINT fighter_type_equipment_gang_variant_id_fkey
+                 TO fighter_type_equipment_gang_subtype_id_fkey;
+
+ALTER TABLE public.custom_trading_post_availability
+  RENAME COLUMN gang_variant_id TO gang_subtype_id;
+ALTER TABLE public.custom_trading_post_availability
+  RENAME CONSTRAINT custom_trading_post_availability_gang_variant_id_fkey
+                 TO custom_trading_post_availability_gang_subtype_id_fkey;
+
+-- 5. Indexes that include / are named for the old column
+ALTER INDEX public.fighter_type_equipment_gang_variant_id_idx
+  RENAME TO fighter_type_equipment_gang_subtype_id_idx;
+
+-- Unique scope index must be rebuilt: Postgres does not rename columns inside
+-- an index definition via ALTER INDEX alone when the column was renamed — the
+-- index follows the column rename automatically for btree columns. Confirm:
+-- after RENAME COLUMN, the uidx still references gang_subtype_id. No rebuild
+-- needed if that holds; leave the index name as-is (it does not embed
+-- gang_variant_id in its name). fighter_type_equipment_fighter_scope_uidx stays.
+
+-- 6. Comments
+COMMENT ON TABLE public.gang_subtype_types IS
+  'Gang subtype catalog (Chaos Corrupted, Wasteland, Skirmish, …). Formerly gang_variant_types.';
+
+COMMENT ON COLUMN public.gang_subtype_types.subtype IS
+  'Display name of the gang subtype. Unique enough in practice per edition; matched by gangs.gang_subtypes UUID array.';
+
+COMMENT ON COLUMN public.gangs.gang_subtypes IS
+  'JSONB array of gang_subtype_types.id values held by this gang. Formerly gangs.gang_variants.';
+
+COMMENT ON COLUMN public.fighter_type_equipment.gang_subtype_id IS
+  'Restricts the row to gangs holding this subtype (gangs.gang_subtypes contains the id). '
+  'NULL applies regardless of subtype.';
+
+COMMENT ON COLUMN public.equipment_availability.gang_subtype_id IS
+  'When set, this availability row applies only to gangs whose gang_subtypes contains this id.';
+
+COMMENT ON COLUMN public.custom_trading_post_availability.gang_subtype_id IS
+  'When set, this custom trading-post availability rule applies only to gangs holding this subtype.';
+
+-- 7. Catalog gang_type labels used by Add Fighter unlocks (Option B)
+UPDATE public.gang_types
+SET gang_type = replace(gang_type, 'Variant: ', 'Subtype: ')
+WHERE gang_type LIKE 'Variant: %';
+
+-- custom_gang_types does not use the Variant:/Subtype: prefix pattern for
+-- subtype pools; official gang_types rows are the join key in fighter-types.
+
+COMMIT;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -151,9 +151,9 @@ INSERT INTO public.campaign_type_resources (id, campaign_type_id, resource_name,
 ON CONFLICT (id) DO NOTHING;
 
 -- ============================================================================
--- 11. GANG VARIANT TYPES
+-- 11. GANG SUBTYPE TYPES
 -- ============================================================================
-INSERT INTO public.gang_variant_types (id, variant, edition_id, created_at) VALUES
+INSERT INTO public.gang_subtype_types (id, subtype, edition_id, created_at) VALUES
 ('2c67ccbc-e103-433c-9535-bc6f9435fa38', 'Chaos Corrupted', '00000000-0000-0000-0000-000000000023', now()),
 ('d66feb66-7a3b-4306-9d0b-58725b72ee0d', 'Genestealer Infected', '00000000-0000-0000-0000-000000000023', now()),
 ('b86a0a06-4f47-4c78-8d04-fb7b7042c14e', 'Outlaw', '00000000-0000-0000-0000-000000000023', now()),

--- a/types/equipment.ts
+++ b/types/equipment.ts
@@ -247,7 +247,7 @@ export interface EquipmentOriginAvailability {
 
 export interface EquipmentSubtypeAvailability {
   subtype: string;
-  gang_variant_id: string;
+  gang_subtype_id: string;
   availability: string;
 }
 
@@ -260,7 +260,7 @@ export interface EquipmentSubtypeAvailability {
 export interface FighterTypeEquipmentGrant {
   fighter_type_id: string | null;
   gang_origin_id: string | null;
-  gang_variant_id: string | null;
+  gang_subtype_id: string | null;
   fighter_subtype: string | null;
 }
 


### PR DESCRIPTION
Add a migration for table/column/FK renames and Variant: → Subtype: catalog labels; update RPCs, seed, and drop the app mapping layer.

## Summary
- Adds migration ``20260906093510_rename_gang_variants_to_gang_subtypes`` (table/columns/indexes/FKs/policies + catalog ``Variant:`` → ``Subtype:``).
- Updates ``get_gang_details``, ``get_equipment_detailed_data``, and ``copy_custom_collection`` under ``supabase/functions/``.
- Drops the app mapping layer so code uses ``gang_subtype_types`` / ``gang_subtypes`` / ``gang_subtype_id`` directly.
- Updates ``seed.sql`` for the renamed catalog table.

## SQL to run (hard cutover — do this before/with app deploy)

Run in this order on the target database (staging then production). Do **not** rely on the app deploy alone; RPCs are not auto-applied by the migration.

### 1. Schema migration
- [ ] ``supabase/migrations/20260906093510_rename_gang_variants_to_gang_subtypes.sql``

### 2. RPC / function SQL (apply full file contents via SQL editor / dashboard)
Apply **after** the migration (they reference the new names):

- [ ] ``supabase/functions/get_equipment_detailed_data.sql`` — ``get_equipment_detailed_data``
- [ ] ``supabase/functions/copy_custom_collection.sql`` — ``copy_custom_collection``
- [ ] ``supabase/functions/get_gang_details.sql`` — ``get_gang_details`` (legacy / Rule Snatcher; still update for compatibility)

### 3. App deploy
- [ ] Deploy this branch so the app matches the new schema/RPC names

### Not a live-DB step
- ``supabase/seed.sql`` — local/dev seed only; not run against production

## Test plan
- [ ] Apply migration to staging/local
- [ ] Apply the three function SQL files above
- [ ] Create/edit gang subtypes; reload and confirm persistence
- [ ] Add Fighter unlocks for Secundan Incursion / Corrupted / Infested / Malstrain
- [ ] Admin equipment: availability + scoped grants by gang subtype
- [ ] Custom trading post rules scoped by gang subtype
- [ ] Copy gang preserves subtypes
