### PR TITLE
Refactored exotic beast cache

### DIFF
--- a/app/actions/edit-fighter.ts
+++ b/app/actions/edit-fighter.ts
@@ -19,25 +19,7 @@ import { mapArchetypeSkillAccessToOverrides } from '@/utils/archetypeEligibility
 import { syncFighter } from '@/utils/syncVenatorSkillOverrides';
 import { isVenatorGang } from '@/utils/venatorSkillAccess';
 import { gangEditionSlug } from '@/types/edition';
-
-// Helper function to invalidate owner's cache when beast fighter is updated
-async function invalidateBeastOwnerCache(fighterId: string, gangId: string, supabase: any) {
-  // Check if this fighter is an exotic beast owned by another fighter
-  const { data: ownerData } = await supabase
-    .from('fighter_exotic_beasts')
-    .select('fighter_owner_id')
-    .eq('fighter_pet_id', fighterId)
-    .single();
-    
-  if (ownerData) {
-    // Invalidate the owner's cache since their total cost changed
-    invalidateFighter(ownerData.fighter_owner_id, gangId);
-
-    // Invalidate the owner's beast costs cache
-    // Without this, the owner's cost calculation uses stale beast data
-    revalidateTag(TAGS.fighter(ownerData.fighter_owner_id), { expire: 0 });
-  }
-}
+import { invalidateBeastOwnerCache } from '@/utils/exotic-beasts';
 
 async function getKilledStatusEffects(supabase: any, fighterId: string) {
   const { data: effects, error } = await supabase

--- a/app/actions/edit-fighter.ts
+++ b/app/actions/edit-fighter.ts
@@ -244,7 +244,8 @@ export async function editFighterStatus(params: EditFighterStatusParams): Promis
         starved,
         recovery,
         captured,
-        captured_by_gang_id
+        captured_by_gang_id,
+        fighter_pet_id
       `)
       .eq('id', params.fighter_id)
       .single();
@@ -368,7 +369,7 @@ export async function editFighterStatus(params: EditFighterStatusParams): Promis
           : { removedCount: 0, removedSkillCount: 0 };
 
         invalidateFighter(params.fighter_id, gangId);
-        await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase);
+        await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase, fighter.fighter_pet_id ?? null);
         if (removedKilledStatusEffects.removedCount > 0) {
           revalidateTag(TAGS.fighter(params.fighter_id), { expire: 0 });
         }
@@ -461,7 +462,7 @@ export async function editFighterStatus(params: EditFighterStatusParams): Promis
 
         const financialResult = await adjustRating(delta);
         invalidateFighter(params.fighter_id, gangId);
-        await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase);
+        await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase, fighter.fighter_pet_id ?? null);
 
         // Log fighter status change
         if (willBeRetired) {
@@ -548,7 +549,7 @@ export async function editFighterStatus(params: EditFighterStatusParams): Promis
         };
         invalidateFighter(params.fighter_id, gangId);
         invalidateGangFinancials(gangId);
-        await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase);
+        await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase, fighter.fighter_pet_id ?? null);
 
         // Log fighter enslaved
         try {
@@ -631,7 +632,7 @@ export async function editFighterStatus(params: EditFighterStatusParams): Promis
         }
 
         invalidateFighter(params.fighter_id, gangId);
-        await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase);
+        await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase, fighter.fighter_pet_id ?? null);
 
         return {
           success: true,
@@ -750,7 +751,7 @@ export async function editFighterStatus(params: EditFighterStatusParams): Promis
           }
 
           invalidateFighter(params.fighter_id, gangId);
-          await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase);
+          await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase, fighter.fighter_pet_id ?? null);
           invalidateCampaign(campaignId);
           invalidateGangCampaignMembership(gangId);
 
@@ -785,7 +786,7 @@ export async function editFighterStatus(params: EditFighterStatusParams): Promis
           }
 
           invalidateFighter(params.fighter_id, gangId);
-          await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase);
+          await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase, fighter.fighter_pet_id ?? null);
 
           return {
             success: true,
@@ -817,7 +818,7 @@ export async function editFighterStatus(params: EditFighterStatusParams): Promis
         });
 
         invalidateFighter(params.fighter_id, gangId);
-        await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase);
+        await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase, fighter.fighter_pet_id ?? null);
 
         return {
           success: true,
@@ -920,7 +921,7 @@ export async function editFighterStatus(params: EditFighterStatusParams): Promis
         }
 
         invalidateFighter(params.fighter_id, gangId);
-        await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase);
+        await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase, fighter.fighter_pet_id ?? null);
         // The capturing gang's pages show this fighter as captured
         if (params.captured_by_gang_id) {
           invalidateGang(params.captured_by_gang_id);
@@ -1004,7 +1005,7 @@ export async function editFighterStatus(params: EditFighterStatusParams): Promis
         }
 
         invalidateFighter(params.fighter_id, gangId);
-        await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase);
+        await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase, fighter.fighter_pet_id ?? null);
         // The gang that held this fighter no longer shows it as captured
         if (fighter.captured_by_gang_id) {
           invalidateGang(fighter.captured_by_gang_id);
@@ -1124,7 +1125,7 @@ export async function editFighterStatus(params: EditFighterStatusParams): Promis
         invalidateFighter(params.fighter_id, gangId);
         invalidateGang(gangId);
         if (refundAmount) invalidateGangFinancials(gangId);
-        await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase);
+        await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase, fighter.fighter_pet_id ?? null);
 
         // If fighter had a vehicle, invalidate gang vehicles cache so it appears in unassigned list
         if (vehicleData?.id) {
@@ -1181,7 +1182,7 @@ export async function updateFighterXp(params: UpdateFighterXpParams): Promise<Ed
     // Get fighter data (RLS will handle permissions)
     const { data: fighter, error: fighterError } = await supabase
       .from('fighters')
-      .select('id, gang_id, xp, fighter_name')
+      .select('id, gang_id, xp, fighter_name, fighter_pet_id')
       .eq('id', params.fighter_id)
       .single();
 
@@ -1220,7 +1221,7 @@ export async function updateFighterXp(params: UpdateFighterXpParams): Promise<Ed
     // Invalidate cache - surgical XP-only invalidation
     revalidateTag(TAGS.fighter(params.fighter_id), { expire: 0 });
     invalidateGang(fighter.gang_id);
-    await invalidateBeastOwnerCache(params.fighter_id, fighter.gang_id, supabase);
+    await invalidateBeastOwnerCache(params.fighter_id, fighter.gang_id, supabase, fighter.fighter_pet_id ?? null);
 
     return {
       success: true,
@@ -1265,7 +1266,7 @@ export async function updateFighterXpWithOoa(params: UpdateFighterXpWithOoaParam
     // Get fighter data (RLS will handle permissions)
     const { data: fighter, error: fighterError } = await supabase
       .from('fighters')
-      .select('id, gang_id, xp, kills, kill_count, fighter_name, fighter_type, fighter_subtypes, fighter_type_id, fighter_types(is_spyrer), gangs!gang_id(name)')
+      .select('id, gang_id, xp, kills, kill_count, fighter_name, fighter_type, fighter_subtypes, fighter_type_id, fighter_pet_id, fighter_types(is_spyrer), gangs!gang_id(name)')
       .eq('id', params.fighter_id)
       .single();
 
@@ -1351,7 +1352,7 @@ export async function updateFighterXpWithOoa(params: UpdateFighterXpWithOoaParam
     if (params.ooa_count && params.ooa_count > 0) {
       invalidateGang(fighter.gang_id);
     }
-    await invalidateBeastOwnerCache(params.fighter_id, fighter.gang_id, supabase);
+    await invalidateBeastOwnerCache(params.fighter_id, fighter.gang_id, supabase, fighter.fighter_pet_id ?? null);
 
     return {
       success: true,
@@ -1382,7 +1383,7 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
     // Get fighter data (RLS will handle permissions)
     const { data: fighter, error: fighterError } = await supabase
       .from('fighters')
-      .select('id, gang_id, user_id, cost_adjustment, kills, kill_count, killed, retired, enslaved, captured, fighter_name, fighter_subtypes, selected_archetype_id')
+      .select('id, gang_id, user_id, cost_adjustment, kills, kill_count, killed, retired, enslaved, captured, fighter_name, fighter_subtypes, selected_archetype_id, fighter_pet_id')
       .eq('id', params.fighter_id)
       .single();
 
@@ -1805,7 +1806,7 @@ export async function updateFighterDetails(params: UpdateFighterDetailsParams): 
 
     // Invalidate cache (already handles BASE_FIGHTER_BASIC and COMPOSITE_GANG_FIGHTERS_LIST)
     invalidateFighter(params.fighter_id, fighter.gang_id);
-    await invalidateBeastOwnerCache(params.fighter_id, fighter.gang_id, supabase);
+    await invalidateBeastOwnerCache(params.fighter_id, fighter.gang_id, supabase, fighter.fighter_pet_id ?? null);
 
     // If fighter name changed, invalidate ownership info for any beasts owned by this fighter
     if (params.fighter_name !== undefined && params.fighter_name.trimEnd() !== fighter.fighter_name) {

--- a/app/actions/equipment.ts
+++ b/app/actions/equipment.ts
@@ -9,25 +9,12 @@ import { getFighterTotalCost } from '@/app/lib/shared/fighter-data';
 import { getAuthenticatedUser } from '@/utils/auth';
 import { countsTowardRating } from '@/utils/fighter-status';
 import { EquipmentGrants, ResourceCost, CostResourcePayload } from '@/types/equipment';
-import { createExoticBeastsForEquipment } from '@/utils/exotic-beasts';
+import { createExoticBeastsForEquipment, invalidateBeastOwnerCache } from '@/utils/exotic-beasts';
 import { syncSubtypeGrants } from '@/utils/fighter-subtype-grants';
 import { grantedSkillFromEffect } from '@/utils/effect-modifiers';
 import { clearHardpointReference } from './vehicle-hardpoints';
 import { deductGangResource, returnGangResource, parseTradePointsCost, REPUTATION_RESOURCE_NAME } from '@/utils/campaigns/resources';
 import { gangEditionSlug, hasMasterCraftedWeapons, hasTradePoints } from '@/types/edition';
-
-// Helper function to invalidate owner's cache when beast fighter is updated
-async function invalidateBeastOwnerCache(fighterId: string, gangId: string, supabase: any) {
-  const { data: ownerData } = await supabase
-    .from('fighter_exotic_beasts')
-    .select('fighter_owner_id')
-    .eq('fighter_pet_id', fighterId)
-    .single();
-
-  if (ownerData) {
-    invalidateFighter(ownerData.fighter_owner_id, gangId);
-  }
-}
 
 interface BuyEquipmentParams {
   equipment_id?: string;
@@ -338,7 +325,7 @@ export async function buyEquipmentForFighter(params: BuyEquipmentParams): Promis
 
     // PARALLEL: Gang info and vehicle data
     // Note: Authorization is enforced by RLS policies on fighter_equipment table
-    const [gangResult, vehicleResult] = await Promise.all([
+    const [gangResult, vehicleResult, fighterResult] = await Promise.all([
       // Gang info
       supabase
         .from('gangs')
@@ -357,6 +344,18 @@ export async function buyEquipmentForFighter(params: BuyEquipmentParams): Promis
             .select('fighter_id')
             .eq('id', params.vehicle_id)
             .single()
+        : Promise.resolve({ data: null }),
+
+      // Fighter row: fighter_name feeds beast creation, fighter_pet_id lets the
+      // owner-cache invalidation below skip its lookup for the 97% of fighters
+      // that are not pets. Fetched here so it overlaps the gang read instead of
+      // costing a serial round trip later.
+      params.fighter_id
+        ? supabase
+            .from('fighters')
+            .select('fighter_name, fighter_pet_id')
+            .eq('id', params.fighter_id)
+            .maybeSingle()
         : Promise.resolve({ data: null })
     ]);
 
@@ -367,6 +366,9 @@ export async function buyEquipmentForFighter(params: BuyEquipmentParams): Promis
 
     // Extract parallel query results
     const vehicleAssignedFighterId = vehicleResult.data?.fighter_id || null;
+    const fighterRow = fighterResult.data as { fighter_name?: string; fighter_pet_id?: string | null } | null;
+    /** null when the row says this fighter is not a pet; undefined when unknown. */
+    const fighterPetId = params.fighter_id ? fighterRow?.fighter_pet_id ?? null : undefined;
 
     // Get equipment details
     let equipmentDetails: any;
@@ -767,16 +769,8 @@ export async function buyEquipmentForFighter(params: BuyEquipmentParams): Promis
 
     await syncSubtypeGrants(supabase, params.fighter_id, { granted: appliedEffects });
 
-    // Get fighter name for beast creation (if applicable)
-    let fighterName: string | null = null;
-    if (params.fighter_id && !params.buy_for_gang_stash && !params.custom_equipment_id && params.equipment_id) {
-      const { data: fighterData } = await supabase
-        .from('fighters')
-        .select('fighter_name')
-        .eq('id', params.fighter_id)
-        .single();
-      fighterName = fighterData?.fighter_name || null;
-    }
+    // Name for beast creation — from the fighter row read in the opening batch.
+    const fighterName: string | null = fighterRow?.fighter_name ?? null;
 
     // Handle beast creation for fighter equipment purchases
     let createdBeasts: any[] = [];
@@ -930,7 +924,7 @@ export async function buyEquipmentForFighter(params: BuyEquipmentParams): Promis
         invalidateFighter(params.fighter_id, params.gang_id);
       }
       // If this fighter is a beast, invalidate the owner's cache
-      await invalidateBeastOwnerCache(params.fighter_id, params.gang_id, supabase);
+      await invalidateBeastOwnerCache(params.fighter_id, params.gang_id, supabase, fighterPetId);
     } else if (params.vehicle_id) {
       if (vehicleAssignedFighterId) {
         invalidateFighter(vehicleAssignedFighterId, params.gang_id); invalidateGangFinancials(params.gang_id);
@@ -1203,15 +1197,18 @@ export async function deleteEquipmentFromFighter(params: DeleteEquipmentParams):
     // BUT only if the fighter is active (not killed, retired, enslaved, or captured)
     // Inactive fighters are already excluded from rating calculations
     let ratingDelta = 0;
+    /** From the fighters row below; undefined means "unknown" and falls back to a lookup. */
+    let fighterPetId: string | null | undefined;
     if (equipmentBefore.fighter_id) {
       // Check if the fighter is active before applying rating delta
       const { data: fighter } = await supabase
         .from('fighters')
-        .select('killed, retired, enslaved, captured')
+        .select('killed, retired, enslaved, captured, fighter_pet_id')
         .eq('id', equipmentBefore.fighter_id)
         .single();
 
       const fighterIsActive = countsTowardRating(fighter);
+      fighterPetId = fighter?.fighter_pet_id ?? null;
 
       if (fighterIsActive) {
         ratingDelta -= (equipmentBefore.purchase_cost || 0);
@@ -1316,7 +1313,7 @@ export async function deleteEquipmentFromFighter(params: DeleteEquipmentParams):
     }
 
     // If this fighter is a beast, invalidate the owner's cache
-    await invalidateBeastOwnerCache(params.fighter_id, params.gang_id, supabase);
+    await invalidateBeastOwnerCache(params.fighter_id, params.gang_id, supabase, fighterPetId);
 
     return {
       success: true, 

--- a/app/actions/equipment.ts
+++ b/app/actions/equipment.ts
@@ -350,7 +350,7 @@ export async function buyEquipmentForFighter(params: BuyEquipmentParams): Promis
       // owner-cache invalidation below skip its lookup for the 97% of fighters
       // that are not pets. Fetched here so it overlaps the gang read instead of
       // costing a serial round trip later.
-      params.fighter_id
+      (params.fighter_id && !params.buy_for_gang_stash)
         ? supabase
             .from('fighters')
             .select('fighter_name, fighter_pet_id')
@@ -366,9 +366,15 @@ export async function buyEquipmentForFighter(params: BuyEquipmentParams): Promis
 
     // Extract parallel query results
     const vehicleAssignedFighterId = vehicleResult.data?.fighter_id || null;
-    const fighterRow = fighterResult.data as { fighter_name?: string; fighter_pet_id?: string | null } | null;
-    /** null when the row says this fighter is not a pet; undefined when unknown. */
-    const fighterPetId = params.fighter_id ? fighterRow?.fighter_pet_id ?? null : undefined;
+    // Shape must match the fighters select in the Promise.all above; the cast is
+    // unavoidable there, so keep the two in step by hand.
+    const fighterRow = fighterResult.data as { fighter_name: string | null; fighter_pet_id: string | null } | null;
+    /**
+     * null only when the row was actually read and says this fighter is not a
+     * pet. A missing/failed read stays undefined so the helper falls back to
+     * its own lookup rather than silently skipping the invalidation.
+     */
+    const fighterPetId = fighterRow ? fighterRow.fighter_pet_id ?? null : undefined;
 
     // Get equipment details
     let equipmentDetails: any;
@@ -1208,7 +1214,12 @@ export async function deleteEquipmentFromFighter(params: DeleteEquipmentParams):
         .single();
 
       const fighterIsActive = countsTowardRating(fighter);
-      fighterPetId = fighter?.fighter_pet_id ?? null;
+      // Only a hint when the row was read AND belongs to the fighter the
+      // invalidation below targets; otherwise leave undefined to force a lookup.
+      fighterPetId =
+        fighter && equipmentBefore.fighter_id === params.fighter_id
+          ? fighter.fighter_pet_id ?? null
+          : undefined;
 
       if (fighterIsActive) {
         ratingDelta -= (equipmentBefore.purchase_cost || 0);

--- a/app/actions/fighter-advancement.ts
+++ b/app/actions/fighter-advancement.ts
@@ -1,10 +1,9 @@
 'use server';
 
-import { TAGS, invalidateFighter, invalidateGangFinancials } from '@/utils/cache-tags';
+import { invalidateFighter, invalidateGangFinancials } from '@/utils/cache-tags';
 import { createClient } from '@/utils/supabase/server';
 
 import { getAuthenticatedUser } from '@/utils/auth';
-import { revalidateTag } from 'next/cache';
 import { updateGangRatingSimple, updateGangFinancials } from '@/utils/gang-rating-and-wealth';
 import { countsTowardRating } from '@/utils/fighter-status';
 import {
@@ -39,6 +38,7 @@ import {
 } from './logs/gang-fighter-logs';
 import type { GangLogActionResult } from './logs/gang-logs';
 import { updateFighterDetails } from './edit-fighter';
+import { invalidateBeastOwnerCache } from '@/utils/exotic-beasts';
 
 // A fighter's edition comes from its gang's (custom) gang type.
 const GANG_EDITION_EMBED = `
@@ -90,25 +90,6 @@ function advancementBlockedReason(
 interface PowerBoostTypeData {
   kill_cost?: number;
   credits_increase?: number;
-}
-
-// Helper function to invalidate owner's cache when beast fighter is updated
-async function invalidateBeastOwnerCache(fighterId: string, gangId: string, supabase: any) {
-  // Check if this fighter is an exotic beast owned by another fighter
-  const { data: ownerData } = await supabase
-    .from('fighter_exotic_beasts')
-    .select('fighter_owner_id')
-    .eq('fighter_pet_id', fighterId)
-    .single();
-
-  if (ownerData) {
-    // Invalidate the owner's cache since their total cost changed
-    invalidateFighter(ownerData.fighter_owner_id, gangId);
-
-    // Invalidate the owner's beast costs cache
-    // Without this, the owner's cost calculation uses stale beast data
-    revalidateTag(TAGS.fighter(ownerData.fighter_owner_id), { expire: 0 });
-  }
 }
 
 // Types for advancement operations

--- a/app/actions/fighter-advancement.ts
+++ b/app/actions/fighter-advancement.ts
@@ -51,7 +51,7 @@ const GANG_EDITION_EMBED = `
 // Whether an Advancement costs XP is edition-specific, so every action that
 // touches a fighter's XP balance loads the edition alongside the fighter.
 const FIGHTER_WITH_EDITION_SELECT = `
-  id, user_id, gang_id, xp, starting_xp, free_skill, fighter_name, killed, retired, enslaved, captured,
+  id, user_id, gang_id, xp, starting_xp, free_skill, fighter_name, killed, retired, enslaved, captured, fighter_pet_id,
   ${GANG_EDITION_EMBED}
 `;
 
@@ -330,7 +330,7 @@ export async function addCharacteristicAdvancement(
 
     
     // If this is a beast fighter, also invalidate owner's cache
-    await invalidateBeastOwnerCache(params.fighter_id, fighter.gang_id, supabase);
+    await invalidateBeastOwnerCache(params.fighter_id, fighter.gang_id, supabase, fighter.fighter_pet_id ?? null);
 
     // Log the characteristic advancement
     await logCharacteristicAdvancement({
@@ -595,7 +595,7 @@ async function addSkillAdvancementInternal(
     invalidateFighter(params.fighter_id, fighter.gang_id);
 
     // If this is a beast fighter, also invalidate owner's cache
-    await invalidateBeastOwnerCache(params.fighter_id, fighter.gang_id, supabase);
+    await invalidateBeastOwnerCache(params.fighter_id, fighter.gang_id, supabase, fighter.fighter_pet_id ?? null);
 
     // Get skill name for logging
     let skillName = 'Unknown Skill';
@@ -1582,7 +1582,7 @@ export async function deleteAdvancement(
     invalidateFighter(params.fighter_id, fighter.gang_id);
     
     // If this is a beast fighter, also invalidate owner's cache
-    await invalidateBeastOwnerCache(params.fighter_id, fighter.gang_id, supabase);
+    await invalidateBeastOwnerCache(params.fighter_id, fighter.gang_id, supabase, fighter.fighter_pet_id ?? null);
 
     let advancementName = deletedSkillName ? deletedSkillName : deletedEffectName
     // Log the advancement deletion
@@ -1641,7 +1641,7 @@ export async function addPowerBoost(
     // Verify fighter ownership and get fighter data
     const { data: fighter, error: fighterError} = await supabase
       .from('fighters')
-      .select('id, user_id, gang_id, kill_count, fighter_name, killed, retired, enslaved, captured')
+      .select('id, user_id, gang_id, kill_count, fighter_name, killed, retired, enslaved, captured, fighter_pet_id')
       .eq('id', params.fighter_id)
       .single();
 
@@ -1832,7 +1832,7 @@ export async function addPowerBoost(
     invalidateFighter(params.fighter_id, fighter.gang_id);
 
     // If this is a beast fighter, also invalidate owner's cache
-    await invalidateBeastOwnerCache(params.fighter_id, fighter.gang_id, supabase);
+    await invalidateBeastOwnerCache(params.fighter_id, fighter.gang_id, supabase, fighter.fighter_pet_id ?? null);
 
     // Invalidate cache for fighter advancement (effects for power boosts)
     invalidateFighter(params.fighter_id, fighter.gang_id);
@@ -1889,7 +1889,7 @@ export async function deletePowerBoost(
     // Verify fighter ownership
     const { data: fighter, error: fighterError } = await supabase
       .from('fighters')
-      .select('id, user_id, gang_id, kill_count, fighter_name, killed, retired, enslaved, captured')
+      .select('id, user_id, gang_id, kill_count, fighter_name, killed, retired, enslaved, captured, fighter_pet_id')
       .eq('id', params.fighter_id)
       .single();
 
@@ -1961,7 +1961,7 @@ export async function deletePowerBoost(
     invalidateFighter(params.fighter_id, fighter.gang_id);
 
     // If this is a beast fighter, also invalidate owner's cache
-    await invalidateBeastOwnerCache(params.fighter_id, fighter.gang_id, supabase);
+    await invalidateBeastOwnerCache(params.fighter_id, fighter.gang_id, supabase, fighter.fighter_pet_id ?? null);
 
     // Invalidate cache for fighter advancement
     invalidateFighter(params.fighter_id, fighter.gang_id);

--- a/app/actions/move-from-stash.ts
+++ b/app/actions/move-from-stash.ts
@@ -10,18 +10,7 @@ import { logEquipmentAction } from './logs/equipment-logs';
 import { insertEffectWithModifiers } from './equipment';
 import { syncSubtypeGrants } from '@/utils/fighter-subtype-grants';
 import { countsTowardRating } from '@/utils/fighter-status';
-
-async function invalidateBeastOwnerCache(fighterId: string, gangId: string, supabase: any) {
-  const { data: ownerData } = await supabase
-    .from('fighter_exotic_beasts')
-    .select('fighter_owner_id')
-    .eq('fighter_pet_id', fighterId)
-    .single();
-
-  if (ownerData) {
-    invalidateFighter(ownerData.fighter_owner_id, gangId);
-  }
-}
+import { invalidateBeastOwnerCache } from '@/utils/exotic-beasts';
 
 export interface MoveFromStashItem {
   stash_id: string;
@@ -108,17 +97,20 @@ export async function moveEquipmentFromStash(params: MoveFromStashParams): Promi
 
     // Validate target belongs to same gang (once)
     let fighterOwnerId: string | null = null;
+    /** From the fighters row below; undefined means "unknown" and falls back to a lookup. */
+    let fighterPetId: string | null | undefined;
 
     if (params.fighter_id) {
       const { data: fighter, error: fighterError } = await supabase
         .from('fighters')
-        .select('gang_id, user_id')
+        .select('gang_id, user_id, fighter_pet_id')
         .eq('id', params.fighter_id)
         .single();
 
       if (fighterError || !fighter) throw new Error('Fighter not found');
       if (fighter.gang_id !== gangId) throw new Error('Fighter does not belong to the same gang');
       fighterOwnerId = fighter.user_id;
+      fighterPetId = fighter.fighter_pet_id ?? null;
     } else if (params.vehicle_id) {
       const { data: vehicle, error: vehicleError } = await supabase
         .from('vehicles')
@@ -537,7 +529,7 @@ export async function moveEquipmentFromStash(params: MoveFromStashParams): Promi
       if (hasExoticBeastEquipment) {
         revalidateTag(TAGS.fighter(params.fighter_id), { expire: 0 });
       }
-      await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase);
+      await invalidateBeastOwnerCache(params.fighter_id, gangId, supabase, fighterPetId);
     }
 
     if (params.vehicle_id) {

--- a/app/actions/move-to-stash.ts
+++ b/app/actions/move-to-stash.ts
@@ -9,19 +9,7 @@ import { updateGangFinancials, GangFinancialUpdateResult } from '@/utils/gang-ra
 import { logEquipmentAction } from './logs/equipment-logs';
 import { countsTowardRating } from '@/utils/fighter-status';
 import { syncSubtypeGrants } from '@/utils/fighter-subtype-grants';
-
-// Helper function to invalidate owner's cache when beast fighter is updated
-async function invalidateBeastOwnerCache(fighterId: string, gangId: string, supabase: any) {
-  const { data: ownerData } = await supabase
-    .from('fighter_exotic_beasts')
-    .select('fighter_owner_id')
-    .eq('fighter_pet_id', fighterId)
-    .single();
-
-  if (ownerData) {
-    invalidateFighter(ownerData.fighter_owner_id, gangId);
-  }
-}
+import { invalidateBeastOwnerCache } from '@/utils/exotic-beasts';
 
 interface MoveToStashParams {
   fighter_equipment_id: string;
@@ -100,12 +88,14 @@ export async function moveEquipmentToStash(params: MoveToStashParams): Promise<M
     let gangOwnerUserId: string | null = null;
     let vehicleAssigned = false;
     let fighterIsActive = true; // Default to true for non-fighter equipment
+    /** From the fighters row below; undefined means "unknown" and falls back to a lookup. */
+    let fighterPetId: string | null | undefined;
     
     if (equipmentData.fighter_id) {
       // Get gang_id and status from fighter
       const { data: fighter, error: fighterError } = await supabase
         .from('fighters')
-        .select('gang_id, user_id, killed, retired, enslaved, captured, fighter_subtypes')
+        .select('gang_id, user_id, killed, retired, enslaved, captured, fighter_subtypes, fighter_pet_id')
         .eq('id', equipmentData.fighter_id)
         .single();
 
@@ -115,6 +105,7 @@ export async function moveEquipmentToStash(params: MoveToStashParams): Promise<M
       gangId = fighter.gang_id;
       gangOwnerUserId = fighter.user_id ?? null;
       fighterIsActive = countsTowardRating(fighter);
+      fighterPetId = fighter.fighter_pet_id ?? null;
 
       // Exotic beasts derive their rating contribution from the owner, not themselves.
       // Check the owner's active status instead.
@@ -298,7 +289,7 @@ export async function moveEquipmentToStash(params: MoveToStashParams): Promise<M
         revalidateTag(TAGS.fighter(equipmentData.fighter_id), { expire: 0 });
       }
       // If this fighter is a beast, invalidate the owner's cache
-      await invalidateBeastOwnerCache(equipmentData.fighter_id, gangId, supabase);
+      await invalidateBeastOwnerCache(equipmentData.fighter_id, gangId, supabase, fighterPetId);
     } else if (equipmentData.vehicle_id) {
       // For vehicle equipment, we need to get the fighter_id from the vehicle
       const { data: vehicleData, error: vehicleError } = await supabase

--- a/app/actions/sell-equipment.ts
+++ b/app/actions/sell-equipment.ts
@@ -12,19 +12,7 @@ import { updateGangFinancials } from '@/utils/gang-rating-and-wealth';
 import { clearHardpointReference } from './vehicle-hardpoints';
 import { returnCostResource } from '@/utils/campaigns/resources';
 import type { CostResourcePayload } from '@/types/equipment';
-
-// Helper function to invalidate owner's cache when beast fighter is updated
-async function invalidateBeastOwnerCache(fighterId: string, gangId: string, supabase: any) {
-  const { data: ownerData } = await supabase
-    .from('fighter_exotic_beasts')
-    .select('fighter_owner_id')
-    .eq('fighter_pet_id', fighterId)
-    .single();
-
-  if (ownerData) {
-    invalidateFighter(ownerData.fighter_owner_id, gangId);
-  }
-}
+import { invalidateBeastOwnerCache } from '@/utils/exotic-beasts';
 
 interface SellEquipmentParams {
   fighter_equipment_id: string;
@@ -94,12 +82,14 @@ export async function sellEquipmentFromFighter(params: SellEquipmentParams): Pro
     let gangOwnerUserId: string | null = null;
     let vehicleAssigned = false;
     let fighterIsActive = true; // Default to true for non-fighter equipment
+    /** From the fighters row below; undefined means "unknown" and falls back to a lookup. */
+    let fighterPetId: string | null | undefined;
     
     if (equipmentData.fighter_id) {
       // Get gang_id and status from fighter
       const { data: fighter, error: fighterError } = await supabase
         .from('fighters')
-        .select('gang_id, user_id, killed, retired, enslaved, captured, fighter_subtypes')
+        .select('gang_id, user_id, killed, retired, enslaved, captured, fighter_subtypes, fighter_pet_id')
         .eq('id', equipmentData.fighter_id)
         .single();
 
@@ -109,6 +99,7 @@ export async function sellEquipmentFromFighter(params: SellEquipmentParams): Pro
       gangId = fighter.gang_id;
       gangOwnerUserId = fighter.user_id ?? null;
       fighterIsActive = countsTowardRating(fighter);
+      fighterPetId = fighter.fighter_pet_id ?? null;
 
       // Exotic beasts derive their rating contribution from the owner, not themselves.
       // Check the owner's active status instead.
@@ -321,7 +312,7 @@ export async function sellEquipmentFromFighter(params: SellEquipmentParams): Pro
         revalidateTag(TAGS.fighter(equipmentData.fighter_id), { expire: 0 });
       }
       // If this fighter is a beast, invalidate the owner's cache
-      await invalidateBeastOwnerCache(equipmentData.fighter_id, gangId, supabase);
+      await invalidateBeastOwnerCache(equipmentData.fighter_id, gangId, supabase, fighterPetId);
     } else if (equipmentData.vehicle_id) {
       // For vehicle equipment, we need to get the fighter_id from the vehicle
       const { data: vehicleData, error: vehicleError } = await supabase

--- a/utils/exotic-beasts.ts
+++ b/utils/exotic-beasts.ts
@@ -25,13 +25,17 @@ export async function invalidateBeastOwnerCache(
 ) {
   if (fighterPetId === null) return;
 
-  const { data: ownerData } = await supabase
-    .from('fighter_exotic_beasts')
-    .select('fighter_owner_id')
-    .eq('fighter_pet_id', fighterId)
-    .maybeSingle();
+  // fighters.fighter_pet_id is the PK of the link row, so a supplied value is a
+  // direct primary-key read; without one, fall back to scanning by pet id.
+  const query = supabase.from('fighter_exotic_beasts').select('fighter_owner_id');
+  const { data: ownerData } = await (fighterPetId
+    ? query.eq('id', fighterPetId)
+    : query.eq('fighter_pet_id', fighterId)
+  ).maybeSingle();
 
-  if (ownerData) {
+  // fighter_owner_id is nullable: a beast created into the gang stash has no
+  // owner fighter, so there is nothing to invalidate.
+  if (ownerData?.fighter_owner_id) {
     invalidateFighter(ownerData.fighter_owner_id, gangId);
   }
 }

--- a/utils/exotic-beasts.ts
+++ b/utils/exotic-beasts.ts
@@ -1,6 +1,40 @@
-'use server'
+import 'server-only';
 
 import { createClient } from "@/utils/supabase/server";
+import { invalidateFighter } from '@/utils/cache-tags';
+
+/**
+ * A beast's cost rolls up into its owner, so changing a beast invalidates the
+ * OWNER's cached data, not just its own. Callers fire this after any mutation
+ * that could alter a beast's cost.
+ *
+ * Only 3% of fighters are beasts, so pass `fighterPetId` whenever the caller
+ * already holds the fighters row — `null` skips the lookup entirely. Omit it
+ * only when the row isn't at hand; the lookup then runs as before.
+ * (`fighters.fighter_pet_id` is a safe predicate: no fighter has a link row
+ * without it set.)
+ *
+ * maybeSingle() rather than single(), which would make PostgREST return
+ * PGRST116 for every ordinary fighter.
+ */
+export async function invalidateBeastOwnerCache(
+  fighterId: string,
+  gangId: string,
+  supabase: any,
+  fighterPetId?: string | null
+) {
+  if (fighterPetId === null) return;
+
+  const { data: ownerData } = await supabase
+    .from('fighter_exotic_beasts')
+    .select('fighter_owner_id')
+    .eq('fighter_pet_id', fighterId)
+    .maybeSingle();
+
+  if (ownerData) {
+    invalidateFighter(ownerData.fighter_owner_id, gangId);
+  }
+}
 
 export interface ExoticBeastCreationParams {
   equipmentId: string;
@@ -412,23 +446,3 @@ async function addDefaultSkillsToBeast(
     return [];
   }
 }
-
-/**
- * Checks if equipment can create exotic beasts
- */
-export async function canEquipmentCreateBeasts(equipmentId: string): Promise<boolean> {
-  try {
-    const supabase = await createClient();
-    
-    const { data: beastConfigs } = await supabase
-      .from('exotic_beasts')
-      .select('id')
-      .eq('equipment_id', equipmentId)
-      .limit(1);
-
-    return !!(beastConfigs && beastConfigs.length > 0);
-  } catch (error) {
-    console.error('Error checking if equipment can create beasts:', error);
-    return false;
-  }
-} 


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? -->

- A DRY consolidation (6 copies → 1, 'use server' removed, dead canEquipmentCreateBeasts deleted) and a latency fix (2 serial round trips → 0 on the buy path, 1 → 0 on four others).

## Type of change

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Schema / migration

## How I tested

<!-- What you tested before opening this PR. Example: Opened gang X → bought equipment → credits/rating updated -->

- Bought an Exotic Beast / Pet, checked the cost on the owner and the owner relation. Sold Exotic Beast equipment and cost on owner fighter is correct.

## Database

<!-- Delete this section if not applicable. Migrations are not auto-applied — a maintainer must apply them before this PR is merged. -->

- [ ] Migration added under `supabase/migrations/`
- [ ] RPC/SQL function changed: updated both `supabase/migrations/` and the matching file under `supabase/functions/`

### Migration status

<!-- Check one. Migrations are not auto-applied. -->

- [ ] Needs maintainer to apply the migration before merge
- [ ] Migration already applied

## Risk / rollout

<!-- e.g. Low / Medium — any deploy notes beyond database (env vars, feature flags, etc.). -->

- None
