### PR TITLE
Add promoted_from_prospects tracker column

### DIFF
--- a/app/actions/copy-fighter.ts
+++ b/app/actions/copy-fighter.ts
@@ -350,6 +350,7 @@ export async function copyFighter(params: CopyFighterParams): Promise<CopyFighte
       fighter_subtypes: sourceFighter.fighter_subtypes || [],
       fighter_specialisation: copySpecialisation.fighter_specialisation,
       fighter_specialisation_id: copySpecialisation.fighter_specialisation_id,
+      promoted_from_prospect: sourceFighter.promoted_from_prospect ?? false,
       fighter_variant: sourceFighter.fighter_variant,
       custom_fighter_type_id: sourceFighter.custom_fighter_type_id,
       fighter_gang_legacy_id: sourceFighter.fighter_gang_legacy_id,

--- a/app/actions/fighter-advancement.ts
+++ b/app/actions/fighter-advancement.ts
@@ -996,7 +996,7 @@ export async function applyN26ProspectPromotion(
       params.special_rules ??
       (Array.isArray(before.special_rules) ? before.special_rules : []);
 
-    return await applyKeepTypePromotionWithSkillGrant({
+    const promotionResult = await applyKeepTypePromotionWithSkillGrant({
       fighterId: params.fighter_id,
       before,
       newSubtypes,
@@ -1006,6 +1006,18 @@ export async function applyN26ProspectPromotion(
       skillId: skillResolved.skillId,
       creditsIncrease: N26_PROSPECT_PROMOTION_CREDITS,
     });
+
+    if (promotionResult.success) {
+      const { error: flagError } = await supabase
+        .from('fighters')
+        .update({ promoted_from_prospect: true })
+        .eq('id', params.fighter_id);
+      if (flagError) {
+        console.error('Failed to set promoted_from_prospect after Prospect promotion:', flagError);
+      }
+    }
+
+    return promotionResult;
   } catch (error) {
     console.error('Error applying N26 Prospect promotion:', error);
     return {
@@ -1455,6 +1467,15 @@ export async function deleteAdvancement(
                   ? 'Skill removed but Leader demotion failed — please restore Champion subtype in Edit Fighter.'
                   : 'Skill removed but Ganger demotion failed — please restore Ganger subtype in Edit Fighter.'),
           };
+        }
+        if (isProspectPromotionGrant) {
+          const { error: flagError } = await supabase
+            .from('fighters')
+            .update({ promoted_from_prospect: false })
+            .eq('id', params.fighter_id);
+          if (flagError) {
+            console.error('Failed to clear promoted_from_prospect on Prospect undo:', flagError);
+          }
         }
         demotedFighterDetails = {
           fighter_subtypes: demotedSubtypes,

--- a/app/actions/fighter-advancement.ts
+++ b/app/actions/fighter-advancement.ts
@@ -201,6 +201,7 @@ export interface AdvancementResult {
     fighter_specialisation: string | null;
     fighter_specialisation_id: string | null;
     special_rules: string[];
+    promoted_from_prospect?: boolean;
   };
   /** False when rating changed without a stash refund (e.g. Prospect promotion undo). */
   refund_stash?: boolean;
@@ -1233,7 +1234,8 @@ export async function deleteAdvancement(
       .select(`
         ${FIGHTER_WITH_EDITION_SELECT},
         fighter_subtypes, fighter_type, fighter_type_id,
-        fighter_specialisation, fighter_specialisation_id, special_rules
+        fighter_specialisation, fighter_specialisation_id, special_rules,
+        promoted_from_prospect
       `)
       .eq('id', params.fighter_id)
       .single();
@@ -1486,6 +1488,9 @@ export async function deleteAdvancement(
             ? null
             : (fighter.fighter_specialisation_id ?? null),
           special_rules: specialRules,
+          promoted_from_prospect: isProspectPromotionGrant
+            ? false
+            : (fighter.promoted_from_prospect ?? false),
         };
       }
 

--- a/app/lib/shared/fighter-data.ts
+++ b/app/lib/shared/fighter-data.ts
@@ -47,6 +47,7 @@ export interface FighterBasic {
     name?: string;
   } | null;
   fighter_specialisation_id?: string;
+  promoted_from_prospect?: boolean;
   fighter_variant?: string | null;
   killed?: boolean;
   starved?: boolean;
@@ -124,6 +125,7 @@ export const getFighterBasic = async (fighterId: string, supabase: any): Promise
             name
           ),
           fighter_specialisation_id,
+          promoted_from_prospect,
           fighter_variant,
           killed,
           starved,
@@ -156,7 +158,7 @@ export const getFighterBasic = async (fighterId: string, supabase: any): Promise
       }
       return data;
     },
-    [`fighter-basic-v4-${fighterId}`],
+    [`fighter-basic-v5-${fighterId}`],
     {
       tags: [TAGS.fighter(fighterId)],
       revalidate: false

--- a/app/lib/shared/gang-data.ts
+++ b/app/lib/shared/gang-data.ts
@@ -834,6 +834,7 @@ export const getGangFightersBundle = async (gangId: string, supabase: any): Prom
               name
             ),
             fighter_specialisation_id,
+            promoted_from_prospect,
             fighter_variant,
             killed,
             starved,

--- a/components/fighter/edit-fighter/fighter-promotion-modal.tsx
+++ b/components/fighter/edit-fighter/fighter-promotion-modal.tsx
@@ -90,6 +90,7 @@ export type FighterPromotionResult = {
   /** N26 promotion recipes with skill grants. */
   kind?: 'n26_prospect' | 'n26_ganger_champion' | 'n26_champion_leader';
   credits_increase?: number;
+  promoted_from_prospect?: boolean;
 };
 
 function promotionSpecialisationFields(
@@ -327,6 +328,7 @@ export function FighterPromotionModal({
         fighter_specialisation: selectedSpecialisation.name,
         fighter_specialisation_id: selectedSpecialisation.id,
         credits_increase: N26_PROSPECT_PROMOTION_CREDITS,
+        promoted_from_prospect: true,
       });
       return;
     }

--- a/components/fighter/fighter-advancement-list.tsx
+++ b/components/fighter/fighter-advancement-list.tsx
@@ -80,6 +80,7 @@ interface AdvancementModalProps {
     fighter_specialisation?: string | null;
     fighter_specialisation_id?: string | null;
     special_rules?: string[];
+    promoted_from_prospect?: boolean;
   }) => void;
 }
 
@@ -212,6 +213,7 @@ interface AdvancementsListProps {
     fighter_specialisation?: string | null;
     fighter_specialisation_id?: string | null;
     special_rules?: string[];
+    promoted_from_prospect?: boolean;
   }) => void;
 }
 
@@ -3013,6 +3015,7 @@ export function AdvancementsList({
         fighter_type: fighterTypeName,
         fighter_type_id: fighterTypeId,
         special_rules: fighterSpecialRules,
+        promoted_from_prospect: promotedFromProspect,
         ...currentPromotionSpecialisation,
       };
       const previousSkills = { ...skills };

--- a/components/fighter/fighter-advancement-list.tsx
+++ b/components/fighter/fighter-advancement-list.tsx
@@ -204,6 +204,7 @@ interface AdvancementsListProps {
   fighterTypeName?: string;
   fighterTypeId?: string;
   fighterSpecialisationId?: string;
+  promotedFromProspect?: boolean;
   onFighterDetailsUpdate?: (patch: {
     fighter_subtypes?: string[];
     fighter_type?: string;
@@ -2909,6 +2910,7 @@ export function AdvancementsList({
   fighterTypeName = '',
   fighterTypeId = '',
   fighterSpecialisationId = '',
+  promotedFromProspect = false,
   onFighterDetailsUpdate
 }: AdvancementsListProps) {
   const [isAdvancementModalOpen, setIsAdvancementModalOpen] = useState(false);
@@ -3319,7 +3321,7 @@ export function AdvancementsList({
 
   const prospectPromotionConsumed = hasN26ProspectPromotionOccurred(
     editionSlug,
-    fighterSpecialisationId,
+    promotedFromProspect,
   );
 
   const openAdvancements = openAdvancementsFor(

--- a/components/fighter/fighter-page.tsx
+++ b/components/fighter/fighter-page.tsx
@@ -60,6 +60,7 @@ interface Fighter {
   };
   fighter_variant?: string | null;
   fighter_subtypes: string[];
+  promoted_from_prospect?: boolean;
   alliance_crew_name?: string;
   label?: string;
   credits: number;
@@ -624,7 +625,7 @@ export default function FighterPage({
             {
               prospectPromotionConsumed: hasN26ProspectPromotionOccurred(
                 editionSlug,
-                f.fighter_specialisation_id,
+                f.promoted_from_prospect,
               ),
             },
           )
@@ -936,6 +937,7 @@ export default function FighterPage({
             fighterTypeName={fighterData.fighter?.fighter_type?.fighter_type || ''}
             fighterTypeId={fighterData.fighter?.fighter_type?.fighter_type_id || ''}
             fighterSpecialisationId={fighterData.fighter?.fighter_specialisation?.fighter_specialisation_id || ''}
+            promotedFromProspect={fighterData.fighter?.promoted_from_prospect ?? false}
             onFighterDetailsUpdate={(patch) => {
               setFighterData((prev) => ({
                 ...prev,

--- a/components/fighter/fighter-page.tsx
+++ b/components/fighter/fighter-page.tsx
@@ -946,6 +946,7 @@ export default function FighterPage({
                       ...prev.fighter,
                       fighter_subtypes: patch.fighter_subtypes ?? prev.fighter.fighter_subtypes,
                       special_rules: patch.special_rules ?? prev.fighter.special_rules,
+                      promoted_from_prospect: patch.promoted_from_prospect ?? prev.fighter.promoted_from_prospect,
                       fighter_type:
                         patch.fighter_type !== undefined && patch.fighter_type_id !== undefined
                           ? {

--- a/components/fighter/fighter-skills-list.tsx
+++ b/components/fighter/fighter-skills-list.tsx
@@ -75,6 +75,7 @@ interface SkillsListProps {
     fighter_specialisation?: string | null;
     fighter_specialisation_id?: string | null;
     special_rules?: string[];
+    promoted_from_prospect?: boolean;
   }) => void;
 }
 
@@ -534,6 +535,7 @@ export function SkillsList({
           fighter_subtypes: buildN26ProspectDemotionSubtypes(fighterSubtypes),
           fighter_specialisation: null,
           fighter_specialisation_id: null,
+          promoted_from_prospect: false,
         });
       } else if (isGangerChampionPromotionGrant) {
         onFighterDetailsUpdate?.({

--- a/components/gang/fighter-card.tsx
+++ b/components/gang/fighter-card.tsx
@@ -137,6 +137,7 @@ const FighterCard = memo(function FighterCard({
   type,
   label,
   fighter_subtypes,
+  promoted_from_prospect,
   fighter_specialisation,
   fighter_variant,
   alliance_crew_name,
@@ -469,13 +470,10 @@ const FighterCard = memo(function FighterCard({
       xp,
       countAdvancementsTaken(effects, skills),
       {
-        prospectPromotionConsumed: hasN26ProspectPromotionOccurred(
-          edition_slug,
-          fighter_specialisation?.fighter_specialisation_id,
-        ),
+        prospectPromotionConsumed: hasN26ProspectPromotionOccurred(edition_slug, promoted_from_prospect),
       },
     ),
-    [edition_slug, starting_xp, xp, effects, skills, fighter_specialisation?.fighter_specialisation_id]
+    [edition_slug, starting_xp, xp, effects, skills, promoted_from_prospect]
   );
 
   // Determine a unique and valid id for the fighter card based on its status.

--- a/supabase/migrations/20260907120000_add_promoted_from_prospect.sql
+++ b/supabase/migrations/20260907120000_add_promoted_from_prospect.sql
@@ -1,0 +1,21 @@
+ALTER TABLE public.fighters
+  ADD COLUMN IF NOT EXISTS promoted_from_prospect BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN public.fighters.promoted_from_prospect IS
+  'True when the N26 Prospect→Ganger+Specialist promotion has been applied. Read by openAdvancementsFor to deduct one Advancement (the roll the promotion traded in). Written by applyN26ProspectPromotion, cleared by its undo path, preserved on copy.';
+
+UPDATE public.fighters f
+SET promoted_from_prospect = TRUE
+FROM public.fighter_types ft
+WHERE f.fighter_type_id = ft.id
+  AND ft.fighter_subtypes @> '["Prospect"]'::jsonb
+  AND f.fighter_specialisation_id IN (
+    'f16c7f9c-3fcc-4384-81c8-14a9e863dc28',
+    '71a99cf2-5a95-4328-b053-ece6cf70818f',
+    '6ba5f84f-1bba-4b33-9837-20750e272b7f',
+    '575d0857-1d6d-41f3-ae41-a2d529d648e2',
+    '1d32f47b-3788-4fc9-a80a-a20ed63e1601',
+    'f9a96b0e-ec6e-4888-b122-84d9d5b8f62a',
+    '83f5f0f8-43bc-4c2c-b1d0-e8a2e092e98c',
+    '5ca912ac-a74f-4320-a6b2-affb159b95ce'
+  );

--- a/supabase/schema/schema.public.sql
+++ b/supabase/schema/schema.public.sql
@@ -5716,6 +5716,7 @@ CREATE TABLE public.fighters (
     is_vehicle boolean DEFAULT false NOT NULL,
     starting_xp numeric,
     fighter_variant text,
+    promoted_from_prospect boolean DEFAULT false NOT NULL,
     CONSTRAINT fighters_label_check CHECK ((length(label) <= 5))
 );
 

--- a/types/fighter.ts
+++ b/types/fighter.ts
@@ -183,6 +183,7 @@ export interface FighterProps {
   captured_by_gang_name?: string;
   free_skill?: boolean;
   fighter_subtypes: string[];
+  promoted_from_prospect?: boolean;
   note?: string;
   effects: {
     injuries: FighterEffect[];

--- a/types/gang.ts
+++ b/types/gang.ts
@@ -148,6 +148,7 @@ export interface GangFighter {
   label?: string;
   fighter_type: string;
   fighter_subtypes: string[];
+  promoted_from_prospect?: boolean;
   fighter_specialisation?: {
     fighter_specialisation: string;
     fighter_specialisation_id: string;
@@ -226,6 +227,7 @@ export interface GangFighterIndexEntry {
   fighter_name: string;
   fighter_type: string;
   fighter_specialisation_id: string | null;
+  promoted_from_prospect: boolean;
   xp: number | null;
   starting_xp: number | null;
   advancements_taken: number;

--- a/utils/gang-assembly.ts
+++ b/utils/gang-assembly.ts
@@ -658,6 +658,7 @@ export function assembleGangFighters(
           label: fighter.label,
           fighter_type: fighter.fighter_type || fighterTypeInfo.fighter_type || 'Unknown',
           fighter_subtypes: fighter.fighter_subtypes || [],
+          promoted_from_prospect: fighter.promoted_from_prospect,
           fighter_specialisation: fighterSpecialisationInfo ? {
             fighter_specialisation: fighterSpecialisationInfo.specialisation_name,
             fighter_specialisation_id: fighterSpecialisationInfo.id
@@ -880,6 +881,7 @@ export function selectGangFighterIndex(bundle: GangFightersBundle): GangFighterI
     fighter_name: f.fighter_name,
     fighter_type: f.fighter_type,
     fighter_specialisation_id: f.fighter_specialisation_id ?? null,
+    promoted_from_prospect: f.promoted_from_prospect,
     xp: f.xp,
     starting_xp: f.starting_xp ?? null,
     advancements_taken: countAdvancementsTaken(

--- a/utils/keepTypePromotionN26.ts
+++ b/utils/keepTypePromotionN26.ts
@@ -45,28 +45,26 @@ export function shouldClearSpecialisationForSubtypes(
 }
 
 /**
- * True when the fighter went through the N26 Prospect promotion — signalled by
- * one of the eight Prospect specialisation ids being set on
- * fighters.fighter_specialisation_id. Those ids are only ever written by the
- * Prospect promotion action, are preserved across every downstream promotion
- * (keep-type Ganger→Champion, type-change Champion→Leader — the Leader recipe
- * keeps the Specialist subtype so the specialisation stays too), and are
- * cleared by the promotion-undo flow. Catalog subtypes are not a reliable
- * signal because Champion→Leader rewrites fighter_type_id.
+ * True when the fighter went through the N26 Prospect promotion, per the
+ * persisted `fighters.promoted_from_prospect` flag written by
+ * applyN26ProspectPromotion (and cleared by the undo path, preserved on copy).
  *
  * RAW, the 13-XP Advancement roll is what a Prospect trades in to become a
  * Ganger+Specialist; the roll itself remains a normal Advancement (a CGC
  * Initiate can spend it on a stat or skill instead). This helper is the signal
  * to deduct one from the fighter's available Advancements once the trade has
  * been made.
+ *
+ * We tried inferring provenance from the fighter's data (catalog subtypes,
+ * then specialisation id) — both false-positive on natively specialised
+ * fighter types, which share the same eight houseless specialisation ids the
+ * Prospect promotion assigns. Only the persisted flag is unambiguous.
  */
 export function hasN26ProspectPromotionOccurred(
   editionSlug?: string | null,
-  fighterSpecialisationId?: string | null
+  promotedFromProspect?: boolean | null
 ): boolean {
-  if (!hasProspectSpecialisationPromotion(editionSlug)) return false;
-  if (!fighterSpecialisationId) return false;
-  return N26_PROSPECT_SPECIALISATIONS.some((s) => s.id === fighterSpecialisationId);
+  return hasProspectSpecialisationPromotion(editionSlug) && Boolean(promotedFromProspect);
 }
 
 /** Catalog ids for the eight houseless specialisations offered on Prospect promotion. */


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? -->
Follow on PR from #2096 

Specialised fighters added to a gang, with a specialist UUID assigned nativity will bypass some of the new advancement deduction logic and cause them to not track their first advancement. To stop this from happening, we add a new `promoted_from_prospect` to track if the fighter has earned their UUID from a promotion or not, then we apply the appropriate logic.

Migration `20260907120000_add_promoted_from_prospect.sql` needs to be applied as part of the deploy. The column should exist in prod before the code that reads/writes it is live.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Schema / migration

## How I tested

<!-- What you tested before opening this PR. Example: Opened gang X → bought equipment → credits/rating updated -->

- [x] local dev


https://github.com/user-attachments/assets/bd82484e-99df-4cb5-b187-79d425c78aeb


https://github.com/user-attachments/assets/160466cc-e499-4ab1-a81a-8db404a62ec7



## Database

<!-- Delete this section if not applicable. Migrations are not auto-applied — a maintainer must apply them before this PR is merged. -->

- [x] Migration added under `supabase/migrations/`
- [ ] RPC/SQL function changed: updated both `supabase/migrations/` and the matching file under `supabase/functions/`

### Migration status

<!-- Check one. Migrations are not auto-applied. -->

- [x] Needs maintainer to apply the migration before merge
- [ ] Migration already applied

## Risk / rollout

<!-- e.g. Low / Medium — any deploy notes beyond database (env vars, feature flags, etc.). -->

- medium, new db column, migration
