### PR TITLE
Fix fighter_exotic_beasts RLS to derive write authority from gang ownership

### DIFF
--- a/supabase/migrations/20260907130000_fix_fighter_exotic_beasts_rls_policies.sql
+++ b/supabase/migrations/20260907130000_fix_fighter_exotic_beasts_rls_policies.sql
@@ -1,0 +1,87 @@
+-- Migration: derive fighter_exotic_beasts write authority from gang ownership
+--
+-- All three write policies derived authority from fighters.user_id:
+--
+--   fighter_owner_id IN (SELECT f.id FROM fighters f WHERE f.user_id = auth.uid())
+--
+-- That is wrong on two counts.
+--
+-- 1. No arbitrator branch. fighter_exotic_beasts was the only table in this
+--    family without one. An arbitrator acting on an ACCEPTED campaign gang
+--    could insert the fighter_equipment row and the beast's own fighters row,
+--    but not the link row joining them -- leaving a half-created beast and the
+--    error "Failed to create beast ownership record: new row violates
+--    row-level security policy for table fighter_exotic_beasts".
+--
+-- 2. fighters.user_id is a creator stamp (DEFAULT auth.uid()), not a statement
+--    of gang ownership. A fighter an arbitrator created inside a member's gang
+--    carries the arbitrator's id permanently, so the gang owner is then
+--    blocked from buying that fighter a beast. 28 fighters across 25 gangs
+--    currently have a user_id that differs from their gang's user_id, and
+--    almost all of them are beasts orphaned by exactly this failure.
+--
+-- A third case the old predicate could not express: fighter_owner_id is NULL
+-- between a gang-stash beast purchase and its assignment to a fighter
+-- (buyEquipmentForFighter passes ownerFighterId: null; moveEquipmentFromStash
+-- sets it later). NULL IN (...) yields NULL rather than TRUE, so the INSERT was
+-- refused outright, and the UPDATE's USING clause could never see the row in
+-- order to claim it.
+--
+-- The policies below derive authority from the gang on the granting
+-- fighter_equipment row instead, mirroring fighter_equipment's own policies.
+-- fighter_equipment_id is fixed for the life of a beast, so one predicate holds
+-- from purchase through assignment to deletion.
+--
+-- Not covered: two legacy rows have a NULL fighter_equipment_id (both already
+-- orphaned -- no matching fighter_equipment row exists). They are not writable
+-- under these policies and want a separate cleanup.
+--
+-- Idempotent: both the old and the new policy names are dropped IF EXISTS.
+
+-- ===========================================================================
+-- INSERT
+-- ===========================================================================
+
+DROP POLICY IF EXISTS "Users can only create their own fighter exotic beasts" ON public.fighter_exotic_beasts;
+DROP POLICY IF EXISTS "Users can create exotic beasts for their gang" ON public.fighter_exotic_beasts;
+CREATE POLICY "Users can create exotic beasts for their gang" ON public.fighter_exotic_beasts FOR INSERT TO authenticated WITH CHECK ((( SELECT private.is_admin() AS is_admin) OR (fighter_equipment_id IN ( SELECT fe.id
+   FROM (public.fighter_equipment fe
+     JOIN public.gangs g ON ((g.id = fe.gang_id)))
+  WHERE (g.user_id = ( SELECT auth.uid() AS uid)))) OR (fighter_equipment_id IN ( SELECT fe.id
+   FROM (public.fighter_equipment fe
+     JOIN public.campaign_gangs cg ON ((cg.gang_id = fe.gang_id)))
+  WHERE ((cg.status = 'ACCEPTED'::text) AND ( SELECT private.is_arb(cg.campaign_id) AS is_arb))))));
+
+-- ===========================================================================
+-- UPDATE
+-- ===========================================================================
+
+DROP POLICY IF EXISTS "Only fighter owner or admin can update exotic beasts" ON public.fighter_exotic_beasts;
+DROP POLICY IF EXISTS "Users can update exotic beasts in their gang" ON public.fighter_exotic_beasts;
+CREATE POLICY "Users can update exotic beasts in their gang" ON public.fighter_exotic_beasts FOR UPDATE TO authenticated USING ((( SELECT private.is_admin() AS is_admin) OR (fighter_equipment_id IN ( SELECT fe.id
+   FROM (public.fighter_equipment fe
+     JOIN public.gangs g ON ((g.id = fe.gang_id)))
+  WHERE (g.user_id = ( SELECT auth.uid() AS uid)))) OR (fighter_equipment_id IN ( SELECT fe.id
+   FROM (public.fighter_equipment fe
+     JOIN public.campaign_gangs cg ON ((cg.gang_id = fe.gang_id)))
+  WHERE ((cg.status = 'ACCEPTED'::text) AND ( SELECT private.is_arb(cg.campaign_id) AS is_arb)))))) WITH CHECK ((( SELECT private.is_admin() AS is_admin) OR (fighter_equipment_id IN ( SELECT fe.id
+   FROM (public.fighter_equipment fe
+     JOIN public.gangs g ON ((g.id = fe.gang_id)))
+  WHERE (g.user_id = ( SELECT auth.uid() AS uid)))) OR (fighter_equipment_id IN ( SELECT fe.id
+   FROM (public.fighter_equipment fe
+     JOIN public.campaign_gangs cg ON ((cg.gang_id = fe.gang_id)))
+  WHERE ((cg.status = 'ACCEPTED'::text) AND ( SELECT private.is_arb(cg.campaign_id) AS is_arb))))));
+
+-- ===========================================================================
+-- DELETE
+-- ===========================================================================
+
+DROP POLICY IF EXISTS "Only fighter owner or admin can delete exotic beasts" ON public.fighter_exotic_beasts;
+DROP POLICY IF EXISTS "Users can delete exotic beasts from their gang" ON public.fighter_exotic_beasts;
+CREATE POLICY "Users can delete exotic beasts from their gang" ON public.fighter_exotic_beasts FOR DELETE TO authenticated USING ((( SELECT private.is_admin() AS is_admin) OR (fighter_equipment_id IN ( SELECT fe.id
+   FROM (public.fighter_equipment fe
+     JOIN public.gangs g ON ((g.id = fe.gang_id)))
+  WHERE (g.user_id = ( SELECT auth.uid() AS uid)))) OR (fighter_equipment_id IN ( SELECT fe.id
+   FROM (public.fighter_equipment fe
+     JOIN public.campaign_gangs cg ON ((cg.gang_id = fe.gang_id)))
+  WHERE ((cg.status = 'ACCEPTED'::text) AND ( SELECT private.is_arb(cg.campaign_id) AS is_arb))))));

--- a/supabase/migrations/20260907130000_fix_fighter_exotic_beasts_rls_policies.sql
+++ b/supabase/migrations/20260907130000_fix_fighter_exotic_beasts_rls_policies.sql
@@ -1,46 +1,18 @@
--- Migration: derive fighter_exotic_beasts write authority from gang ownership
+-- Derive fighter_exotic_beasts write authority from gang ownership.
 --
--- All three write policies derived authority from fighters.user_id:
+-- All three write policies keyed off fighters.user_id via fighter_owner_id.
+-- That has no arbitrator branch (the only table in this family without one),
+-- treats the fighters.user_id creator stamp as if it stated gang ownership, so
+-- a gang owner is locked out of any fighter an arbitrator created inside their
+-- gang, and cannot express a stash beast whose fighter_owner_id is still NULL
+-- (NULL IN (...) is NULL, not TRUE, so both the INSERT and the later claiming
+-- UPDATE were refused).
 --
---   fighter_owner_id IN (SELECT f.id FROM fighters f WHERE f.user_id = auth.uid())
---
--- That is wrong on two counts.
---
--- 1. No arbitrator branch. fighter_exotic_beasts was the only table in this
---    family without one. An arbitrator acting on an ACCEPTED campaign gang
---    could insert the fighter_equipment row and the beast's own fighters row,
---    but not the link row joining them -- leaving a half-created beast and the
---    error "Failed to create beast ownership record: new row violates
---    row-level security policy for table fighter_exotic_beasts".
---
--- 2. fighters.user_id is a creator stamp (DEFAULT auth.uid()), not a statement
---    of gang ownership. A fighter an arbitrator created inside a member's gang
---    carries the arbitrator's id permanently, so the gang owner is then
---    blocked from buying that fighter a beast. 28 fighters across 25 gangs
---    currently have a user_id that differs from their gang's user_id, and
---    almost all of them are beasts orphaned by exactly this failure.
---
--- A third case the old predicate could not express: fighter_owner_id is NULL
--- between a gang-stash beast purchase and its assignment to a fighter
--- (buyEquipmentForFighter passes ownerFighterId: null; moveEquipmentFromStash
--- sets it later). NULL IN (...) yields NULL rather than TRUE, so the INSERT was
--- refused outright, and the UPDATE's USING clause could never see the row in
--- order to claim it.
---
--- The policies below derive authority from the gang on the granting
--- fighter_equipment row instead, mirroring fighter_equipment's own policies.
--- fighter_equipment_id is fixed for the life of a beast, so one predicate holds
--- from purchase through assignment to deletion.
---
--- Not covered: two legacy rows have a NULL fighter_equipment_id (both already
--- orphaned -- no matching fighter_equipment row exists). They are not writable
--- under these policies and want a separate cleanup.
---
--- Idempotent: both the old and the new policy names are dropped IF EXISTS.
-
--- ===========================================================================
--- INSERT
--- ===========================================================================
+-- Key off the gang on the granting fighter_equipment row instead, mirroring
+-- fighter_equipment's own policies. fighter_equipment_id is fixed for the life
+-- of a beast, so one predicate holds from purchase through assignment to
+-- deletion. Two legacy rows with a NULL fighter_equipment_id stay unwritable;
+-- both are already orphaned and want a separate cleanup.
 
 DROP POLICY IF EXISTS "Users can only create their own fighter exotic beasts" ON public.fighter_exotic_beasts;
 DROP POLICY IF EXISTS "Users can create exotic beasts for their gang" ON public.fighter_exotic_beasts;
@@ -52,9 +24,6 @@ CREATE POLICY "Users can create exotic beasts for their gang" ON public.fighter_
      JOIN public.campaign_gangs cg ON ((cg.gang_id = fe.gang_id)))
   WHERE ((cg.status = 'ACCEPTED'::text) AND ( SELECT private.is_arb(cg.campaign_id) AS is_arb))))));
 
--- ===========================================================================
--- UPDATE
--- ===========================================================================
 
 DROP POLICY IF EXISTS "Only fighter owner or admin can update exotic beasts" ON public.fighter_exotic_beasts;
 DROP POLICY IF EXISTS "Users can update exotic beasts in their gang" ON public.fighter_exotic_beasts;
@@ -72,9 +41,6 @@ CREATE POLICY "Users can update exotic beasts in their gang" ON public.fighter_e
      JOIN public.campaign_gangs cg ON ((cg.gang_id = fe.gang_id)))
   WHERE ((cg.status = 'ACCEPTED'::text) AND ( SELECT private.is_arb(cg.campaign_id) AS is_arb))))));
 
--- ===========================================================================
--- DELETE
--- ===========================================================================
 
 DROP POLICY IF EXISTS "Only fighter owner or admin can delete exotic beasts" ON public.fighter_exotic_beasts;
 DROP POLICY IF EXISTS "Users can delete exotic beasts from their gang" ON public.fighter_exotic_beasts;


### PR DESCRIPTION
## Summary

All three write policies on `fighter_exotic_beasts` derived authority from `fighters.user_id`:

```sql
fighter_owner_id IN (SELECT f.id FROM fighters f WHERE f.user_id = auth.uid())
```

That is wrong on three counts:

- **No arbitrator branch.** `fighter_exotic_beasts` was the only table in this family without one. An arbitrator acting on an ACCEPTED campaign gang could insert the `fighter_equipment` row and the beast's own `fighters` row, but not the link row joining them — leaving a half-created beast and the error `Failed to create beast ownership record: new row violates row-level security policy for table fighter_exotic_beasts`.
- **`fighters.user_id` is a creator stamp** (`DEFAULT auth.uid()`), not a statement of gang ownership. A fighter an arbitrator created inside a member's gang carries the arbitrator's id permanently, so the gang owner is then blocked from buying that fighter a beast. 28 fighters across 25 gangs currently have a `user_id` that differs from their gang's `user_id`, and almost all of them are beasts orphaned by exactly this failure.
- **NULL `fighter_owner_id` could not be expressed.** Between a gang-stash beast purchase and its assignment to a fighter, `fighter_owner_id` is NULL (`buyEquipmentForFighter` passes `ownerFighterId: null`; `moveEquipmentFromStash` sets it later). `NULL IN (...)` yields NULL rather than TRUE, so the INSERT was refused outright, and the UPDATE's `USING` clause could never see the row in order to claim it.

The new policies derive authority from the gang on the granting `fighter_equipment` row instead, mirroring `fighter_equipment`'s own policies. `fighter_equipment_id` is fixed for the life of a beast, so one predicate holds from purchase through assignment to deletion.

Not covered: two legacy rows have a NULL `fighter_equipment_id` (both already orphaned — no matching `fighter_equipment` row exists). They are not writable under these policies and want a separate cleanup.

The migration is idempotent — both the old and the new policy names are dropped `IF EXISTS`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Schema / migration

## How I tested

- [x] Verified against the committed schema snapshot that the three existing policy names and their predicates are exactly the ones this migration replaces, and that the new predicates mirror `fighter_equipment`'s own INSERT/UPDATE/DELETE policies
- [ ] Not applied to any database from here — needs a maintainer to apply and exercise the arbitrator and stash-beast flows

## Database

- [x] Migration added under `supabase/migrations/` (`20260907130000_fix_fighter_exotic_beasts_rls_policies.sql`)
- [ ] RPC/SQL function changed: updated both `supabase/migrations/` and the matching file under `supabase/functions/` — n/a, policies only

### Migration status

- [x] Needs maintainer to apply the migration before merge
- [ ] Migration already applied

## Risk / rollout

- Low. Policy-only change on a single table; no schema, data, or application code touched. It widens write access strictly along the same lines `fighter_equipment` already grants (gang owner, or arbitrator on an ACCEPTED campaign gang), and narrows nothing that was legitimately permitted before. No env vars or feature flags.