### PR TITLE
Refac/added fighter type availability

### DIFF
--- a/app/api/fighter-types/route.ts
+++ b/app/api/fighter-types/route.ts
@@ -6,10 +6,14 @@ import { withEditionSlug } from '@/types/edition';
 
 type SupabaseServerClient = Awaited<ReturnType<typeof createClient>>;
 
-const subtypeGangTypeName = (name: string) => `Subtype: ${name}`;
+type GangSubtype = { id: string; subtype: string; edition_id: string | null };
 
-// Keyed by name so a later edition's re-issue of the subtype inherits the rule.
-const subtypesWithoutLeaders = new Set(['secundan incursion']);
+// The gang properties fighter_type_availability scopes against.
+type GangScope = {
+  gangTypeId: string | null;
+  gangOriginId: string | null;
+  gangSubtypes: GangSubtype[];
+};
 
 // Fetch the user's own custom fighters plus any shared with them through campaigns,
 // de-duplicated by id.
@@ -232,6 +236,122 @@ function mergeById(existing: any[], extra: any[]) {
   return [...existing, ...extra.filter((row: any) => !seen.has(row.id))];
 }
 
+/**
+ * Applies fighter_type_availability to the gang's own pool: denies first, then grants.
+ *
+ * Order is load-bearing. Secundan Incursion denies 'Leader' and grants four Spyre Hunters that
+ * are themselves ["Leader"], so a deny evaluated over the appended grants would leave those
+ * gangs with no addable leader at all. Denies only ever narrow the gang type's own fighters;
+ * grants only ever add.
+ */
+async function applyAvailabilityRules(
+  supabase: SupabaseServerClient,
+  rows: any[],
+  scope: GangScope
+) {
+  const subtypeIds = scope.gangSubtypes.map(subtype => subtype.id);
+
+  // Fetch anything matching on at least one axis; the conjunction below does the real filtering.
+  const axisMatches = [
+    subtypeIds.length > 0 ? `gang_subtype_id.in.(${subtypeIds.join(',')})` : null,
+    scope.gangOriginId ? `gang_origin_id.eq.${scope.gangOriginId}` : null,
+    scope.gangTypeId ? `gang_type_id.eq.${scope.gangTypeId}` : null,
+  ].filter((clause): clause is string => clause !== null);
+
+  if (axisMatches.length === 0) return rows;
+
+  const { data: candidates, error } = await supabase
+    .from('fighter_type_availability')
+    .select('fighter_type_id, fighter_subtype, gang_type_id, gang_origin_id, gang_subtype_id, excluded')
+    .or(axisMatches.join(','));
+
+  // Returning the rows unfiltered is the safer degradation — it offers too many fighters rather
+  // than hiding a gang's roster — but it is indistinguishable from a gang with no rules, so say so.
+  if (error) {
+    console.error('Error fetching fighter type availability:', error);
+    return rows;
+  }
+
+  // Every non-NULL axis must match: the JS twin of the (X IS NULL OR X = ...) conjunction
+  // get_equipment_detailed_data.sql uses for the same three axes.
+  const held = new Set(subtypeIds);
+  const rules = (candidates ?? []).filter((rule: any) =>
+    (rule.gang_subtype_id === null || held.has(rule.gang_subtype_id)) &&
+    (rule.gang_origin_id === null || rule.gang_origin_id === scope.gangOriginId) &&
+    (rule.gang_type_id === null || rule.gang_type_id === scope.gangTypeId)
+  );
+
+  if (rules.length === 0) return rows;
+
+  const denies = rules.filter((rule: any) => rule.excluded);
+  const deniedIds = new Set(
+    denies.map((rule: any) => rule.fighter_type_id).filter((id: string | null): id is string => id !== null)
+  );
+  const deniedSubtypes = new Set(
+    denies.map((rule: any) => rule.fighter_subtype).filter((name: string | null): name is string => name !== null)
+  );
+
+  let result = rows.filter((type: any) =>
+    !deniedIds.has(type.id) &&
+    !((type.fighter_subtypes ?? []) as string[]).some(name => deniedSubtypes.has(name))
+  );
+
+  const grants = rules.filter((rule: any) => !rule.excluded);
+  const grantedIds = [...new Set<string>(grants.map((rule: any) => rule.fighter_type_id))];
+  if (grantedIds.length === 0) return result;
+
+  // A granted fighter still needs its adjusted cost, equipment and skills, so it comes back
+  // through the same RPC as the gang's own roster — reached by the fighter's own gang type
+  // rather than by the 'Subtype: <name>' string match this replaces.
+  const { data: granted, error: grantedError } = await supabase
+    .from('fighter_types')
+    .select('id, gang_type_id')
+    .in('id', grantedIds);
+
+  if (grantedError) {
+    console.error('Error resolving granted fighter types:', grantedError);
+    return result;
+  }
+
+  // Name the subtype that granted each fighter, so the UI still groups it as a subtype addition.
+  // A row scoped only by origin or gang type carries no subtype name and stays untagged.
+  const subtypeNameById = new Map(scope.gangSubtypes.map(subtype => [subtype.id, subtype.subtype]));
+  const grantedBy = new Map<string, string>();
+  for (const rule of grants) {
+    const name = rule.gang_subtype_id ? subtypeNameById.get(rule.gang_subtype_id) : undefined;
+    if (name && !grantedBy.has(rule.fighter_type_id)) grantedBy.set(rule.fighter_type_id, name);
+  }
+
+  const wanted = new Set(grantedIds);
+  const pools = new Set<string>((granted ?? []).map((row: any) => row.gang_type_id));
+
+  for (const poolGangTypeId of pools) {
+    const { data: poolRows, error: poolError } = await supabase.rpc('get_fighter_types_with_cost', {
+      p_gang_type_id: poolGangTypeId,
+      p_gang_affiliation_id: null,
+      p_is_gang_addition: false
+    });
+
+    if (poolError) {
+      console.error('Error fetching granted fighter pool:', poolError);
+      continue;
+    }
+
+    const additions = (poolRows ?? [])
+      .filter((type: any) => wanted.has(type.id))
+      .map((type: any) => {
+        const subtypeName = grantedBy.get(type.id);
+        return subtypeName
+          ? { ...type, is_gang_subtype: true, gang_subtype_name: subtypeName }
+          : type;
+      });
+
+    result = mergeById(result, additions);
+  }
+
+  return result;
+}
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const gangId = searchParams.get('gang_id');
@@ -360,14 +480,16 @@ export async function GET(request: Request) {
       data = result;
     }
 
-    // Fetch gang subtypes from the database
-    let gangSubtypes: Array<{id: string, subtype: string, edition_id: string | null}> = [];
+    // Fighter types this gang's scope grants or denies. Gang additions are out of scope: the
+    // generic Brutes and Hired Guns they return belong to no gang type in particular.
     if (!isGangAddition) {
+      let gangSubtypes: GangSubtype[] = [];
+      let gangOriginId: string | null = null;
+
       try {
-        // Get gang data including gang_subtypes
         const { data: gangData, error: gangError } = await supabase
           .from('gangs')
-          .select('gang_subtypes')
+          .select('gang_subtypes, gang_origin_id')
           .eq('id', gangId)
           .single();
 
@@ -376,8 +498,10 @@ export async function GET(request: Request) {
           throw gangError;
         }
 
+        gangOriginId = gangData.gang_origin_id ?? null;
+
         // If gang has subtypes, fetch the subtype details
-        if (gangData.gang_subtypes && Array.isArray(gangData.gang_subtypes) && gangData.gang_subtypes.length > 0) {
+        if (Array.isArray(gangData.gang_subtypes) && gangData.gang_subtypes.length > 0) {
           const { data: subtypeDetails, error: subtypeError } = await supabase
             .from('gang_subtype_types')
             .select('id, subtype, edition_id')
@@ -388,59 +512,19 @@ export async function GET(request: Request) {
             throw subtypeError;
           }
 
-          gangSubtypes = (subtypeDetails || []).map((row: { id: string; subtype: string; edition_id: string | null }) => ({
-            id: row.id,
-            subtype: row.subtype,
-            edition_id: row.edition_id,
-          }));
+          gangSubtypes = subtypeDetails ?? [];
         }
       } catch (error) {
-        // Continue without subtypes rather than failing
+        // Continue without a scope rather than failing
         gangSubtypes = [];
+        gangOriginId = null;
       }
 
-      if (gangSubtypes.length > 0) {
-        // Match on edition too — "Malstrain Corrupted" exists in both N23 and N26.
-        const { data: subtypeGangTypes, error: subtypeGangTypesError } = await supabase
-          .from('gang_types')
-          .select('gang_type_id, gang_type, edition_id')
-          .in('gang_type', gangSubtypes.map(v => subtypeGangTypeName(v.subtype)));
-
-        // Falling through to "no subtype fighters" is a fine degradation, but a failure here
-        // looks identical to a subtype having no pool, so say so rather than vanish silently.
-        if (subtypeGangTypesError) {
-          console.error('Error fetching subtype gang types:', subtypeGangTypesError);
-        }
-
-        for (const subtype of gangSubtypes) {
-          if (subtypesWithoutLeaders.has(subtype.subtype.toLowerCase())) {
-            data = data.filter((type: any) => !(type.fighter_subtypes ?? []).includes('Leader'));
-          }
-
-          const subtypeGangTypeId = (subtypeGangTypes ?? []).find(gt =>
-            gt.gang_type === subtypeGangTypeName(subtype.subtype) &&
-            gt.edition_id === subtype.edition_id
-          )?.gang_type_id;
-          if (!subtypeGangTypeId) continue;
-
-          // Fetch subtype-specific fighter types and merge
-          const { data: subtypeData, error: subtypeError } = await supabase.rpc('get_fighter_types_with_cost', {
-            p_gang_type_id: subtypeGangTypeId,
-            p_gang_affiliation_id: null,
-            p_is_gang_addition: false
-          });
-          
-          if (!subtypeError && subtypeData) {
-            // Mark these as gang subtype fighter types
-            const markedSubtypeData = subtypeData.map((type: any) => ({
-              ...type,
-              is_gang_subtype: true,
-              gang_subtype_name: subtype.subtype
-            }));
-            data = [...data, ...markedSubtypeData];
-          }
-        }
-      }
+      data = await applyAvailabilityRules(supabase, data, {
+        gangTypeId,
+        gangOriginId,
+        gangSubtypes,
+      });
     }
 
     // Add custom fighter types if requested.

--- a/app/api/fighter-types/route.ts
+++ b/app/api/fighter-types/route.ts
@@ -6,15 +6,6 @@ import { withEditionSlug } from '@/types/edition';
 
 type SupabaseServerClient = Awaited<ReturnType<typeof createClient>>;
 
-type GangSubtype = { id: string; subtype: string; edition_id: string | null };
-
-// The gang properties fighter_type_availability scopes against.
-type GangScope = {
-  gangTypeId: string | null;
-  gangOriginId: string | null;
-  gangSubtypes: GangSubtype[];
-};
-
 // Fetch the user's own custom fighters plus any shared with them through campaigns,
 // de-duplicated by id.
 async function getCombinedCustomFighters(supabase: SupabaseServerClient, userId: string) {
@@ -236,122 +227,6 @@ function mergeById(existing: any[], extra: any[]) {
   return [...existing, ...extra.filter((row: any) => !seen.has(row.id))];
 }
 
-/**
- * Applies fighter_type_availability to the gang's own pool: denies first, then grants.
- *
- * Order is load-bearing. Secundan Incursion denies 'Leader' and grants four Spyre Hunters that
- * are themselves ["Leader"], so a deny evaluated over the appended grants would leave those
- * gangs with no addable leader at all. Denies only ever narrow the gang type's own fighters;
- * grants only ever add.
- */
-async function applyAvailabilityRules(
-  supabase: SupabaseServerClient,
-  rows: any[],
-  scope: GangScope
-) {
-  const subtypeIds = scope.gangSubtypes.map(subtype => subtype.id);
-
-  // Fetch anything matching on at least one axis; the conjunction below does the real filtering.
-  const axisMatches = [
-    subtypeIds.length > 0 ? `gang_subtype_id.in.(${subtypeIds.join(',')})` : null,
-    scope.gangOriginId ? `gang_origin_id.eq.${scope.gangOriginId}` : null,
-    scope.gangTypeId ? `gang_type_id.eq.${scope.gangTypeId}` : null,
-  ].filter((clause): clause is string => clause !== null);
-
-  if (axisMatches.length === 0) return rows;
-
-  const { data: candidates, error } = await supabase
-    .from('fighter_type_availability')
-    .select('fighter_type_id, fighter_subtype, gang_type_id, gang_origin_id, gang_subtype_id, excluded')
-    .or(axisMatches.join(','));
-
-  // Returning the rows unfiltered is the safer degradation — it offers too many fighters rather
-  // than hiding a gang's roster — but it is indistinguishable from a gang with no rules, so say so.
-  if (error) {
-    console.error('Error fetching fighter type availability:', error);
-    return rows;
-  }
-
-  // Every non-NULL axis must match: the JS twin of the (X IS NULL OR X = ...) conjunction
-  // get_equipment_detailed_data.sql uses for the same three axes.
-  const held = new Set(subtypeIds);
-  const rules = (candidates ?? []).filter((rule: any) =>
-    (rule.gang_subtype_id === null || held.has(rule.gang_subtype_id)) &&
-    (rule.gang_origin_id === null || rule.gang_origin_id === scope.gangOriginId) &&
-    (rule.gang_type_id === null || rule.gang_type_id === scope.gangTypeId)
-  );
-
-  if (rules.length === 0) return rows;
-
-  const denies = rules.filter((rule: any) => rule.excluded);
-  const deniedIds = new Set(
-    denies.map((rule: any) => rule.fighter_type_id).filter((id: string | null): id is string => id !== null)
-  );
-  const deniedSubtypes = new Set(
-    denies.map((rule: any) => rule.fighter_subtype).filter((name: string | null): name is string => name !== null)
-  );
-
-  let result = rows.filter((type: any) =>
-    !deniedIds.has(type.id) &&
-    !((type.fighter_subtypes ?? []) as string[]).some(name => deniedSubtypes.has(name))
-  );
-
-  const grants = rules.filter((rule: any) => !rule.excluded);
-  const grantedIds = [...new Set<string>(grants.map((rule: any) => rule.fighter_type_id))];
-  if (grantedIds.length === 0) return result;
-
-  // A granted fighter still needs its adjusted cost, equipment and skills, so it comes back
-  // through the same RPC as the gang's own roster — reached by the fighter's own gang type
-  // rather than by the 'Subtype: <name>' string match this replaces.
-  const { data: granted, error: grantedError } = await supabase
-    .from('fighter_types')
-    .select('id, gang_type_id')
-    .in('id', grantedIds);
-
-  if (grantedError) {
-    console.error('Error resolving granted fighter types:', grantedError);
-    return result;
-  }
-
-  // Name the subtype that granted each fighter, so the UI still groups it as a subtype addition.
-  // A row scoped only by origin or gang type carries no subtype name and stays untagged.
-  const subtypeNameById = new Map(scope.gangSubtypes.map(subtype => [subtype.id, subtype.subtype]));
-  const grantedBy = new Map<string, string>();
-  for (const rule of grants) {
-    const name = rule.gang_subtype_id ? subtypeNameById.get(rule.gang_subtype_id) : undefined;
-    if (name && !grantedBy.has(rule.fighter_type_id)) grantedBy.set(rule.fighter_type_id, name);
-  }
-
-  const wanted = new Set(grantedIds);
-  const pools = new Set<string>((granted ?? []).map((row: any) => row.gang_type_id));
-
-  for (const poolGangTypeId of pools) {
-    const { data: poolRows, error: poolError } = await supabase.rpc('get_fighter_types_with_cost', {
-      p_gang_type_id: poolGangTypeId,
-      p_gang_affiliation_id: null,
-      p_is_gang_addition: false
-    });
-
-    if (poolError) {
-      console.error('Error fetching granted fighter pool:', poolError);
-      continue;
-    }
-
-    const additions = (poolRows ?? [])
-      .filter((type: any) => wanted.has(type.id))
-      .map((type: any) => {
-        const subtypeName = grantedBy.get(type.id);
-        return subtypeName
-          ? { ...type, is_gang_subtype: true, gang_subtype_name: subtypeName }
-          : type;
-      });
-
-    result = mergeById(result, additions);
-  }
-
-  return result;
-}
-
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const gangId = searchParams.get('gang_id');
@@ -404,11 +279,14 @@ export async function GET(request: Request) {
     }
 
     if (includeAllTypes) {
-      // Fetch all fighter types across all gang types
+      // Fetch all fighter types across all gang types. p_gang_id still applies the gang's grants,
+      // which is what surfaces its subtype pools here; denies self-disable because they are
+      // anchored to p_gang_type_id, which is NULL on this path.
       const { data: result, error } = await supabase.rpc('get_fighter_types_with_cost', {
         p_gang_type_id: null,
         p_gang_affiliation_id: null,
-        p_is_gang_addition: null
+        p_is_gang_addition: null,
+        p_gang_id: gangId
       });
 
       if (error) {
@@ -431,7 +309,13 @@ export async function GET(request: Request) {
 
       if (hiddenGangTypes && hiddenGangTypes.length > 0) {
         const hiddenIds = new Set(hiddenGangTypes.map(gt => gt.gang_type_id));
-        data = data.filter((fighter: any) => !hiddenIds.has(fighter.gang_type_id));
+        // The 'Subtype: <name>' pools are hidden gang types, so a fighter this gang was granted
+        // has to survive this filter — it is in the list because a rule put it there, not because
+        // the catalogue offers it. Keyed on is_gang_subtype rather than "was granted" because a
+        // grant scoped only by origin or gang type has no business pointing into a hidden pool.
+        data = data.filter((fighter: any) =>
+          fighter.is_gang_subtype || !hiddenIds.has(fighter.gang_type_id)
+        );
       }
 
       // For a custom gang, keep its own custom fighters in the list alongside the
@@ -466,10 +350,13 @@ export async function GET(request: Request) {
       // Use the unified catalog function for regular (roster) fighters.
       // p_is_gang_addition=false reproduces the old get_add_fighter_details filter:
       // fighters of this gang type (incl. its gang-addition-flagged fighters).
+      // p_gang_id applies fighter_type_availability: grants pull in the gang's subtype pools,
+      // denies drop the gang type's own fighters the gang may not take.
       const { data: result, error } = await supabase.rpc('get_fighter_types_with_cost', {
         p_gang_type_id: gangTypeId,
         p_gang_affiliation_id: gangAffiliationId || null,
-        p_is_gang_addition: false
+        p_is_gang_addition: false,
+        p_gang_id: gangId
       });
 
       if (error) {
@@ -478,53 +365,6 @@ export async function GET(request: Request) {
       }
 
       data = result;
-    }
-
-    // Fighter types this gang's scope grants or denies. Gang additions are out of scope: the
-    // generic Brutes and Hired Guns they return belong to no gang type in particular.
-    if (!isGangAddition) {
-      let gangSubtypes: GangSubtype[] = [];
-      let gangOriginId: string | null = null;
-
-      try {
-        const { data: gangData, error: gangError } = await supabase
-          .from('gangs')
-          .select('gang_subtypes, gang_origin_id')
-          .eq('id', gangId)
-          .single();
-
-        if (gangError) {
-          console.error('Error fetching gang data:', gangError);
-          throw gangError;
-        }
-
-        gangOriginId = gangData.gang_origin_id ?? null;
-
-        // If gang has subtypes, fetch the subtype details
-        if (Array.isArray(gangData.gang_subtypes) && gangData.gang_subtypes.length > 0) {
-          const { data: subtypeDetails, error: subtypeError } = await supabase
-            .from('gang_subtype_types')
-            .select('id, subtype, edition_id')
-            .in('id', gangData.gang_subtypes);
-
-          if (subtypeError) {
-            console.error('Error fetching subtype details:', subtypeError);
-            throw subtypeError;
-          }
-
-          gangSubtypes = subtypeDetails ?? [];
-        }
-      } catch (error) {
-        // Continue without a scope rather than failing
-        gangSubtypes = [];
-        gangOriginId = null;
-      }
-
-      data = await applyAvailabilityRules(supabase, data, {
-        gangTypeId,
-        gangOriginId,
-        gangSubtypes,
-      });
     }
 
     // Add custom fighter types if requested.

--- a/app/api/fighter-types/route.ts
+++ b/app/api/fighter-types/route.ts
@@ -279,9 +279,8 @@ export async function GET(request: Request) {
     }
 
     if (includeAllTypes) {
-      // Fetch all fighter types across all gang types. p_gang_id still applies the gang's grants,
-      // which is what surfaces its subtype pools here; denies self-disable because they are
-      // anchored to p_gang_type_id, which is NULL on this path.
+      // Fetch all fighter types across all gang types. p_gang_id still applies this gang's rules,
+      // so its own denied fighters stay out even here.
       const { data: result, error } = await supabase.rpc('get_fighter_types_with_cost', {
         p_gang_type_id: null,
         p_gang_affiliation_id: null,
@@ -309,10 +308,8 @@ export async function GET(request: Request) {
 
       if (hiddenGangTypes && hiddenGangTypes.length > 0) {
         const hiddenIds = new Set(hiddenGangTypes.map(gt => gt.gang_type_id));
-        // The 'Subtype: <name>' pools are hidden gang types, so a fighter this gang was granted
-        // has to survive this filter — it is in the list because a rule put it there, not because
-        // the catalogue offers it. Keyed on is_gang_subtype rather than "was granted" because a
-        // grant scoped only by origin or gang type has no business pointing into a hidden pool.
+        // The 'Subtype: <name>' pools are themselves hidden gang types, so a granted fighter has
+        // to survive this filter — a rule put it in the list, not the catalogue.
         data = data.filter((fighter: any) =>
           fighter.is_gang_subtype || !hiddenIds.has(fighter.gang_type_id)
         );
@@ -350,8 +347,8 @@ export async function GET(request: Request) {
       // Use the unified catalog function for regular (roster) fighters.
       // p_is_gang_addition=false reproduces the old get_add_fighter_details filter:
       // fighters of this gang type (incl. its gang-addition-flagged fighters).
-      // p_gang_id applies fighter_type_availability: grants pull in the gang's subtype pools,
-      // denies drop the gang type's own fighters the gang may not take.
+      // p_gang_id applies fighter_type_availability: the gang's subtype pools in, its denied
+      // fighters out.
       const { data: result, error } = await supabase.rpc('get_fighter_types_with_cost', {
         p_gang_type_id: gangTypeId,
         p_gang_affiliation_id: gangAffiliationId || null,

--- a/app/api/fighter-types/route.ts
+++ b/app/api/fighter-types/route.ts
@@ -310,6 +310,9 @@ export async function GET(request: Request) {
         const hiddenIds = new Set(hiddenGangTypes.map(gt => gt.gang_type_id));
         // The 'Subtype: <name>' pools are themselves hidden gang types, so a granted fighter has
         // to survive this filter — a rule put it in the list, not the catalogue.
+        // Only subtype-scoped grants set is_gang_subtype, so an origin- or gang-type-scoped grant
+        // pointing into a hidden pool would still be dropped here. None exist yet; widening the
+        // flag is not the fix, since fighter-edit-modal renders gang_subtype_name off it.
         data = data.filter((fighter: any) =>
           fighter.is_gang_subtype || !hiddenIds.has(fighter.gang_type_id)
         );

--- a/components/admin/admin-edit-equipment.tsx
+++ b/components/admin/admin-edit-equipment.tsx
@@ -12,7 +12,7 @@ import { WeaponProfileInput, emptyWeaponProfile, EquipmentGrants, EquipmentAvail
 import { HiX } from "react-icons/hi";
 import { getFighterSubtypeSortRank } from "@/utils/fighterSubtypeRank";
 import { gangOriginRank } from "@/utils/gangOriginRank";
-import { gangSubtypeRank } from "@/utils/gangSubtypeRank";
+import { getGangSubtypeRank } from "@/utils/gangSubtypeRank";
 import { AdminFighterEffects } from "./admin-fighter-effects";
 import { EditionSelect, useEditions, editionSlugOf } from '@/components/edition-select';
 import { hasLethalityStatline, hasTradePoints } from '@/types/edition';
@@ -86,8 +86,17 @@ function GangOriginOptions({ origins }: { origins: GangOriginOption[] }) {
   );
 }
 
-/** Gang-subtype <option>s ordered by gangSubtypeRank. */
-function GangSubtypeOptions({ subtypes }: { subtypes: Array<{ id: string; subtype: string }> }) {
+/**
+ * Gang-subtype <option>s in the edition's own order. With no edition selected the list spans
+ * editions and ranks empty, leaving them unordered rather than in one edition's order.
+ */
+function GangSubtypeOptions(
+  { subtypes, editionSlug }: {
+    subtypes: Array<{ id: string; subtype: string }>;
+    editionSlug?: string | null;
+  }
+) {
+  const gangSubtypeRank = getGangSubtypeRank(editionSlug);
   return (
     <>
       {[...subtypes]
@@ -1733,7 +1742,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                                 className="w-full p-2 border rounded-md"
                               >
                                 <option key="default" value="">Select a Gang Subtype</option>
-                                <GangSubtypeOptions subtypes={filteredGangSubtypes} />
+                                <GangSubtypeOptions subtypes={filteredGangSubtypes} editionSlug={editionSlug} />
                               </select>
                             </div>
 
@@ -1925,7 +1934,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                             className="w-full p-2 border rounded-md"
                           >
                             <option key="default" value="">Any Gang Subtype</option>
-                            <GangSubtypeOptions subtypes={filteredGangSubtypes} />
+                            <GangSubtypeOptions subtypes={filteredGangSubtypes} editionSlug={editionSlug} />
                           </select>
                         </div>
                       </div>

--- a/components/create-gang-modal.tsx
+++ b/components/create-gang-modal.tsx
@@ -11,7 +11,7 @@ import { createClient } from "@/utils/supabase/client"
 import { SubmitButton } from "./submit-button"
 import { toast } from 'sonner';
 import { getGangListRank } from "@/utils/gangListRank"
-import { gangSubtypeRank } from "@/utils/gangSubtypeRank"
+import { getGangSubtypeRank } from "@/utils/gangSubtypeRank"
 import { gangVariantsFor, hasParentGangType } from "@/utils/gangTypeVariants"
 import { createGang } from "@/app/actions/create-gang"
 import { useRouter } from "next/navigation"
@@ -133,6 +133,8 @@ export function CreateGangModal({ onClose }: CreateGangModalProps) {
     () => availableSubtypes.filter(subtype => sameEditionForDisplay(subtype.edition_slug, editionSlug)),
     [availableSubtypes, editionSlug]
   );
+
+  const gangSubtypeRank = useMemo(() => getGangSubtypeRank(editionSlug), [editionSlug]);
 
   const selectedRootGangType = useMemo(
     () => editionGangTypes.find(type => type.gang_type_id === gangType),

--- a/components/gang/gang-edit-modal.tsx
+++ b/components/gang/gang-edit-modal.tsx
@@ -11,7 +11,7 @@ import Modal from '@/components/ui/modal';
 import { toast } from 'sonner';
 import { HexColorPicker } from "react-colorful";
 import { groupAlliancesByType } from "@/utils/allianceRank";
-import { gangSubtypeRank } from "@/utils/gangSubtypeRank";
+import { getGangSubtypeRank } from "@/utils/gangSubtypeRank";
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { deleteGang } from '@/app/actions/delete-gang';
 import { hasAlignment, sameEditionForDisplay } from '@/types/edition';
@@ -199,6 +199,7 @@ export default function GangEditModal({
     sameEditionForDisplay(subtype.edition_slug, editionSlug)
   );
   const showGangSubtypes = editionAvailableSubtypes.length > 0;
+  const gangSubtypeRank = getGangSubtypeRank(editionSlug);
   const showAlignment = hasAlignment(editionSlug);
   // Mirror admin fighter-type forms: clear alignment when the edition lacks it
   const effectiveAlignment = showAlignment ? alignment : '';

--- a/supabase/functions/get_fighter_types_with_cost.sql
+++ b/supabase/functions/get_fighter_types_with_cost.sql
@@ -1,8 +1,5 @@
--- Drop previous versions.
---
--- The 3-arg drop is load-bearing now that a 4-arg version exists: CREATE OR REPLACE with a new
--- arity creates an *overload* rather than replacing, and two candidates make the PostgREST call
--- ambiguous because every argument is defaulted.
+-- Drop previous versions. Every arg is defaulted, so leaving an older arity in place would make
+-- the PostgREST call ambiguous.
 DROP FUNCTION IF EXISTS get_fighter_types_with_cost(uuid, uuid, boolean, uuid);
 DROP FUNCTION IF EXISTS get_fighter_types_with_cost(uuid, uuid, boolean);
 DROP FUNCTION IF EXISTS get_fighter_types_with_cost(uuid, boolean);
@@ -14,9 +11,7 @@ CREATE OR REPLACE FUNCTION get_fighter_types_with_cost(
     p_gang_type_id uuid DEFAULT NULL,
     p_gang_affiliation_id uuid DEFAULT NULL,
     p_is_gang_addition boolean DEFAULT NULL,
-    -- Applies fighter_type_availability for this gang: grants pull fighters in from the hidden
-    -- 'Subtype: <name>' pools, denies remove the gang type's own. NULL skips availability
-    -- entirely, which is what the gang-addition and Available-to-All callers want.
+    -- Applies fighter_type_availability for this gang. NULL skips it entirely.
     p_gang_id uuid DEFAULT NULL
 )
 RETURNS TABLE (
@@ -57,8 +52,8 @@ RETURNS TABLE (
     edition_slug text,
     starting_xp numeric,
     is_vehicle boolean,
-    -- Set when a fighter_type_availability grant scoped by gang_subtype_id pulled this row in.
-    -- A grant scoped only by origin or gang type leaves both NULL/false.
+    -- Set when a grant scoped by gang_subtype_id pulled this row in; an origin- or
+    -- gang-type-scoped grant leaves both unset.
     is_gang_subtype boolean,
     gang_subtype_name text
 ) LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
@@ -69,17 +64,14 @@ DECLARE
     v_has_gang       boolean := false;
 BEGIN
     IF p_gang_id IS NOT NULL THEN
-        -- The gang's own gang type, not p_gang_type_id: the include-all caller passes NULL for
-        -- that, and a rule must still know which gang type it is dealing with.
+        -- The gang's own gang type, not p_gang_type_id, which the include-all caller passes NULL.
         SELECT g.gang_type_id, g.gang_origin_id, COALESCE(g.gang_subtypes, '[]'::jsonb)
           INTO v_gang_type_id, v_gang_origin_id, v_gang_subtypes
           FROM gangs g
          WHERE g.id = p_gang_id;
 
-        -- SELECT INTO sets every target to NULL when no row matches, discarding the '[]'
-        -- initialiser above. Left as NULL the jsonb ? test below yields NULL, which would skip
-        -- subtype and origin rules while gang-type-only rules still fired -- a half-applied
-        -- ruleset. An unknown gang must mean no rules at all.
+        -- SELECT INTO nulls every target when no row matches, discarding the '[]' initialiser;
+        -- a NULL there would skip subtype and origin rules while gang-type rules still fired.
         v_has_gang := FOUND;
         IF NOT v_has_gang THEN
             v_gang_subtypes := '[]'::jsonb;
@@ -88,12 +80,9 @@ BEGIN
 
     RETURN QUERY
     WITH rules AS (
-        -- Every non-NULL axis must match, mirroring the conjunction get_equipment_detailed_data
-        -- applies to equipment_availability and fighter_type_equipment.
+        -- Every non-NULL axis must match, as get_equipment_detailed_data does for its own tables.
         SELECT a.fighter_type_id, a.fighter_subtype, a.excluded, a.gang_subtype_id
         FROM fighter_type_availability a
-        -- Availability is opt-in per call site: no gang, no rules. Keeps the gang-addition and
-        -- Available-to-All callers byte-identical to the 3-arg function.
         WHERE v_has_gang
           AND (a.gang_subtype_id IS NULL OR v_gang_subtypes ? a.gang_subtype_id::text)
           AND (a.gang_origin_id  IS NULL OR a.gang_origin_id = v_gang_origin_id)
@@ -961,12 +950,8 @@ BEGIN
                 SELECT 1
                 FROM rules r
                 WHERE r.excluded
-                  -- A deny only ever removes the gang's OWN gang type's fighters. Without this
-                  -- anchor an include-all call would strip every matching fighter in the game,
-                  -- and a roster call would strip affiliation-granted ones that are not the
-                  -- gang's. Anchored to the gang's gang type rather than p_gang_type_id, which
-                  -- the include-all caller passes as NULL -- that would silently disable every
-                  -- deny on exactly the path where the fighter is still offered.
+                  -- A deny only removes the gang's own gang type's fighters; without the anchor
+                  -- an include-all call would strip every match in the game.
                   AND ft.gang_type_id = v_gang_type_id
                   AND (
                       r.fighter_type_id = ft.id
@@ -975,14 +960,12 @@ BEGIN
                   )
             )
         )
-        -- Grants reach into the hidden 'Subtype: <name>' pools, which the CASE above excludes.
-        -- Evaluated after the deny block, so a granted fighter is never removed by a deny.
+        -- Outside the parens so a grant survives a deny, and reaches the hidden 'Subtype: <name>'
+        -- pools the CASE above excludes.
         OR g.fighter_type_id IS NOT NULL;
 END;
 $$;
 
--- Signature must match the function created above: the 3-arg version is dropped, so naming it
--- here would abort the deploy with "function does not exist".
 REVOKE ALL ON FUNCTION public.get_fighter_types_with_cost(UUID, UUID, BOOLEAN, UUID) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION public.get_fighter_types_with_cost(UUID, UUID, BOOLEAN, UUID) FROM anon;
 GRANT EXECUTE ON FUNCTION public.get_fighter_types_with_cost(UUID, UUID, BOOLEAN, UUID) TO authenticated;

--- a/supabase/functions/get_fighter_types_with_cost.sql
+++ b/supabase/functions/get_fighter_types_with_cost.sql
@@ -1,4 +1,9 @@
--- Drop previous versions
+-- Drop previous versions.
+--
+-- The 3-arg drop is load-bearing now that a 4-arg version exists: CREATE OR REPLACE with a new
+-- arity creates an *overload* rather than replacing, and two candidates make the PostgREST call
+-- ambiguous because every argument is defaulted.
+DROP FUNCTION IF EXISTS get_fighter_types_with_cost(uuid, uuid, boolean, uuid);
 DROP FUNCTION IF EXISTS get_fighter_types_with_cost(uuid, uuid, boolean);
 DROP FUNCTION IF EXISTS get_fighter_types_with_cost(uuid, boolean);
 DROP FUNCTION IF EXISTS get_fighter_types_with_cost(uuid);
@@ -8,7 +13,11 @@ DROP FUNCTION IF EXISTS get_fighter_types_with_cost();
 CREATE OR REPLACE FUNCTION get_fighter_types_with_cost(
     p_gang_type_id uuid DEFAULT NULL,
     p_gang_affiliation_id uuid DEFAULT NULL,
-    p_is_gang_addition boolean DEFAULT NULL
+    p_is_gang_addition boolean DEFAULT NULL,
+    -- Applies fighter_type_availability for this gang: grants pull fighters in from the hidden
+    -- 'Subtype: <name>' pools, denies remove the gang type's own. NULL skips availability
+    -- entirely, which is what the gang-addition and Available-to-All callers want.
+    p_gang_id uuid DEFAULT NULL
 )
 RETURNS TABLE (
     id uuid,
@@ -47,10 +56,46 @@ RETURNS TABLE (
     is_dramatis_personae boolean,
     edition_slug text,
     starting_xp numeric,
-    is_vehicle boolean
+    is_vehicle boolean,
+    -- Set when a fighter_type_availability grant scoped by gang_subtype_id pulled this row in.
+    -- A grant scoped only by origin or gang type leaves both NULL/false.
+    is_gang_subtype boolean,
+    gang_subtype_name text
 ) LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+    v_gang_origin_id uuid;
+    v_gang_subtypes  jsonb := '[]'::jsonb;
 BEGIN
+    IF p_gang_id IS NOT NULL THEN
+        SELECT g.gang_origin_id, COALESCE(g.gang_subtypes, '[]'::jsonb)
+          INTO v_gang_origin_id, v_gang_subtypes
+          FROM gangs g
+         WHERE g.id = p_gang_id;
+    END IF;
+
     RETURN QUERY
+    WITH rules AS (
+        -- Every non-NULL axis must match, mirroring the conjunction get_equipment_detailed_data
+        -- applies to equipment_availability and fighter_type_equipment.
+        SELECT a.fighter_type_id, a.fighter_subtype, a.excluded, a.gang_subtype_id
+        FROM fighter_type_availability a
+        -- Availability is opt-in per call site: no gang, no rules. Keeps the gang-addition and
+        -- Available-to-All callers byte-identical to the 3-arg function.
+        WHERE p_gang_id IS NOT NULL
+          AND (a.gang_subtype_id IS NULL OR v_gang_subtypes ? a.gang_subtype_id::text)
+          AND (a.gang_origin_id  IS NULL OR a.gang_origin_id = v_gang_origin_id)
+          AND (a.gang_type_id    IS NULL OR a.gang_type_id  = p_gang_type_id)
+    ),
+    granted AS (
+        -- DISTINCT ON so two subtypes granting the same fighter yield one row, not a duplicate.
+        SELECT DISTINCT ON (r.fighter_type_id)
+               r.fighter_type_id,
+               gst.subtype AS subtype_name
+        FROM rules r
+        LEFT JOIN gang_subtype_types gst ON gst.id = r.gang_subtype_id
+        WHERE NOT r.excluded
+        ORDER BY r.fighter_type_id, gst.subtype NULLS LAST
+    )
     SELECT
         ft.id,
         ft.fighter_type,
@@ -872,33 +917,57 @@ BEGIN
         ft.is_dramatis_personae,
         ed.slug AS edition_slug,
         ft.starting_xp,
-        ft.is_vehicle
+        ft.is_vehicle,
+        (g.subtype_name IS NOT NULL) AS is_gang_subtype,
+        g.subtype_name AS gang_subtype_name
     FROM fighter_types ft
     LEFT JOIN fighter_type_gang_cost ftgc ON ftgc.fighter_type_id = ft.id
         AND ftgc.gang_type_id = p_gang_type_id
         AND (ftgc.gang_affiliation_id IS NULL OR ftgc.gang_affiliation_id = p_gang_affiliation_id)
     LEFT JOIN fighter_specialisations fspec ON fspec.id = ft.fighter_specialisation_id
     LEFT JOIN editions ed ON ed.id = ft.edition_id
+    LEFT JOIN granted g ON g.fighter_type_id = ft.id
     WHERE
-        CASE
-            -- Gang additions: cross-gang pool, filtered only by the flag
-            WHEN p_is_gang_addition = true THEN ft.is_gang_addition = true
-            -- Roster: fighters belonging to this gang type (plus affiliation-cost
-            -- overrides). Matches the previous get_add_fighter_details behaviour,
-            -- including this gang type's own gang-addition-flagged fighters.
-            WHEN p_is_gang_addition = false THEN (
-                ft.gang_type_id = p_gang_type_id
-                OR (ftgc.fighter_type_id IS NOT NULL
-                    AND ftgc.gang_affiliation_id IS NOT NULL
-                    AND ftgc.gang_affiliation_id = p_gang_affiliation_id)
+        (
+            CASE
+                -- Gang additions: cross-gang pool, filtered only by the flag
+                WHEN p_is_gang_addition = true THEN ft.is_gang_addition = true
+                -- Roster: fighters belonging to this gang type (plus affiliation-cost
+                -- overrides). Matches the previous get_add_fighter_details behaviour,
+                -- including this gang type's own gang-addition-flagged fighters.
+                WHEN p_is_gang_addition = false THEN (
+                    ft.gang_type_id = p_gang_type_id
+                    OR (ftgc.fighter_type_id IS NOT NULL
+                        AND ftgc.gang_affiliation_id IS NOT NULL
+                        AND ftgc.gang_affiliation_id = p_gang_affiliation_id)
+                )
+                -- Include-all (both params NULL): every fighter type
+                ELSE true
+            END
+            AND NOT EXISTS (
+                SELECT 1
+                FROM rules r
+                WHERE r.excluded
+                  -- A deny only ever removes the gang type's OWN fighters. Without this anchor
+                  -- an include-all call would strip every matching fighter in the game, and a
+                  -- roster call would strip affiliation-granted ones that are not the gang's.
+                  AND ft.gang_type_id = p_gang_type_id
+                  AND (
+                      r.fighter_type_id = ft.id
+                      OR (r.fighter_subtype IS NOT NULL
+                          AND ft.fighter_subtypes ? r.fighter_subtype)
+                  )
             )
-            -- Include-all (both params NULL): every fighter type
-            ELSE true
-        END;
+        )
+        -- Grants reach into the hidden 'Subtype: <name>' pools, which the CASE above excludes.
+        -- Evaluated after the deny block, so a granted fighter is never removed by a deny.
+        OR g.fighter_type_id IS NOT NULL;
 END;
 $$;
 
-REVOKE ALL ON FUNCTION public.get_fighter_types_with_cost(UUID, UUID, BOOLEAN) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION public.get_fighter_types_with_cost(UUID, UUID, BOOLEAN) FROM anon;
-GRANT EXECUTE ON FUNCTION public.get_fighter_types_with_cost(UUID, UUID, BOOLEAN) TO authenticated;
-GRANT EXECUTE ON FUNCTION public.get_fighter_types_with_cost(UUID, UUID, BOOLEAN) TO service_role;
+-- Signature must match the function created above: the 3-arg version is dropped, so naming it
+-- here would abort the deploy with "function does not exist".
+REVOKE ALL ON FUNCTION public.get_fighter_types_with_cost(UUID, UUID, BOOLEAN, UUID) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_fighter_types_with_cost(UUID, UUID, BOOLEAN, UUID) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_fighter_types_with_cost(UUID, UUID, BOOLEAN, UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_fighter_types_with_cost(UUID, UUID, BOOLEAN, UUID) TO service_role;

--- a/supabase/functions/get_fighter_types_with_cost.sql
+++ b/supabase/functions/get_fighter_types_with_cost.sql
@@ -63,14 +63,27 @@ RETURNS TABLE (
     gang_subtype_name text
 ) LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
 DECLARE
+    v_gang_type_id   uuid;
     v_gang_origin_id uuid;
     v_gang_subtypes  jsonb := '[]'::jsonb;
+    v_has_gang       boolean := false;
 BEGIN
     IF p_gang_id IS NOT NULL THEN
-        SELECT g.gang_origin_id, COALESCE(g.gang_subtypes, '[]'::jsonb)
-          INTO v_gang_origin_id, v_gang_subtypes
+        -- The gang's own gang type, not p_gang_type_id: the include-all caller passes NULL for
+        -- that, and a rule must still know which gang type it is dealing with.
+        SELECT g.gang_type_id, g.gang_origin_id, COALESCE(g.gang_subtypes, '[]'::jsonb)
+          INTO v_gang_type_id, v_gang_origin_id, v_gang_subtypes
           FROM gangs g
          WHERE g.id = p_gang_id;
+
+        -- SELECT INTO sets every target to NULL when no row matches, discarding the '[]'
+        -- initialiser above. Left as NULL the jsonb ? test below yields NULL, which would skip
+        -- subtype and origin rules while gang-type-only rules still fired -- a half-applied
+        -- ruleset. An unknown gang must mean no rules at all.
+        v_has_gang := FOUND;
+        IF NOT v_has_gang THEN
+            v_gang_subtypes := '[]'::jsonb;
+        END IF;
     END IF;
 
     RETURN QUERY
@@ -81,10 +94,10 @@ BEGIN
         FROM fighter_type_availability a
         -- Availability is opt-in per call site: no gang, no rules. Keeps the gang-addition and
         -- Available-to-All callers byte-identical to the 3-arg function.
-        WHERE p_gang_id IS NOT NULL
+        WHERE v_has_gang
           AND (a.gang_subtype_id IS NULL OR v_gang_subtypes ? a.gang_subtype_id::text)
           AND (a.gang_origin_id  IS NULL OR a.gang_origin_id = v_gang_origin_id)
-          AND (a.gang_type_id    IS NULL OR a.gang_type_id  = p_gang_type_id)
+          AND (a.gang_type_id    IS NULL OR a.gang_type_id  = v_gang_type_id)
     ),
     granted AS (
         -- DISTINCT ON so two subtypes granting the same fighter yield one row, not a duplicate.
@@ -948,10 +961,13 @@ BEGIN
                 SELECT 1
                 FROM rules r
                 WHERE r.excluded
-                  -- A deny only ever removes the gang type's OWN fighters. Without this anchor
-                  -- an include-all call would strip every matching fighter in the game, and a
-                  -- roster call would strip affiliation-granted ones that are not the gang's.
-                  AND ft.gang_type_id = p_gang_type_id
+                  -- A deny only ever removes the gang's OWN gang type's fighters. Without this
+                  -- anchor an include-all call would strip every matching fighter in the game,
+                  -- and a roster call would strip affiliation-granted ones that are not the
+                  -- gang's. Anchored to the gang's gang type rather than p_gang_type_id, which
+                  -- the include-all caller passes as NULL -- that would silently disable every
+                  -- deny on exactly the path where the fighter is still offered.
+                  AND ft.gang_type_id = v_gang_type_id
                   AND (
                       r.fighter_type_id = ft.id
                       OR (r.fighter_subtype IS NOT NULL

--- a/supabase/migrations/20260908120000_create_fighter_type_availability.sql
+++ b/supabase/migrations/20260908120000_create_fighter_type_availability.sql
@@ -1,0 +1,157 @@
+-- Fighter types granted or denied by a gang's scope.
+--
+-- The fighter-type counterpart of equipment_availability, carrying the same three gang-scope
+-- axes (gang_type_id / gang_origin_id / gang_subtype_id) plus fighter_type_equipment's
+-- grant/deny polarity. Per-column semantics are in the COMMENT ON COLUMN statements below.
+--
+-- Until now app/api/fighter-types/route.ts hardcoded both halves of this. Grants came from
+-- string-matching a hidden gang type named 'Subtype: <name>'; denies were a single literal set
+-- (`subtypesWithoutLeaders = new Set(['secundan incursion'])`). Neither could express the N26
+-- rule that a gang holding Malstrain Corrupted may not add its own gang type's Brutes, and the
+-- name-matching actively got in the way: 'Malstrain Corrupted' exists in both N23 and N26, but
+-- only the N26 gang loses its Brutes -- the N23 subtype pool is itself two Brutes. Keying on
+-- gang_subtype_types.id, which is per-edition, is what keeps those two apart.
+--
+-- excluded exists because scoping alone cannot take something away: a deny has to remove a
+-- fighter the base catalogue already offers, and adding more grants cannot subtract those.
+--
+-- Ordering matters and lives in the route, not here: denies apply to the gang type's own pool
+-- BEFORE grants are appended. Secundan Incursion denies 'Leader' and grants four Spyre Hunters
+-- that are themselves ["Leader"] -- a deny evaluated over the whole result would leave those
+-- gangs with no addable leader at all.
+
+CREATE TABLE public.fighter_type_availability (
+    id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    updated_at      timestamptz,
+
+    -- what the row acts on: exactly one of these
+    fighter_type_id uuid        REFERENCES public.fighter_types(id) ON DELETE CASCADE,
+    fighter_subtype text,
+
+    -- gang scope: every non-NULL axis must match, at least one must be set
+    gang_type_id    uuid        REFERENCES public.gang_types(gang_type_id) ON DELETE CASCADE,
+    gang_origin_id  uuid        REFERENCES public.gang_origins(id) ON DELETE CASCADE,
+    gang_subtype_id uuid        REFERENCES public.gang_subtype_types(id) ON DELETE CASCADE,
+
+    excluded        boolean     NOT NULL DEFAULT false,
+
+    CONSTRAINT fighter_type_availability_target_chk CHECK (
+        (fighter_type_id IS NOT NULL) <> (fighter_subtype IS NOT NULL)
+        AND (excluded OR fighter_type_id IS NOT NULL)
+    ),
+    CONSTRAINT fighter_type_availability_scope_chk CHECK (
+        num_nonnulls(gang_type_id, gang_origin_id, gang_subtype_id) >= 1
+    )
+);
+
+COMMENT ON COLUMN public.fighter_type_availability.fighter_type_id IS
+  'The fighter type this row acts on. With excluded=false it is granted to gangs matching the '
+  'scope; with excluded=true just this one is denied. Required for a grant -- "grant every '
+  'Brute" names no fighter to add -- which fighter_type_availability_target_chk enforces.';
+COMMENT ON COLUMN public.fighter_type_availability.fighter_subtype IS
+  'Deny-only alternative to fighter_type_id: every fighter carrying this subtype name, matched '
+  'against fighter_types.fighter_subtypes. A name rather than an FK because subtypes are stored '
+  'as names in jsonb arrays throughout; see 20260806120000. Mirrors '
+  'fighter_type_equipment.fighter_subtype.';
+COMMENT ON COLUMN public.fighter_type_availability.gang_type_id IS
+  'Restricts the row to gangs of this gang type. NULL applies regardless of gang type.';
+COMMENT ON COLUMN public.fighter_type_availability.gang_origin_id IS
+  'Restricts the row to gangs with this origin (gangs.gang_origin_id). NULL applies regardless '
+  'of origin.';
+COMMENT ON COLUMN public.fighter_type_availability.gang_subtype_id IS
+  'Restricts the row to gangs holding this subtype (gangs.gang_subtypes contains the id). '
+  'Per-edition by construction, so an N26 rule cannot reach the N23 re-issue of the same '
+  'subtype. NULL applies regardless of subtype.';
+COMMENT ON COLUMN public.fighter_type_availability.excluded IS
+  'false grants the fighter type to gangs matching this row''s scope; true denies it, removing '
+  'it from the gang type''s own pool even where the base catalogue offers it. A deny never '
+  'strips a fighter that a grant row supplied -- see the ordering note in the table comment.';
+COMMENT ON CONSTRAINT fighter_type_availability_scope_chk ON public.fighter_type_availability IS
+  'At least one scope axis must be set. An all-NULL scope would grant or deny a fighter type for '
+  'every gang in the game, which is a data-entry mistake rather than an intended rule.';
+
+-- One row per target/scope combination. NULLS NOT DISTINCT because the default would let two
+-- identical scopes both through, which is the duplicate this prevents. excluded is deliberately
+-- not in the key, so a grant and a deny for one scope collide and the contradictory pair cannot
+-- be stored -- same reasoning as fighter_type_equipment_fighter_scope_uidx.
+CREATE UNIQUE INDEX fighter_type_availability_scope_uidx
+    ON public.fighter_type_availability
+       (fighter_type_id, fighter_subtype, gang_type_id, gang_origin_id, gang_subtype_id)
+    NULLS NOT DISTINCT;
+
+-- The three gang-scope columns are what the route probes to find a gang's rules. No index on
+-- fighter_subtype: fighter_type_equipment has one because get_equipment_detailed_data joins on
+-- it, whereas here that column is only ever evaluated in the route.
+CREATE INDEX fighter_type_availability_fighter_type_id_idx
+    ON public.fighter_type_availability (fighter_type_id);
+CREATE INDEX fighter_type_availability_gang_type_id_idx
+    ON public.fighter_type_availability (gang_type_id);
+CREATE INDEX fighter_type_availability_gang_origin_id_idx
+    ON public.fighter_type_availability (gang_origin_id);
+CREATE INDEX fighter_type_availability_gang_subtype_id_idx
+    ON public.fighter_type_availability (gang_subtype_id);
+
+ALTER TABLE public.fighter_type_availability ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow authenticated users to view fighter_type_availability"
+    ON public.fighter_type_availability
+    FOR SELECT
+    TO authenticated
+    USING (true);
+
+CREATE POLICY fighter_type_availability_admin_insert_policy
+    ON public.fighter_type_availability
+    FOR INSERT
+    TO authenticated
+    WITH CHECK ((SELECT private.is_admin()));
+
+CREATE POLICY fighter_type_availability_admin_update_policy
+    ON public.fighter_type_availability
+    FOR UPDATE
+    TO authenticated
+    USING ((SELECT private.is_admin()))
+    WITH CHECK ((SELECT private.is_admin()));
+
+CREATE POLICY fighter_type_availability_admin_delete_policy
+    ON public.fighter_type_availability
+    FOR DELETE
+    TO authenticated
+    USING ((SELECT private.is_admin()));
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fighter_type_availability
+    TO authenticated, service_role;
+
+-- Seed the grants from the 'Subtype: <name>' pools the route matched by name until now, so
+-- behaviour is unchanged by this migration. Derived rather than written out as literals, so it
+-- stays honest about where the data came from: 30 rows across six subtypes today.
+--
+-- 'Subtype: Genestealer Corrupted' (N26) is deliberately not reached by this join -- the N26
+-- gang_subtype_types row is named 'Genestealer Infected', so the name convention never matched
+-- that pool either. Reviving it would hand those gangs fighters they do not currently get.
+INSERT INTO public.fighter_type_availability (fighter_type_id, gang_subtype_id, excluded)
+SELECT ft.id, gst.id, false
+FROM public.gang_subtype_types gst
+JOIN public.gang_types gt
+  ON gt.gang_type = ('Subtype: ' || gst.subtype)
+ AND gt.edition_id = gst.edition_id
+JOIN public.fighter_types ft ON ft.gang_type_id = gt.gang_type_id
+ON CONFLICT DO NOTHING;
+
+-- The denies. Resolved by subtype name + edition rather than by literal id: the same subtype
+-- name exists in both editions and the two ids are not guessable from the name.
+INSERT INTO public.fighter_type_availability (fighter_subtype, gang_subtype_id, excluded)
+SELECT v.fighter_subtype, gst.id, true
+FROM (VALUES
+    -- Migrated from the route's subtypesWithoutLeaders hardcode. The four Spyre Hunters granted
+    -- above replace the gang's own Leaders.
+    ('Secundan Incursion',  'n23', 'Leader'),
+    -- A gang holding Malstrain Corrupted may not add its own gang type's Brutes. N26 only: the
+    -- N23 Malstrain pool is itself two Brutes and is unaffected.
+    ('Malstrain Corrupted', 'n26', 'Brute')
+) AS v(subtype, edition_slug, fighter_subtype)
+JOIN public.editions e ON e.slug = v.edition_slug
+JOIN public.gang_subtype_types gst
+  ON gst.subtype = v.subtype
+ AND gst.edition_id = e.id
+ON CONFLICT DO NOTHING;

--- a/supabase/migrations/20260908120000_create_fighter_type_availability.sql
+++ b/supabase/migrations/20260908120000_create_fighter_type_availability.sql
@@ -2,23 +2,17 @@
 --
 -- The fighter-type counterpart of equipment_availability, carrying the same three gang-scope
 -- axes (gang_type_id / gang_origin_id / gang_subtype_id) plus fighter_type_equipment's
--- grant/deny polarity. Per-column semantics are in the COMMENT ON COLUMN statements below.
+-- grant/deny polarity. Replaces two hardcodes in app/api/fighter-types/route.ts: grants that
+-- string-matched a hidden gang type named 'Subtype: <name>', and a literal deny set.
 --
--- Until now app/api/fighter-types/route.ts hardcoded both halves of this. Grants came from
--- string-matching a hidden gang type named 'Subtype: <name>'; denies were a single literal set
--- (`subtypesWithoutLeaders = new Set(['secundan incursion'])`). Neither could express the N26
--- rule that a gang holding Malstrain Corrupted may not add its own gang type's Brutes, and the
--- name-matching actively got in the way: 'Malstrain Corrupted' exists in both N23 and N26, but
--- only the N26 gang loses its Brutes -- the N23 subtype pool is itself two Brutes. Keying on
--- gang_subtype_types.id, which is per-edition, is what keeps those two apart.
+-- Rows key on gang_subtype_types.id rather than the subtype name because the name is not unique
+-- across editions: 'Malstrain Corrupted' exists in both N23 and N26, and only the N26 gang loses
+-- its Brutes -- the N23 subtype pool is itself two Brutes.
 --
 -- excluded exists because scoping alone cannot take something away: a deny has to remove a
--- fighter the base catalogue already offers, and adding more grants cannot subtract those.
+-- fighter the base catalogue already offers, and adding grants cannot subtract those.
 --
--- Ordering matters and lives in the route, not here: denies apply to the gang type's own pool
--- BEFORE grants are appended. Secundan Incursion denies 'Leader' and grants four Spyre Hunters
--- that are themselves ["Leader"] -- a deny evaluated over the whole result would leave those
--- gangs with no addable leader at all.
+-- get_fighter_types_with_cost reads this table; see it for how grants and denies interact.
 
 CREATE TABLE public.fighter_type_availability (
     id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -46,14 +40,12 @@ CREATE TABLE public.fighter_type_availability (
 );
 
 COMMENT ON COLUMN public.fighter_type_availability.fighter_type_id IS
-  'The fighter type this row acts on. With excluded=false it is granted to gangs matching the '
-  'scope; with excluded=true just this one is denied. Required for a grant -- "grant every '
-  'Brute" names no fighter to add -- which fighter_type_availability_target_chk enforces.';
+  'The fighter type this row acts on. Required for a grant -- "grant every Brute" names no '
+  'fighter to add -- which fighter_type_availability_target_chk enforces.';
 COMMENT ON COLUMN public.fighter_type_availability.fighter_subtype IS
   'Deny-only alternative to fighter_type_id: every fighter carrying this subtype name, matched '
   'against fighter_types.fighter_subtypes. A name rather than an FK because subtypes are stored '
-  'as names in jsonb arrays throughout; see 20260806120000. Mirrors '
-  'fighter_type_equipment.fighter_subtype.';
+  'as names in jsonb arrays throughout; see 20260806120000.';
 COMMENT ON COLUMN public.fighter_type_availability.gang_type_id IS
   'Restricts the row to gangs of this gang type. NULL applies regardless of gang type.';
 COMMENT ON COLUMN public.fighter_type_availability.gang_origin_id IS
@@ -61,28 +53,25 @@ COMMENT ON COLUMN public.fighter_type_availability.gang_origin_id IS
   'of origin.';
 COMMENT ON COLUMN public.fighter_type_availability.gang_subtype_id IS
   'Restricts the row to gangs holding this subtype (gangs.gang_subtypes contains the id). '
-  'Per-edition by construction, so an N26 rule cannot reach the N23 re-issue of the same '
-  'subtype. NULL applies regardless of subtype.';
+  'Per-edition, so an N26 rule cannot reach the N23 re-issue of the same subtype. NULL applies '
+  'regardless of subtype.';
 COMMENT ON COLUMN public.fighter_type_availability.excluded IS
   'false grants the fighter type to gangs matching this row''s scope; true denies it, removing '
   'it from the gang type''s own pool even where the base catalogue offers it. A deny never '
-  'strips a fighter that a grant row supplied -- see the ordering note in the table comment.';
+  'strips a fighter that a grant supplied.';
 COMMENT ON CONSTRAINT fighter_type_availability_scope_chk ON public.fighter_type_availability IS
-  'At least one scope axis must be set. An all-NULL scope would grant or deny a fighter type for '
-  'every gang in the game, which is a data-entry mistake rather than an intended rule.';
+  'At least one scope axis must be set; an all-NULL scope would apply to every gang in the game.';
 
 -- One row per target/scope combination. NULLS NOT DISTINCT because the default would let two
--- identical scopes both through, which is the duplicate this prevents. excluded is deliberately
--- not in the key, so a grant and a deny for one scope collide and the contradictory pair cannot
--- be stored -- same reasoning as fighter_type_equipment_fighter_scope_uidx.
+-- identical scopes both through. excluded is deliberately not in the key, so a grant and a deny
+-- for one scope collide -- same reasoning as fighter_type_equipment_fighter_scope_uidx.
 CREATE UNIQUE INDEX fighter_type_availability_scope_uidx
     ON public.fighter_type_availability
        (fighter_type_id, fighter_subtype, gang_type_id, gang_origin_id, gang_subtype_id)
     NULLS NOT DISTINCT;
 
--- The three gang-scope columns are what the route probes to find a gang's rules. No index on
--- fighter_subtype: fighter_type_equipment has one because get_equipment_detailed_data joins on
--- it, whereas here that column is only ever evaluated in the route.
+-- The gang-scope columns are what get_fighter_types_with_cost filters on. No index on
+-- fighter_subtype: it is only tested against the handful of rows that survive that filter.
 CREATE INDEX fighter_type_availability_fighter_type_id_idx
     ON public.fighter_type_availability (fighter_type_id);
 CREATE INDEX fighter_type_availability_gang_type_id_idx
@@ -123,12 +112,11 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON public.fighter_type_availability
     TO authenticated, service_role;
 
 -- Seed the grants from the 'Subtype: <name>' pools the route matched by name until now, so
--- behaviour is unchanged by this migration. Derived rather than written out as literals, so it
--- stays honest about where the data came from: 30 rows across six subtypes today.
+-- behaviour is unchanged. Derived rather than literal: 30 rows across six subtypes today.
 --
--- 'Subtype: Genestealer Corrupted' (N26) is deliberately not reached by this join -- the N26
--- gang_subtype_types row is named 'Genestealer Infected', so the name convention never matched
--- that pool either. Reviving it would hand those gangs fighters they do not currently get.
+-- 'Subtype: Genestealer Corrupted' (N26) is deliberately not reached -- the N26 subtype row is
+-- named 'Genestealer Infected', so the name convention never matched that pool either, and
+-- reviving it would hand those gangs fighters they do not currently get.
 INSERT INTO public.fighter_type_availability (fighter_type_id, gang_subtype_id, excluded)
 SELECT ft.id, gst.id, false
 FROM public.gang_subtype_types gst
@@ -138,16 +126,14 @@ JOIN public.gang_types gt
 JOIN public.fighter_types ft ON ft.gang_type_id = gt.gang_type_id
 ON CONFLICT DO NOTHING;
 
--- The denies. Resolved by subtype name + edition rather than by literal id: the same subtype
--- name exists in both editions and the two ids are not guessable from the name.
+-- The denies. Resolved by subtype name + edition rather than by literal id, since the same
+-- subtype name exists in both editions and the ids are not guessable from the name.
 INSERT INTO public.fighter_type_availability (fighter_subtype, gang_subtype_id, excluded)
 SELECT v.fighter_subtype, gst.id, true
 FROM (VALUES
-    -- Migrated from the route's subtypesWithoutLeaders hardcode. The four Spyre Hunters granted
-    -- above replace the gang's own Leaders.
+    -- The four Spyre Hunters granted above replace the gang's own Leaders.
     ('Secundan Incursion',  'n23', 'Leader'),
-    -- A gang holding Malstrain Corrupted may not add its own gang type's Brutes. N26 only: the
-    -- N23 Malstrain pool is itself two Brutes and is unaffected.
+    -- N26 only: the N23 Malstrain pool is itself two Brutes and is unaffected.
     ('Malstrain Corrupted', 'n26', 'Brute')
 ) AS v(subtype, edition_slug, fighter_subtype)
 JOIN public.editions e ON e.slug = v.edition_slug

--- a/supabase/migrations/20260908120000_create_fighter_type_availability.sql
+++ b/supabase/migrations/20260908120000_create_fighter_type_availability.sql
@@ -112,11 +112,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON public.fighter_type_availability
     TO authenticated, service_role;
 
 -- Seed the grants from the 'Subtype: <name>' pools the route matched by name until now, so
--- behaviour is unchanged. Derived rather than literal: 30 rows across six subtypes today.
---
--- 'Subtype: Genestealer Corrupted' (N26) is deliberately not reached -- the N26 subtype row is
--- named 'Genestealer Infected', so the name convention never matched that pool either, and
--- reviving it would hand those gangs fighters they do not currently get.
+-- behaviour is unchanged. Derived rather than literal: 32 rows across seven subtypes today.
 INSERT INTO public.fighter_type_availability (fighter_type_id, gang_subtype_id, excluded)
 SELECT ft.id, gst.id, false
 FROM public.gang_subtype_types gst

--- a/supabase/migrations/20260908120000_create_fighter_type_availability.sql
+++ b/supabase/migrations/20260908120000_create_fighter_type_availability.sql
@@ -137,3 +137,42 @@ JOIN public.gang_subtype_types gst
   ON gst.subtype = v.subtype
  AND gst.edition_id = e.id
 ON CONFLICT DO NOTHING;
+
+-- Both seeds above match names as text, and both are ON CONFLICT DO NOTHING, so a rename makes
+-- them insert nothing and raise nothing -- the rule just quietly ceases to exist. That is not
+-- hypothetical: the N26 'Subtype: Genestealer Corrupted' pool sat unreachable for weeks because
+-- its catalog row was spelled 'Genestealer Infected'. Assert instead of trusting.
+DO $$
+DECLARE
+    v_denies       int;
+    v_orphan_pools text;
+BEGIN
+    SELECT count(*) INTO v_denies
+    FROM public.fighter_type_availability WHERE excluded;
+
+    IF v_denies <> 2 THEN
+        RAISE EXCEPTION
+            'fighter_type_availability: expected 2 deny rows, found %. A gang_subtype_types.subtype '
+            'rename breaks the literal join in the deny seed above.', v_denies;
+    END IF;
+
+    -- A populated 'Subtype: <name>' pool that pairs with no catalog row contributes no grants and
+    -- reports no error; its fighters simply never reach the gangs that should get them.
+    SELECT string_agg(gt.gang_type || ' (' || coalesce(e.slug, '?') || ')', ', ')
+      INTO v_orphan_pools
+    FROM public.gang_types gt
+    LEFT JOIN public.editions e ON e.id = gt.edition_id
+    WHERE gt.gang_type LIKE 'Subtype: %'
+      AND EXISTS (SELECT 1 FROM public.fighter_types ft WHERE ft.gang_type_id = gt.gang_type_id)
+      AND NOT EXISTS (
+          SELECT 1 FROM public.gang_subtype_types gst
+          WHERE ('Subtype: ' || gst.subtype) = gt.gang_type
+            AND gst.edition_id = gt.edition_id
+      );
+
+    IF v_orphan_pools IS NOT NULL THEN
+        RAISE EXCEPTION
+            'fighter_type_availability: fighter pool(s) with no matching gang subtype, whose '
+            'fighters would be silently ungranted: %', v_orphan_pools;
+    END IF;
+END $$;

--- a/utils/gangSubtypeRank.ts
+++ b/utils/gangSubtypeRank.ts
@@ -1,4 +1,8 @@
-export const gangSubtypeRank: { [key: string]: number } = {
+import type { EditionSlug } from '@/types/edition';
+
+// Ranks 1-9 are the "Unaffiliated" column, 10+ the "Outlaw / Corrupted" one; anything unranked is
+// hidden from both, which is how Outlaw stays out despite the gangs holding it.
+const gangSubtypeRankN23: { [key: string]: number } = {
   "aranthian-aligned": 1,
   "crusading": 2,
   "secundan incursion": 3,
@@ -10,3 +14,23 @@ export const gangSubtypeRank: { [key: string]: number } = {
   "genestealer infected": 13,
   "malstrain corrupted": 14,
 };
+
+// N26 renamed Genestealer Infected to Genestealer Corrupted, which is why these cannot share one
+// map with N23.
+const gangSubtypeRankN26: { [key: string]: number } = {
+  "chaos corrupted": 12,
+  "genestealer corrupted": 13,
+  "malstrain corrupted": 14,
+};
+
+// Keyed by EditionSlug so a new edition is a compile error until it states its own order.
+const GANG_SUBTYPE_RANK_BY_EDITION: Record<EditionSlug, { [key: string]: number }> = {
+  n23: gangSubtypeRankN23,
+  n26: gangSubtypeRankN26,
+};
+
+/** Unset or unrecognised slug gets no ranking rather than another edition's order. */
+export function getGangSubtypeRank(editionSlug?: string | null): { [key: string]: number } {
+  if (!editionSlug) return {};
+  return GANG_SUBTYPE_RANK_BY_EDITION[editionSlug as EditionSlug] ?? {};
+}


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? -->

- Added table fighter_type_availability to enable granting end excluding specific fighter types based on gang subtype (gang origin etc added as well for future support). No admin support atm, will be a follow up PR. Also backfills needed data as logic moved to db instead of in the api route.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [x] Schema / migration

## How I tested

<!-- What you tested before opening this PR. Example: Opened gang X → bought equipment → credits/rating updated -->

- Will be tested in preview

## Database

<!-- Delete this section if not applicable. Migrations are not auto-applied — a maintainer must apply them before this PR is merged. -->

- [x] Migration added under `supabase/migrations/`
- [x] RPC/SQL function changed: updated both `supabase/migrations/` and the matching file under `supabase/functions/`

### Migration status

<!-- Check one. Migrations are not auto-applied. -->

- [x] Needs maintainer to apply the migration before merge
- [ ] Migration already applied

## Risk / rollout

<!-- e.g. Low / Medium — any deploy notes beyond database (env vars, feature flags, etc.). -->

- None. New table, so production will not be affected by the migration or the RPC
