### PR TITLE
fix(equipment): stop writing null fighter_owner_id to fighter_exotic_beasts

### DIFF
--- a/app/actions/equipment.ts
+++ b/app/actions/equipment.ts
@@ -809,29 +809,6 @@ export async function buyEquipmentForFighter(params: BuyEquipmentParams): Promis
       }
     }
 
-    // Handle beast creation for STASH equipment purchases
-    if (params.buy_for_gang_stash && !params.custom_equipment_id && params.equipment_id) {
-      try {
-        const beastResult = await createExoticBeastsForEquipment({
-          equipmentId: params.equipment_id,
-          ownerFighterId: null,  // No owner for stash
-          ownerFighterName: null,
-          gangId: params.gang_id,
-          userId: gang.user_id,
-          fighterEquipmentId: newEquipmentId
-        });
-
-        if (beastResult.success && beastResult.createdBeasts.length > 0) {
-          createdBeasts = beastResult.createdBeasts;
-          // Note: Don't add to rating since equipment is in stash
-        }
-      } catch (error) {
-        // Clean up the stash equipment that was just inserted since the beast it grants failed to create
-        await supabase.from('gang_stash').delete().eq('id', newEquipmentId);
-        throw error;
-      }
-    }
-
     // Calculate deltas for gang updates
     const totalRatingDelta = ratingDelta + createdBeastsRatingDelta + grantsRatingDelta;
     const stashValueDelta = params.buy_for_gang_stash ? ratingCost : 0;

--- a/app/actions/move-to-stash.ts
+++ b/app/actions/move-to-stash.ts
@@ -233,13 +233,6 @@ export async function moveEquipmentToStash(params: MoveToStashParams): Promise<M
       }
     }
 
-    // Clear beast owner AFTER successful stash update (prevents data loss if stash update fails)
-    // Keep the fighter_exotic_beasts row (tracks beast_equipment_stashed via fighter_equipment.gang_stash)
-    await supabase
-      .from('fighter_exotic_beasts')
-      .update({ fighter_owner_id: null })
-      .eq('fighter_equipment_id', params.fighter_equipment_id);
-
     // Rating delta: subtract equipment purchase_cost, effects, and beast equipment cost
     // BUT only if the fighter is active (not killed, retired, enslaved, or captured)
     // Inactive fighters are already excluded from rating calculations

--- a/app/lib/shared/fighter-data.ts
+++ b/app/lib/shared/fighter-data.ts
@@ -220,7 +220,7 @@ export const getFighterTotalCost = async (fighterId: string, supabase: any): Pro
       .eq('fighter_id', fighterId),
     supabase
       .from('fighter_exotic_beasts')
-      .select('fighter_pet_id')
+      .select('fighter_pet_id, fighter_equipment!fighter_equipment_id (gang_stash)')
       .eq('fighter_owner_id', fighterId)
   ]);
 
@@ -244,7 +244,10 @@ export const getFighterTotalCost = async (fighterId: string, supabase: any): Pro
 
   // Owned exotic beasts roll their cost into the owner
   let beastsCost = 0;
-  const beastIds = (beastLinksRes.data || []).map((b: any) => b.fighter_pet_id);
+  // A stashed beast's cost sits in the gang stash, not on its owner.
+  const beastIds = (beastLinksRes.data || [])
+    .filter((b: any) => !b.fighter_equipment?.gang_stash)
+    .map((b: any) => b.fighter_pet_id);
   if (beastIds.length > 0) {
     const { data: beastData } = await supabase
       .from('fighters')

--- a/app/lib/shared/fighter-data.ts
+++ b/app/lib/shared/fighter-data.ts
@@ -244,7 +244,7 @@ export const getFighterTotalCost = async (fighterId: string, supabase: any): Pro
 
   // Owned exotic beasts roll their cost into the owner
   let beastsCost = 0;
-  // A stashed beast's cost sits in the gang stash, not on its owner.
+  // Skip beasts created by equipment that is in the stash.
   const beastIds = (beastLinksRes.data || [])
     .filter((b: any) => !b.fighter_equipment?.gang_stash)
     .map((b: any) => b.fighter_pet_id);

--- a/app/lib/shared/fighter-data.ts
+++ b/app/lib/shared/fighter-data.ts
@@ -244,10 +244,11 @@ export const getFighterTotalCost = async (fighterId: string, supabase: any): Pro
 
   // Owned exotic beasts roll their cost into the owner
   let beastsCost = 0;
-  // Skip beasts created by equipment that is in the stash.
-  const beastIds = (beastLinksRes.data || [])
-    .filter((b: any) => !b.fighter_equipment?.gang_stash)
-    .map((b: any) => b.fighter_pet_id);
+  const beastLinks = beastLinksRes.data || [];
+  const stashedBeastIds = new Set(
+    beastLinks.filter((b: any) => b.fighter_equipment?.gang_stash).map((b: any) => b.fighter_pet_id)
+  );
+  const beastIds = beastLinks.map((b: any) => b.fighter_pet_id);
   if (beastIds.length > 0) {
     const { data: beastData } = await supabase
       .from('fighters')
@@ -267,7 +268,10 @@ export const getFighterTotalCost = async (fighterId: string, supabase: any): Pro
       .eq('captured', false);
 
     beastsCost = (beastData || []).reduce((sum: number, beast: any) => {
-      const beastEquipment = ((beast.fighter_equipment as any[]) || []).reduce((s, eq) => s + (eq.purchase_cost || 0), 0);
+      // Stashed equipment already moved its cost to stash value; the beast's advancements did not.
+      const beastEquipment = stashedBeastIds.has(beast.id)
+        ? 0
+        : ((beast.fighter_equipment as any[]) || []).reduce((s, eq) => s + (eq.purchase_cost || 0), 0);
       const beastSkills = ((beast.fighter_skills as any[]) || []).reduce((s, skill) => s + (skill.credits_increase || 0), 0);
       const beastEffects = ((beast.fighter_effects as any[]) || []).reduce(
         (s, effect) => s + (effect.type_specific_data?.credits_increase || 0), 0

--- a/utils/gang-assembly.ts
+++ b/utils/gang-assembly.ts
@@ -201,7 +201,7 @@ export function assembleGangFighters(
       const skillsData = skillsByFighter[fighterId] || [];
       const effectsData = effectsByFighter[fighterId] || [];
       const vehicles = vehiclesByFighter[fighterId] || [];
-      // A stashed beast's cost sits in the gang stash, not on its owner's card.
+      // Skip beasts created by equipment that is in the stash.
       const ownedBeasts = (beastsByOwner[fighterId] || []).filter((b: any) => !b.fighter_equipment?.gang_stash);
       const ownershipInfo = ownershipInfoMap.get(fighter.id) || null;
 
@@ -1271,7 +1271,7 @@ export function assembleFighterView(bundle: GangFightersBundle, fighterId: strin
     });
 
   // ---- Owned beasts: costs + display data (previous getFighterOwnedBeastsCost/Data) ----
-  // A stashed beast's cost sits in the gang stash, not on its owner's card.
+  // Skip beasts created by equipment that is in the stash.
   const myBeastLinks = bundle.beastsOwned.filter((b: any) => b.fighter_owner_id === fighterId && !b.fighter_equipment?.gang_stash);
   const fighterById = new Map(bundle.fighters.map((f: any) => [f.id, f]));
 

--- a/utils/gang-assembly.ts
+++ b/utils/gang-assembly.ts
@@ -201,7 +201,8 @@ export function assembleGangFighters(
       const skillsData = skillsByFighter[fighterId] || [];
       const effectsData = effectsByFighter[fighterId] || [];
       const vehicles = vehiclesByFighter[fighterId] || [];
-      const ownedBeasts = beastsByOwner[fighterId] || [];
+      // A stashed beast's cost sits in the gang stash, not on its owner's card.
+      const ownedBeasts = (beastsByOwner[fighterId] || []).filter((b: any) => !b.fighter_equipment?.gang_stash);
       const ownershipInfo = ownershipInfoMap.get(fighter.id) || null;
 
       // Build list of loadout contexts to process (one for normal, multiple when expanding for print)
@@ -1270,7 +1271,8 @@ export function assembleFighterView(bundle: GangFightersBundle, fighterId: strin
     });
 
   // ---- Owned beasts: costs + display data (previous getFighterOwnedBeastsCost/Data) ----
-  const myBeastLinks = bundle.beastsOwned.filter((b: any) => b.fighter_owner_id === fighterId);
+  // A stashed beast's cost sits in the gang stash, not on its owner's card.
+  const myBeastLinks = bundle.beastsOwned.filter((b: any) => b.fighter_owner_id === fighterId && !b.fighter_equipment?.gang_stash);
   const fighterById = new Map(bundle.fighters.map((f: any) => [f.id, f]));
 
   const byEquipmentId: Record<string, { equipment: number; advancements: number }> = {};

--- a/utils/gang-assembly.ts
+++ b/utils/gang-assembly.ts
@@ -201,8 +201,7 @@ export function assembleGangFighters(
       const skillsData = skillsByFighter[fighterId] || [];
       const effectsData = effectsByFighter[fighterId] || [];
       const vehicles = vehiclesByFighter[fighterId] || [];
-      // Skip beasts created by equipment that is in the stash.
-      const ownedBeasts = (beastsByOwner[fighterId] || []).filter((b: any) => !b.fighter_equipment?.gang_stash);
+      const ownedBeasts = beastsByOwner[fighterId] || [];
       const ownershipInfo = ownershipInfoMap.get(fighter.id) || null;
 
       // Build list of loadout contexts to process (one for normal, multiple when expanding for print)
@@ -455,7 +454,10 @@ export function assembleGangFighters(
           const beastSkills = skillsByFighter[beastRel.fighter_pet_id] || [];
           const beastEffects = effectsByFighter[beastRel.fighter_pet_id] || [];
 
-          const equipmentCost = beastEquipment.reduce((sum: number, eq: any) => sum + (eq.purchase_cost || 0), 0);
+          // Stashed equipment already moved its cost to stash value; the beast's advancements did not.
+          const equipmentCost = beastRel.fighter_equipment?.gang_stash
+            ? 0
+            : beastEquipment.reduce((sum: number, eq: any) => sum + (eq.purchase_cost || 0), 0);
           const skillsCost = beastSkills.reduce((sum: number, skill: any) => sum + (skill.credits_increase || 0), 0);
           const effectsCost = beastEffects.reduce((sum: number, effect: any) => {
             return sum + (effect.type_specific_data?.credits_increase || 0);
@@ -1271,8 +1273,7 @@ export function assembleFighterView(bundle: GangFightersBundle, fighterId: strin
     });
 
   // ---- Owned beasts: costs + display data (previous getFighterOwnedBeastsCost/Data) ----
-  // Skip beasts created by equipment that is in the stash.
-  const myBeastLinks = bundle.beastsOwned.filter((b: any) => b.fighter_owner_id === fighterId && !b.fighter_equipment?.gang_stash);
+  const myBeastLinks = bundle.beastsOwned.filter((b: any) => b.fighter_owner_id === fighterId);
   const fighterById = new Map(bundle.fighters.map((f: any) => [f.id, f]));
 
   const byEquipmentId: Record<string, { equipment: number; advancements: number }> = {};
@@ -1285,7 +1286,10 @@ export function assembleFighterView(bundle: GangFightersBundle, fighterId: strin
     const beastSkills = bundle.skills.filter((s: any) => s.fighter_id === beast.id);
     const beastEffects = bundle.effects.filter((e: any) => e.fighter_id === beast.id && !e.vehicle_id);
 
-    const equipmentCost = beastEquipment.reduce((s: number, eq: any) => s + (eq.purchase_cost || 0), 0);
+    // Stashed equipment already moved its cost to stash value; the beast's advancements did not.
+    const equipmentCost = link.fighter_equipment?.gang_stash
+      ? 0
+      : beastEquipment.reduce((s: number, eq: any) => s + (eq.purchase_cost || 0), 0);
     const skillsCost = beastSkills.reduce((s: number, skill: any) => s + (skill.credits_increase || 0), 0);
     const effectsCost = beastEffects.reduce((s: number, effect: any) => s + (effect.type_specific_data?.credits_increase || 0), 0);
     const baseBeastCost = (beast.fighter_types as any)?.cost || 0;


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? -->

- Buying beast-granting wargear into the gang stash inserted a fighter_exotic_beasts row with a null fighter_owner_id, which RLS rejects: NULL IN (...) is NULL, not TRUE. Since fb9c4db9 that 403 threw before updateGangFinancials and logEquipmentAction could run, and the block's own rollback deleted from the legacy gang_stash table instead of fighter_equipment, so it matched nothing. The result was unpaid, unlogged stash rows that broke the rating + credits + stash = wealth invariant.

move-to-stash cleared the owner the same way. That write was rejected too, and its result went unchecked, so it was a silent no-op for every non-admin. Nothing depended on it: beast visibility comes from fighter_equipment.gang_stash via beast_equipment_stashed.

Restores pre-ab6cdb94 behaviour, in which stash-bought beast wargear grants no beast.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Schema / migration

## How I tested

<!-- What you tested before opening this PR. Example: Opened gang X → bought equipment → credits/rating updated -->

- Bought a pet from the stash, moved it to a fighter, moved it back to the stash, then sold it. Also bought a pet to a fighter, pet fighter card shows and then sold the pet from the fighter. Gang rating and wealth checks out.

## Risk / rollout

<!-- e.g. Low / Medium — any deploy notes beyond database (env vars, feature flags, etc.). -->

- None
