### PR TITLE
Add admin management for official gang types.

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { LuUsers, LuSword, LuCar, LuBookOpen, LuScrollText, LuBookUser, LuHeartCrack, LuSearch, LuBell, LuHandshake } from "react-icons/lu";
+import { LuUsers, LuSword, LuCar, LuBookOpen, LuScrollText, LuBookUser, LuHeartCrack, LuSearch, LuBell, LuHandshake, LuHouse } from "react-icons/lu";
 import { LuChartColumn } from "react-icons/lu";
 import { PiFlagBannerFoldBold } from "react-icons/pi";
 import { LuSquarePen } from 'react-icons/lu';
@@ -18,6 +18,7 @@ import { AdminStatsModal } from "@/components/admin/admin-stats-modal";
 import { AdminScenariosModal } from "@/components/admin/admin-scenarios-modal";
 import { AdminInjuriesGlitchesModal } from "@/components/admin/admin-injuries";
 import { AdminAlliancesModal } from "@/components/admin/admin-alliances";
+import { AdminGangTypesModal } from "@/components/admin/admin-gang-types";
 import { AdminCampaignManagementModal } from "@/components/admin/admin-campaign-management";
 import { AdminSupportToolsModal } from "@/components/admin/admin-support-tools";
 import { AdminNotificationsModal } from "@/components/admin/admin-notifications-modal";
@@ -36,6 +37,7 @@ export default function AdminPage() {
   const [showScenarios, setShowScenarios] = useState(false);
   const [showInjuriesGlitches, setShowInjuriesGlitches] = useState(false);
   const [showAlliances, setShowAlliances] = useState(false);
+  const [showGangTypes, setShowGangTypes] = useState(false);
   const [showCampaignManagement, setShowCampaignManagement] = useState(false);
   const [showSupportTools, setShowSupportTools] = useState(false);
   const [showNotifications, setShowNotifications] = useState(false);
@@ -118,6 +120,12 @@ export default function AdminPage() {
       description: "Manage campaign types, territories, and triumphs",
       action: () => setShowCampaignManagement(true),
       icon: PiFlagBannerFoldBold
+    },
+    {
+      title: "Gangs",
+      description: "Manage gang types",
+      action: () => setShowGangTypes(true),
+      icon: LuHouse
     }
   ];
 
@@ -286,6 +294,12 @@ export default function AdminPage() {
         {showAlliances && (
           <AdminAlliancesModal
             onClose={() => setShowAlliances(false)}
+          />
+        )}
+
+        {showGangTypes && (
+          <AdminGangTypesModal
+            onClose={() => setShowGangTypes(false)}
           />
         )}
 

--- a/app/api/admin/gang-origin-categories/route.ts
+++ b/app/api/admin/gang-origin-categories/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server'
+import { createClient } from "@/utils/supabase/server";
+import { checkAdmin } from "@/utils/auth";
+
+export async function GET() {
+  const supabase = await createClient();
+
+  try {
+    const isAdmin = await checkAdmin(supabase);
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { data, error } = await supabase
+      .from('gang_origin_categories')
+      .select('id, category_name')
+      .order('category_name');
+
+    if (error) throw error;
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error fetching gang origin categories:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch gang origin categories' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/gang-types/route.ts
+++ b/app/api/admin/gang-types/route.ts
@@ -17,6 +17,13 @@ const ALLOWED_ALIGNMENTS = [
   'Unaligned',
 ] as const;
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type DefaultImagePayload = {
+  url: string;
+  credit?: { name?: string; url?: string; suffix?: string };
+};
+
 type GangTypePayload = {
   gang_type: string;
   edition_id: string;
@@ -26,10 +33,32 @@ type GangTypePayload = {
   trading_post_type_id: string | null;
   gang_origin_category_id: string | null;
   parent_gang_type_id: string | null;
-  default_image_urls: Array<{
-    url: string;
-    credit?: { name?: string; url?: string; suffix?: string };
-  }> | null;
+  default_image_urls: DefaultImagePayload[] | null;
+};
+
+type GangTypePatch = {
+  gang_type?: string;
+  edition_id?: string;
+  alignment?: string | null;
+  is_hidden?: boolean;
+  affiliation?: boolean;
+  trading_post_type_id?: string | null;
+  gang_origin_category_id?: string | null;
+  parent_gang_type_id?: string | null;
+  default_image_urls?: DefaultImagePayload[] | null;
+};
+
+type GangTypeRow = {
+  gang_type_id: string;
+  gang_type: string | null;
+  alignment: string | null;
+  is_hidden: boolean | null;
+  affiliation: boolean | null;
+  trading_post_type_id: string | null;
+  gang_origin_category_id: string | null;
+  parent_gang_type_id: string | null;
+  default_image_urls: unknown;
+  edition_id: string | null;
 };
 
 function emptyToNull(value: unknown): string | null {
@@ -37,6 +66,33 @@ function emptyToNull(value: unknown): string | null {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
   return trimmed === '' ? null : trimmed;
+}
+
+function postgresCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object' || !('code' in error)) return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' ? code : undefined;
+}
+
+function mutationErrorResponse(error: unknown, fallback: string): NextResponse {
+  const code = postgresCode(error);
+  if (code === '22P02') {
+    return NextResponse.json({ error: 'Invalid id format' }, { status: 400 });
+  }
+  console.error(fallback, error);
+  return NextResponse.json({ error: fallback }, { status: 500 });
+}
+
+function parseUuid(
+  value: unknown,
+  field: string
+): { error: string } | { data: string | null } {
+  const trimmed = emptyToNull(value);
+  if (trimmed === null) return { data: null };
+  if (!UUID_RE.test(trimmed)) {
+    return { error: `${field} must be a valid UUID` };
+  }
+  return { data: trimmed };
 }
 
 function parseOptionalBoolean(
@@ -53,9 +109,42 @@ function parseOptionalBoolean(
   return { error: `${field} must be a boolean` };
 }
 
+function parseBooleanField(
+  value: unknown,
+  field: string
+): { error: string } | { data: boolean } {
+  if (typeof value === 'boolean') {
+    return { data: value };
+  }
+  return { error: `${field} must be a boolean` };
+}
+
+function parseAlignment(
+  value: unknown
+): { error: string } | { data: string | null } {
+  const alignment = emptyToNull(value);
+  if (alignment && !(ALLOWED_ALIGNMENTS as readonly string[]).includes(alignment)) {
+    return { error: 'Invalid alignment' };
+  }
+  return { data: alignment };
+}
+
+function parseGangTypeName(
+  value: unknown
+): { error: string } | { data: string } {
+  const gangType = emptyToNull(value);
+  if (!gangType) {
+    return { error: 'gang_type is required' };
+  }
+  if (gangType.length > 200) {
+    return { error: 'gang_type must be 200 characters or less' };
+  }
+  return { data: gangType };
+}
+
 function parseDefaultImageUrls(value: unknown):
   | { error: string }
-  | { data: GangTypePayload['default_image_urls'] } {
+  | { data: DefaultImagePayload[] | null } {
   if (value === undefined || value === null || value === '') {
     return { data: null };
   }
@@ -64,12 +153,14 @@ function parseDefaultImageUrls(value: unknown):
     return { error: 'default_image_urls must be an array or null' };
   }
 
-  const parsed: NonNullable<GangTypePayload['default_image_urls']> = [];
+  const parsed: DefaultImagePayload[] = [];
 
   for (const entry of value) {
     if (typeof entry === 'string') {
       const url = entry.trim();
-      if (!url) continue;
+      if (!url) {
+        return { error: 'default_image_urls entries require a valid http(s) image url' };
+      }
       if (!isValidHttpUrl(url)) {
         return { error: 'default_image_urls entries must be valid http(s) URLs' };
       }
@@ -101,29 +192,62 @@ function parseDefaultImageUrls(value: unknown):
       return { error: 'default_image_urls entries must be valid http(s) URLs' };
     }
 
-    if (!rawCredit || typeof rawCredit !== 'object') {
-      parsed.push({ url });
-      continue;
-    }
-
-    const creditName = creditFields.name;
-    const creditUrl = creditFields.url;
-    const creditSuffix = creditFields.suffix;
-
-    if (creditUrl && !isValidHttpUrl(creditUrl)) {
+    if (creditFields.url && !isValidHttpUrl(creditFields.url)) {
       return { error: 'default_image_urls credit url must be a valid http(s) URL' };
     }
 
     const credit: { name?: string; url?: string; suffix?: string } = {
-      ...(creditName ? { name: creditName } : {}),
-      ...(creditUrl ? { url: creditUrl } : {}),
-      ...(creditSuffix ? { suffix: creditSuffix } : {}),
+      ...(creditFields.name ? { name: creditFields.name } : {}),
+      ...(creditFields.url ? { url: creditFields.url } : {}),
+      ...(creditFields.suffix ? { suffix: creditFields.suffix } : {}),
     };
 
     parsed.push(Object.keys(credit).length > 0 ? { url, credit } : { url });
   }
 
   return { data: parsed.length > 0 ? parsed : null };
+}
+
+function defaultImageUrlsOf(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((entry) => {
+    if (typeof entry === 'string') return entry.trim();
+    if (entry && typeof entry === 'object') {
+      return emptyToNull((entry as { url?: unknown }).url) ?? '';
+    }
+    return '';
+  });
+}
+
+/**
+ * gangs.default_gang_image is a positional index into default_image_urls.
+ * Same-length edits keep indexes; length changes match by URL. Removed slots
+ * map to null. Duplicate URLs are claimed left-to-right.
+ */
+function buildDefaultImageIndexMap(
+  oldUrls: string[],
+  newUrls: string[]
+): Map<number, number | null> {
+  const map = new Map<number, number | null>();
+  if (oldUrls.length === newUrls.length) {
+    oldUrls.forEach((_, index) => map.set(index, index));
+    return map;
+  }
+
+  const used = new Set<number>();
+  for (let oldIndex = 0; oldIndex < oldUrls.length; oldIndex++) {
+    let found: number | null = null;
+    for (let newIndex = 0; newIndex < newUrls.length; newIndex++) {
+      if (used.has(newIndex)) continue;
+      if (oldUrls[oldIndex] === newUrls[newIndex]) {
+        found = newIndex;
+        used.add(newIndex);
+        break;
+      }
+    }
+    map.set(oldIndex, found);
+  }
+  return map;
 }
 
 function validateGangTypePayload(body: {
@@ -137,54 +261,118 @@ function validateGangTypePayload(body: {
   parent_gang_type_id?: unknown;
   default_image_urls?: unknown;
 }): { error: string } | { data: GangTypePayload } {
-  const gangType = emptyToNull(body.gang_type);
-  const editionId = emptyToNull(body.edition_id);
+  const gangType = parseGangTypeName(body.gang_type);
+  if ('error' in gangType) return gangType;
 
-  if (!gangType) {
-    return { error: 'gang_type is required' };
-  }
-
-  if (gangType.length > 200) {
-    return { error: 'gang_type must be 200 characters or less' };
-  }
-
-  if (!editionId) {
+  const editionId = parseUuid(body.edition_id, 'edition_id');
+  if ('error' in editionId) return editionId;
+  if (!editionId.data) {
     return { error: 'edition_id is required' };
   }
 
-  const alignment = emptyToNull(body.alignment);
-  if (alignment && !(ALLOWED_ALIGNMENTS as readonly string[]).includes(alignment)) {
-    return { error: 'Invalid alignment' };
-  }
+  const alignment = parseAlignment(body.alignment);
+  if ('error' in alignment) return alignment;
 
   const defaultImages = parseDefaultImageUrls(body.default_image_urls);
-  if ('error' in defaultImages) {
-    return defaultImages;
-  }
+  if ('error' in defaultImages) return defaultImages;
 
   const isHidden = parseOptionalBoolean(body.is_hidden, 'is_hidden', false);
-  if ('error' in isHidden) {
-    return isHidden;
-  }
+  if ('error' in isHidden) return isHidden;
 
   const affiliation = parseOptionalBoolean(body.affiliation, 'affiliation', false);
-  if ('error' in affiliation) {
-    return affiliation;
-  }
+  if ('error' in affiliation) return affiliation;
+
+  const tradingPostTypeId = parseUuid(body.trading_post_type_id, 'trading_post_type_id');
+  if ('error' in tradingPostTypeId) return tradingPostTypeId;
+
+  const originCategoryId = parseUuid(body.gang_origin_category_id, 'gang_origin_category_id');
+  if ('error' in originCategoryId) return originCategoryId;
+
+  const parentGangTypeId = parseUuid(body.parent_gang_type_id, 'parent_gang_type_id');
+  if ('error' in parentGangTypeId) return parentGangTypeId;
 
   return {
     data: {
-      gang_type: gangType,
-      edition_id: editionId,
-      alignment,
+      gang_type: gangType.data,
+      edition_id: editionId.data,
+      alignment: alignment.data,
       is_hidden: isHidden.data,
       affiliation: affiliation.data,
-      trading_post_type_id: emptyToNull(body.trading_post_type_id),
-      gang_origin_category_id: emptyToNull(body.gang_origin_category_id),
-      parent_gang_type_id: emptyToNull(body.parent_gang_type_id),
+      trading_post_type_id: tradingPostTypeId.data,
+      gang_origin_category_id: originCategoryId.data,
+      parent_gang_type_id: parentGangTypeId.data,
       default_image_urls: defaultImages.data,
     },
   };
+}
+
+function validateGangTypePatch(body: Record<string, unknown>):
+  | { error: string }
+  | { data: GangTypePatch } {
+  const data: GangTypePatch = {};
+
+  if ('gang_type' in body) {
+    const gangType = parseGangTypeName(body.gang_type);
+    if ('error' in gangType) return gangType;
+    data.gang_type = gangType.data;
+  }
+
+  if ('edition_id' in body) {
+    const editionId = parseUuid(body.edition_id, 'edition_id');
+    if ('error' in editionId) return editionId;
+    if (!editionId.data) {
+      return { error: 'edition_id is required' };
+    }
+    data.edition_id = editionId.data;
+  }
+
+  if ('alignment' in body) {
+    const alignment = parseAlignment(body.alignment);
+    if ('error' in alignment) return alignment;
+    data.alignment = alignment.data;
+  }
+
+  if ('is_hidden' in body) {
+    const isHidden = parseBooleanField(body.is_hidden, 'is_hidden');
+    if ('error' in isHidden) return isHidden;
+    data.is_hidden = isHidden.data;
+  }
+
+  if ('affiliation' in body) {
+    const affiliation = parseBooleanField(body.affiliation, 'affiliation');
+    if ('error' in affiliation) return affiliation;
+    data.affiliation = affiliation.data;
+  }
+
+  if ('trading_post_type_id' in body) {
+    const tradingPostTypeId = parseUuid(body.trading_post_type_id, 'trading_post_type_id');
+    if ('error' in tradingPostTypeId) return tradingPostTypeId;
+    data.trading_post_type_id = tradingPostTypeId.data;
+  }
+
+  if ('gang_origin_category_id' in body) {
+    const originCategoryId = parseUuid(body.gang_origin_category_id, 'gang_origin_category_id');
+    if ('error' in originCategoryId) return originCategoryId;
+    data.gang_origin_category_id = originCategoryId.data;
+  }
+
+  if ('parent_gang_type_id' in body) {
+    const parentGangTypeId = parseUuid(body.parent_gang_type_id, 'parent_gang_type_id');
+    if ('error' in parentGangTypeId) return parentGangTypeId;
+    data.parent_gang_type_id = parentGangTypeId.data;
+  }
+
+  if ('default_image_urls' in body) {
+    const defaultImages = parseDefaultImageUrls(body.default_image_urls);
+    if ('error' in defaultImages) return defaultImages;
+    data.default_image_urls = defaultImages.data;
+  }
+
+  if (Object.keys(data).length === 0) {
+    return { error: 'No fields to update' };
+  }
+
+  return { data };
 }
 
 async function assertEditionExists(
@@ -205,7 +393,7 @@ async function assertEditionExists(
 async function assertTradingPostMatchesEdition(
   supabase: SupabaseClient,
   tradingPostTypeId: string | null,
-  editionId: string
+  editionId: string | null
 ): Promise<string | null> {
   if (!tradingPostTypeId) return null;
 
@@ -217,7 +405,7 @@ async function assertTradingPostMatchesEdition(
 
   if (error) throw error;
   if (!data) return 'trading_post_type_id must reference an existing trading post type';
-  if (data.edition_id && data.edition_id !== editionId) {
+  if (data.edition_id && editionId && data.edition_id !== editionId) {
     return 'trading_post_type_id must be a trading post type of the same edition';
   }
   return null;
@@ -243,10 +431,14 @@ async function assertOriginCategoryExists(
 async function assertParentGangType(
   supabase: SupabaseClient,
   parentGangTypeId: string | null,
-  editionId: string,
+  editionId: string | null,
   currentGangTypeId?: string
 ): Promise<string | null> {
   if (!parentGangTypeId) return null;
+
+  if (!editionId) {
+    return 'parent_gang_type_id requires edition_id';
+  }
 
   if (currentGangTypeId && parentGangTypeId === currentGangTypeId) {
     return 'parent_gang_type_id cannot reference itself';
@@ -285,11 +477,16 @@ async function assertParentGangType(
 
 async function assertEditionScopedRefs(
   supabase: SupabaseClient,
-  payload: GangTypePayload,
+  payload: {
+    edition_id: string | null;
+    trading_post_type_id: string | null;
+    gang_origin_category_id: string | null;
+    parent_gang_type_id: string | null;
+  },
   currentGangTypeId?: string
 ): Promise<string | null> {
   const [editionError, tradingPostError, originError, parentError] = await Promise.all([
-    assertEditionExists(supabase, payload.edition_id),
+    payload.edition_id ? assertEditionExists(supabase, payload.edition_id) : Promise.resolve(null),
     assertTradingPostMatchesEdition(supabase, payload.trading_post_type_id, payload.edition_id),
     assertOriginCategoryExists(supabase, payload.gang_origin_category_id),
     assertParentGangType(
@@ -310,45 +507,97 @@ async function assertEditionChangeAllowed(
 ): Promise<string | null> {
   if (currentEditionId === nextEditionId) return null;
 
-  const [
-    { count: gangCount, error: gangError },
-    { count: fighterTypeCount, error: fighterTypeError },
-    { count: tacticsPackCount, error: tacticsPackError },
-    { count: childTypeCount, error: childTypeError },
-  ] = await Promise.all([
-    supabase
-      .from('gangs')
-      .select('id', { count: 'exact', head: true })
-      .eq('gang_type_id', gangTypeId),
-    supabase
-      .from('fighter_types')
-      .select('id', { count: 'exact', head: true })
-      .eq('gang_type_id', gangTypeId),
-    supabase
-      .from('tactics_cards_packs')
-      .select('id', { count: 'exact', head: true })
-      .eq('gang_type_id', gangTypeId),
-    supabase
-      .from('gang_types')
-      .select('gang_type_id', { count: 'exact', head: true })
-      .eq('parent_gang_type_id', gangTypeId),
-  ]);
+  const { count: gangCount, error: gangError } = await supabase
+    .from('gangs')
+    .select('id', { count: 'exact', head: true })
+    .eq('gang_type_id', gangTypeId);
 
   if (gangError) throw gangError;
-  if (fighterTypeError) throw fighterTypeError;
-  if (tacticsPackError) throw tacticsPackError;
-  if (childTypeError) throw childTypeError;
 
-  if (
-    (gangCount ?? 0) > 0 ||
-    (fighterTypeCount ?? 0) > 0 ||
-    (tacticsPackCount ?? 0) > 0 ||
-    (childTypeCount ?? 0) > 0
-  ) {
-    return 'Cannot change edition_id while gangs, fighter types, tactics packs, or child gang types still reference this gang type';
+  if ((gangCount ?? 0) > 0) {
+    return 'Cannot change edition_id while gangs still reference this gang type';
   }
 
   return null;
+}
+
+async function syncDenormalizedGangTypeName(
+  supabase: SupabaseClient,
+  gangTypeId: string,
+  gangType: string
+): Promise<void> {
+  const [gangsResult, fighterTypesResult] = await Promise.all([
+    supabase
+      .from('gangs')
+      .update({ gang_type: gangType })
+      .eq('gang_type_id', gangTypeId)
+      .neq('gang_type', gangType),
+    supabase
+      .from('fighter_types')
+      .update({ gang_type: gangType })
+      .eq('gang_type_id', gangTypeId)
+      .neq('gang_type', gangType),
+  ]);
+
+  if (gangsResult.error) throw gangsResult.error;
+  if (fighterTypesResult.error) throw fighterTypesResult.error;
+}
+
+async function remapPinnedDefaultImages(
+  supabase: SupabaseClient,
+  gangTypeId: string,
+  oldUrls: string[],
+  newUrls: string[]
+): Promise<void> {
+  const indexMap = buildDefaultImageIndexMap(oldUrls, newUrls);
+  const changes = [...indexMap.entries()].filter(([from, to]) => from !== to);
+
+  const clearOutOfRange = async () => {
+    const { error } = await supabase
+      .from('gangs')
+      .update({ default_gang_image: null })
+      .eq('gang_type_id', gangTypeId)
+      .gte('default_gang_image', newUrls.length);
+    if (error) throw error;
+  };
+
+  if (changes.length === 0) {
+    await clearOutOfRange();
+    return;
+  }
+
+  try {
+    // Phase 1: unique negatives so 2→1 cannot collide with existing 1s.
+    for (const [from] of changes) {
+      const { error } = await supabase
+        .from('gangs')
+        .update({ default_gang_image: -(from + 1) })
+        .eq('gang_type_id', gangTypeId)
+        .eq('default_gang_image', from);
+      if (error) throw error;
+    }
+
+    for (const [from, to] of changes) {
+      const { error } = await supabase
+        .from('gangs')
+        .update({ default_gang_image: to })
+        .eq('gang_type_id', gangTypeId)
+        .eq('default_gang_image', -(from + 1));
+      if (error) throw error;
+    }
+  } catch (error) {
+    for (const [from] of changes) {
+      await supabase
+        .from('gangs')
+        .update({ default_gang_image: from })
+        .eq('gang_type_id', gangTypeId)
+        .eq('default_gang_image', -(from + 1));
+    }
+    await clearOutOfRange();
+    throw error;
+  }
+
+  await clearOutOfRange();
 }
 
 function withReferenceInvalidation(
@@ -419,11 +668,7 @@ async function _POST(request: Request) {
 
     return NextResponse.json(gangType);
   } catch (error) {
-    console.error('Error creating gang type:', error);
-    return NextResponse.json(
-      { error: 'Failed to create gang type' },
-      { status: 500 }
-    );
+    return mutationErrorResponse(error, 'Failed to create gang type');
   }
 }
 
@@ -436,21 +681,25 @@ async function _PATCH(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const body = await request.json();
-    const gangTypeId = emptyToNull(body.gang_type_id);
+    const body = await request.json() as Record<string, unknown>;
+    const gangTypeIdParsed = parseUuid(body.gang_type_id, 'gang_type_id');
+    if ('error' in gangTypeIdParsed) {
+      return NextResponse.json({ error: gangTypeIdParsed.error }, { status: 400 });
+    }
+    const gangTypeId = gangTypeIdParsed.data;
 
     if (!gangTypeId) {
       return NextResponse.json({ error: 'gang_type_id is required' }, { status: 400 });
     }
 
-    const validated = validateGangTypePayload(body);
+    const validated = validateGangTypePatch(body);
     if ('error' in validated) {
       return NextResponse.json({ error: validated.error }, { status: 400 });
     }
 
     const { data: existing, error: existingError } = await supabase
       .from('gang_types')
-      .select('gang_type_id, edition_id')
+      .select(GANG_TYPE_COLUMNS)
       .eq('gang_type_id', gangTypeId)
       .maybeSingle();
 
@@ -459,24 +708,45 @@ async function _PATCH(request: Request) {
       return NextResponse.json({ error: 'Gang type not found' }, { status: 404 });
     }
 
-    const editionChangeError = await assertEditionChangeAllowed(
-      supabase,
-      gangTypeId,
-      existing.edition_id,
-      validated.data.edition_id
-    );
-    if (editionChangeError) {
-      return NextResponse.json({ error: editionChangeError }, { status: 409 });
+    const current = existing as GangTypeRow;
+    const patch = validated.data;
+    const nextEditionId = patch.edition_id ?? current.edition_id;
+
+    if (patch.edition_id) {
+      const editionChangeError = await assertEditionChangeAllowed(
+        supabase,
+        gangTypeId,
+        current.edition_id,
+        patch.edition_id
+      );
+      if (editionChangeError) {
+        return NextResponse.json({ error: editionChangeError }, { status: 409 });
+      }
     }
 
-    const refError = await assertEditionScopedRefs(supabase, validated.data, gangTypeId);
+    const refError = await assertEditionScopedRefs(
+      supabase,
+      {
+        edition_id: nextEditionId,
+        trading_post_type_id: patch.trading_post_type_id !== undefined
+          ? patch.trading_post_type_id
+          : current.trading_post_type_id,
+        gang_origin_category_id: patch.gang_origin_category_id !== undefined
+          ? patch.gang_origin_category_id
+          : current.gang_origin_category_id,
+        parent_gang_type_id: patch.parent_gang_type_id !== undefined
+          ? patch.parent_gang_type_id
+          : current.parent_gang_type_id,
+      },
+      gangTypeId
+    );
     if (refError) {
       return NextResponse.json({ error: refError }, { status: 400 });
     }
 
     const { data: gangType, error } = await supabase
       .from('gang_types')
-      .update(validated.data)
+      .update(patch)
       .eq('gang_type_id', gangTypeId)
       .select(GANG_TYPE_COLUMNS)
       .maybeSingle();
@@ -486,13 +756,22 @@ async function _PATCH(request: Request) {
       return NextResponse.json({ error: 'Gang type not found' }, { status: 404 });
     }
 
+    if (patch.gang_type) {
+      await syncDenormalizedGangTypeName(supabase, gangTypeId, patch.gang_type);
+    }
+
+    if (patch.default_image_urls !== undefined) {
+      await remapPinnedDefaultImages(
+        supabase,
+        gangTypeId,
+        defaultImageUrlsOf(current.default_image_urls),
+        (patch.default_image_urls ?? []).map((entry) => entry.url)
+      );
+    }
+
     return NextResponse.json(gangType);
   } catch (error) {
-    console.error('Error updating gang type:', error);
-    return NextResponse.json(
-      { error: 'Failed to update gang type' },
-      { status: 500 }
-    );
+    return mutationErrorResponse(error, 'Failed to update gang type');
   }
 }
 

--- a/app/api/admin/gang-types/route.ts
+++ b/app/api/admin/gang-types/route.ts
@@ -221,19 +221,15 @@ function defaultImageUrlsOf(value: unknown): string[] {
 
 /**
  * gangs.default_gang_image is a positional index into default_image_urls.
- * Same-length edits keep indexes; length changes match by URL. Removed slots
- * map to null. Duplicate URLs are claimed left-to-right.
+ * Match by URL left-to-right so a same-length remove+add (e.g. [A,B,C] →
+ * [A,C,D]) remaps pins instead of keeping stale positions. Unmatched old
+ * slots map to null. Duplicate URLs are claimed in order.
  */
 function buildDefaultImageIndexMap(
   oldUrls: string[],
   newUrls: string[]
 ): Map<number, number | null> {
   const map = new Map<number, number | null>();
-  if (oldUrls.length === newUrls.length) {
-    oldUrls.forEach((_, index) => map.set(index, index));
-    return map;
-  }
-
   const used = new Set<number>();
   for (let oldIndex = 0; oldIndex < oldUrls.length; oldIndex++) {
     let found: number | null = null;
@@ -507,15 +503,45 @@ async function assertEditionChangeAllowed(
 ): Promise<string | null> {
   if (currentEditionId === nextEditionId) return null;
 
-  const { count: gangCount, error: gangError } = await supabase
-    .from('gangs')
-    .select('id', { count: 'exact', head: true })
-    .eq('gang_type_id', gangTypeId);
+  // Composite FKs on (gang_type_id, edition_id) are ON UPDATE CASCADE, so a
+  // successful edition change would silently reclassify fighter types, tactics
+  // packs, and child variants into the new edition. Block while any remain.
+  const [
+    { count: gangCount, error: gangError },
+    { count: fighterTypeCount, error: fighterTypeError },
+    { count: tacticsPackCount, error: tacticsPackError },
+    { count: childTypeCount, error: childTypeError },
+  ] = await Promise.all([
+    supabase
+      .from('gangs')
+      .select('id', { count: 'exact', head: true })
+      .eq('gang_type_id', gangTypeId),
+    supabase
+      .from('fighter_types')
+      .select('id', { count: 'exact', head: true })
+      .eq('gang_type_id', gangTypeId),
+    supabase
+      .from('tactics_cards_packs')
+      .select('id', { count: 'exact', head: true })
+      .eq('gang_type_id', gangTypeId),
+    supabase
+      .from('gang_types')
+      .select('gang_type_id', { count: 'exact', head: true })
+      .eq('parent_gang_type_id', gangTypeId),
+  ]);
 
   if (gangError) throw gangError;
+  if (fighterTypeError) throw fighterTypeError;
+  if (tacticsPackError) throw tacticsPackError;
+  if (childTypeError) throw childTypeError;
 
-  if ((gangCount ?? 0) > 0) {
-    return 'Cannot change edition_id while gangs still reference this gang type';
+  if (
+    (gangCount ?? 0) > 0 ||
+    (fighterTypeCount ?? 0) > 0 ||
+    (tacticsPackCount ?? 0) > 0 ||
+    (childTypeCount ?? 0) > 0
+  ) {
+    return 'Cannot change edition_id while gangs, fighter types, tactics packs, or child gang types still reference this gang type';
   }
 
   return null;
@@ -586,6 +612,8 @@ async function remapPinnedDefaultImages(
       if (error) throw error;
     }
   } catch (error) {
+    // Best-effort, not transactional: phase-2 rows already written to `to` no
+    // longer match -(from+1), so they stay migrated while later entries revert.
     for (const [from] of changes) {
       await supabase
         .from('gangs')

--- a/app/api/admin/gang-types/route.ts
+++ b/app/api/admin/gang-types/route.ts
@@ -4,6 +4,7 @@ import { createClient } from "@/utils/supabase/server";
 import { checkAdmin } from "@/utils/auth";
 import { revalidateTag } from "next/cache";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { isValidHttpUrl } from '@/utils/http-url';
 
 const GANG_TYPE_LIST_COLUMNS = 'gang_type_id, gang_type, edition_id';
 
@@ -38,18 +39,18 @@ function emptyToNull(value: unknown): string | null {
   return trimmed === '' ? null : trimmed;
 }
 
-function parseBoolean(value: unknown, defaultValue = false): boolean {
-  if (typeof value === 'boolean') return value;
-  return defaultValue;
-}
-
-function isValidHttpUrl(value: string): boolean {
-  try {
-    const parsed = new URL(value);
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
-  } catch {
-    return false;
+function parseOptionalBoolean(
+  value: unknown,
+  field: string,
+  defaultValue: boolean
+): { error: string } | { data: boolean } {
+  if (value === undefined || value === null) {
+    return { data: defaultValue };
   }
+  if (typeof value === 'boolean') {
+    return { data: value };
+  }
+  return { error: `${field} must be a boolean` };
 }
 
 function parseDefaultImageUrls(value: unknown):
@@ -161,13 +162,23 @@ function validateGangTypePayload(body: {
     return defaultImages;
   }
 
+  const isHidden = parseOptionalBoolean(body.is_hidden, 'is_hidden', false);
+  if ('error' in isHidden) {
+    return isHidden;
+  }
+
+  const affiliation = parseOptionalBoolean(body.affiliation, 'affiliation', false);
+  if ('error' in affiliation) {
+    return affiliation;
+  }
+
   return {
     data: {
       gang_type: gangType,
       edition_id: editionId,
       alignment,
-      is_hidden: parseBoolean(body.is_hidden),
-      affiliation: parseBoolean(body.affiliation),
+      is_hidden: isHidden.data,
+      affiliation: affiliation.data,
       trading_post_type_id: emptyToNull(body.trading_post_type_id),
       gang_origin_category_id: emptyToNull(body.gang_origin_category_id),
       parent_gang_type_id: emptyToNull(body.parent_gang_type_id),
@@ -291,6 +302,55 @@ async function assertEditionScopedRefs(
   return editionError ?? tradingPostError ?? originError ?? parentError;
 }
 
+async function assertEditionChangeAllowed(
+  supabase: SupabaseClient,
+  gangTypeId: string,
+  currentEditionId: string | null,
+  nextEditionId: string
+): Promise<string | null> {
+  if (currentEditionId === nextEditionId) return null;
+
+  const [
+    { count: gangCount, error: gangError },
+    { count: fighterTypeCount, error: fighterTypeError },
+    { count: tacticsPackCount, error: tacticsPackError },
+    { count: childTypeCount, error: childTypeError },
+  ] = await Promise.all([
+    supabase
+      .from('gangs')
+      .select('id', { count: 'exact', head: true })
+      .eq('gang_type_id', gangTypeId),
+    supabase
+      .from('fighter_types')
+      .select('id', { count: 'exact', head: true })
+      .eq('gang_type_id', gangTypeId),
+    supabase
+      .from('tactics_cards_packs')
+      .select('id', { count: 'exact', head: true })
+      .eq('gang_type_id', gangTypeId),
+    supabase
+      .from('gang_types')
+      .select('gang_type_id', { count: 'exact', head: true })
+      .eq('parent_gang_type_id', gangTypeId),
+  ]);
+
+  if (gangError) throw gangError;
+  if (fighterTypeError) throw fighterTypeError;
+  if (tacticsPackError) throw tacticsPackError;
+  if (childTypeError) throw childTypeError;
+
+  if (
+    (gangCount ?? 0) > 0 ||
+    (fighterTypeCount ?? 0) > 0 ||
+    (tacticsPackCount ?? 0) > 0 ||
+    (childTypeCount ?? 0) > 0
+  ) {
+    return 'Cannot change edition_id while gangs, fighter types, tactics packs, or child gang types still reference this gang type';
+  }
+
+  return null;
+}
+
 function withReferenceInvalidation(
   handler: (request: Request) => Promise<Response>
 ) {
@@ -386,6 +446,27 @@ async function _PATCH(request: Request) {
     const validated = validateGangTypePayload(body);
     if ('error' in validated) {
       return NextResponse.json({ error: validated.error }, { status: 400 });
+    }
+
+    const { data: existing, error: existingError } = await supabase
+      .from('gang_types')
+      .select('gang_type_id, edition_id')
+      .eq('gang_type_id', gangTypeId)
+      .maybeSingle();
+
+    if (existingError) throw existingError;
+    if (!existing) {
+      return NextResponse.json({ error: 'Gang type not found' }, { status: 404 });
+    }
+
+    const editionChangeError = await assertEditionChangeAllowed(
+      supabase,
+      gangTypeId,
+      existing.edition_id,
+      validated.data.edition_id
+    );
+    if (editionChangeError) {
+      return NextResponse.json({ error: editionChangeError }, { status: 409 });
     }
 
     const refError = await assertEditionScopedRefs(supabase, validated.data, gangTypeId);

--- a/app/api/admin/gang-types/route.ts
+++ b/app/api/admin/gang-types/route.ts
@@ -633,11 +633,7 @@ function withReferenceInvalidation(
   return async (request: Request) => {
     const response = await handler(request);
     if (response.ok) {
-      const body = await response.clone().json().catch(() => null);
-      const gangTypeId = body && typeof body.gang_type_id === 'string'
-        ? body.gang_type_id
-        : undefined;
-      invalidateGangTypesCatalog(gangTypeId);
+      invalidateGangTypesCatalog();
     }
     return response;
   };

--- a/app/api/admin/gang-types/route.ts
+++ b/app/api/admin/gang-types/route.ts
@@ -1,8 +1,307 @@
 import { TAGS } from '@/utils/cache-tags';
-import { NextResponse } from 'next/server'
+import { NextResponse } from 'next/server';
 import { createClient } from "@/utils/supabase/server";
 import { checkAdmin } from "@/utils/auth";
 import { revalidateTag } from "next/cache";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const GANG_TYPE_LIST_COLUMNS = 'gang_type_id, gang_type, edition_id';
+
+const GANG_TYPE_COLUMNS =
+  'gang_type_id, gang_type, alignment, is_hidden, affiliation, trading_post_type_id, gang_origin_category_id, parent_gang_type_id, default_image_urls, edition_id';
+
+const ALLOWED_ALIGNMENTS = [
+  'Law Abiding',
+  'Outlaw',
+  'Unaligned',
+] as const;
+
+type GangTypePayload = {
+  gang_type: string;
+  edition_id: string;
+  alignment: string | null;
+  is_hidden: boolean;
+  affiliation: boolean;
+  trading_post_type_id: string | null;
+  gang_origin_category_id: string | null;
+  parent_gang_type_id: string | null;
+  default_image_urls: Array<{
+    url: string;
+    credit?: { name?: string; url?: string; suffix?: string };
+  }> | null;
+};
+
+function emptyToNull(value: unknown): string | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed === '' ? null : trimmed;
+}
+
+function parseBoolean(value: unknown, defaultValue = false): boolean {
+  if (typeof value === 'boolean') return value;
+  return defaultValue;
+}
+
+function isValidHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function parseDefaultImageUrls(value: unknown):
+  | { error: string }
+  | { data: GangTypePayload['default_image_urls'] } {
+  if (value === undefined || value === null || value === '') {
+    return { data: null };
+  }
+
+  if (!Array.isArray(value)) {
+    return { error: 'default_image_urls must be an array or null' };
+  }
+
+  const parsed: NonNullable<GangTypePayload['default_image_urls']> = [];
+
+  for (const entry of value) {
+    if (typeof entry === 'string') {
+      const url = entry.trim();
+      if (!url) continue;
+      if (!isValidHttpUrl(url)) {
+        return { error: 'default_image_urls entries must be valid http(s) URLs' };
+      }
+      parsed.push({ url });
+      continue;
+    }
+
+    if (!entry || typeof entry !== 'object') {
+      return { error: 'default_image_urls entries must be objects or URL strings' };
+    }
+
+    const url = emptyToNull((entry as { url?: unknown }).url);
+    const rawCredit = (entry as { credit?: unknown }).credit;
+    const creditFields = rawCredit && typeof rawCredit === 'object'
+      ? {
+          name: emptyToNull((rawCredit as { name?: unknown }).name),
+          url: emptyToNull((rawCredit as { url?: unknown }).url),
+          suffix: emptyToNull((rawCredit as { suffix?: unknown }).suffix),
+        }
+      : { name: null, url: null, suffix: null };
+
+    if (!url) {
+      if (creditFields.name || creditFields.url || creditFields.suffix) {
+        return { error: 'default_image_urls entries require an image url when credit fields are set' };
+      }
+      return { error: 'default_image_urls entries require a valid http(s) image url' };
+    }
+    if (!isValidHttpUrl(url)) {
+      return { error: 'default_image_urls entries must be valid http(s) URLs' };
+    }
+
+    if (!rawCredit || typeof rawCredit !== 'object') {
+      parsed.push({ url });
+      continue;
+    }
+
+    const creditName = creditFields.name;
+    const creditUrl = creditFields.url;
+    const creditSuffix = creditFields.suffix;
+
+    if (creditUrl && !isValidHttpUrl(creditUrl)) {
+      return { error: 'default_image_urls credit url must be a valid http(s) URL' };
+    }
+
+    const credit: { name?: string; url?: string; suffix?: string } = {
+      ...(creditName ? { name: creditName } : {}),
+      ...(creditUrl ? { url: creditUrl } : {}),
+      ...(creditSuffix ? { suffix: creditSuffix } : {}),
+    };
+
+    parsed.push(Object.keys(credit).length > 0 ? { url, credit } : { url });
+  }
+
+  return { data: parsed.length > 0 ? parsed : null };
+}
+
+function validateGangTypePayload(body: {
+  gang_type?: unknown;
+  edition_id?: unknown;
+  alignment?: unknown;
+  is_hidden?: unknown;
+  affiliation?: unknown;
+  trading_post_type_id?: unknown;
+  gang_origin_category_id?: unknown;
+  parent_gang_type_id?: unknown;
+  default_image_urls?: unknown;
+}): { error: string } | { data: GangTypePayload } {
+  const gangType = emptyToNull(body.gang_type);
+  const editionId = emptyToNull(body.edition_id);
+
+  if (!gangType) {
+    return { error: 'gang_type is required' };
+  }
+
+  if (gangType.length > 200) {
+    return { error: 'gang_type must be 200 characters or less' };
+  }
+
+  if (!editionId) {
+    return { error: 'edition_id is required' };
+  }
+
+  const alignment = emptyToNull(body.alignment);
+  if (alignment && !(ALLOWED_ALIGNMENTS as readonly string[]).includes(alignment)) {
+    return { error: 'Invalid alignment' };
+  }
+
+  const defaultImages = parseDefaultImageUrls(body.default_image_urls);
+  if ('error' in defaultImages) {
+    return defaultImages;
+  }
+
+  return {
+    data: {
+      gang_type: gangType,
+      edition_id: editionId,
+      alignment,
+      is_hidden: parseBoolean(body.is_hidden),
+      affiliation: parseBoolean(body.affiliation),
+      trading_post_type_id: emptyToNull(body.trading_post_type_id),
+      gang_origin_category_id: emptyToNull(body.gang_origin_category_id),
+      parent_gang_type_id: emptyToNull(body.parent_gang_type_id),
+      default_image_urls: defaultImages.data,
+    },
+  };
+}
+
+async function assertEditionExists(
+  supabase: SupabaseClient,
+  editionId: string
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('editions')
+    .select('id')
+    .eq('id', editionId)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) return 'edition_id not found';
+  return null;
+}
+
+async function assertTradingPostMatchesEdition(
+  supabase: SupabaseClient,
+  tradingPostTypeId: string | null,
+  editionId: string
+): Promise<string | null> {
+  if (!tradingPostTypeId) return null;
+
+  const { data, error } = await supabase
+    .from('trading_post_types')
+    .select('id, edition_id')
+    .eq('id', tradingPostTypeId)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) return 'trading_post_type_id must reference an existing trading post type';
+  if (data.edition_id && data.edition_id !== editionId) {
+    return 'trading_post_type_id must be a trading post type of the same edition';
+  }
+  return null;
+}
+
+async function assertOriginCategoryExists(
+  supabase: SupabaseClient,
+  originCategoryId: string | null
+): Promise<string | null> {
+  if (!originCategoryId) return null;
+
+  const { data, error } = await supabase
+    .from('gang_origin_categories')
+    .select('id')
+    .eq('id', originCategoryId)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) return 'gang_origin_category_id must reference an existing origin category';
+  return null;
+}
+
+async function assertParentGangType(
+  supabase: SupabaseClient,
+  parentGangTypeId: string | null,
+  editionId: string,
+  currentGangTypeId?: string
+): Promise<string | null> {
+  if (!parentGangTypeId) return null;
+
+  if (currentGangTypeId && parentGangTypeId === currentGangTypeId) {
+    return 'parent_gang_type_id cannot reference itself';
+  }
+
+  const { data, error } = await supabase
+    .from('gang_types')
+    .select('gang_type_id, edition_id, parent_gang_type_id')
+    .eq('gang_type_id', parentGangTypeId)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) return 'parent_gang_type_id must reference an existing gang type';
+  if (data.edition_id !== editionId) {
+    return 'parent_gang_type_id must be a gang type of the same edition';
+  }
+  if (data.parent_gang_type_id) {
+    return 'parent_gang_type_id must reference a root gang type';
+  }
+
+  if (currentGangTypeId) {
+    const { data: children, error: childrenError } = await supabase
+      .from('gang_types')
+      .select('gang_type_id')
+      .eq('parent_gang_type_id', currentGangTypeId)
+      .limit(1);
+
+    if (childrenError) throw childrenError;
+    if (children && children.length > 0) {
+      return 'cannot set parent_gang_type_id on a gang type that is already a parent of other gang lists';
+    }
+  }
+
+  return null;
+}
+
+async function assertEditionScopedRefs(
+  supabase: SupabaseClient,
+  payload: GangTypePayload,
+  currentGangTypeId?: string
+): Promise<string | null> {
+  const [editionError, tradingPostError, originError, parentError] = await Promise.all([
+    assertEditionExists(supabase, payload.edition_id),
+    assertTradingPostMatchesEdition(supabase, payload.trading_post_type_id, payload.edition_id),
+    assertOriginCategoryExists(supabase, payload.gang_origin_category_id),
+    assertParentGangType(
+      supabase,
+      payload.parent_gang_type_id,
+      payload.edition_id,
+      currentGangTypeId
+    ),
+  ]);
+  return editionError ?? tradingPostError ?? originError ?? parentError;
+}
+
+function withReferenceInvalidation(
+  handler: (request: Request) => Promise<Response>
+) {
+  return async (request: Request) => {
+    const response = await handler(request);
+    if (response.ok) {
+      revalidateTag(TAGS.globalGangTypes(), { expire: 0 });
+    }
+    return response;
+  };
+}
 
 export async function GET(request: Request) {
   const supabase = await createClient();
@@ -13,9 +312,10 @@ export async function GET(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    const detailed = new URL(request.url).searchParams.get('detailed') === '1';
     const { data, error } = await supabase
       .from('gang_types')
-      .select('gang_type_id, gang_type, edition_id')
+      .select(detailed ? GANG_TYPE_COLUMNS : GANG_TYPE_LIST_COLUMNS)
       .order('gang_type');
 
     if (error) throw error;
@@ -29,133 +329,91 @@ export async function GET(request: Request) {
   }
 }
 
-// Add interface for the request data
-interface FighterTypeData {
-  fighterType: string;
-  baseCost: number;
-  gangTypeId: string;
-  fighterSubtype: string;
-  fighterSubtypes?: string[];
-  movement: number;
-  weapon_skill: number;
-  ballistic_skill: number;
-  strength: number;
-  toughness: number;
-  wounds: number;
-  initiative: number;
-  leadership: number;
-  cool: number;
-  willpower: number;
-  intelligence: number;
-  attacks: number;
-  special_rules?: string;
-  free_skill: boolean;
-  default_equipment?: string[];  // Array of equipment IDs
-}
-
 async function _POST(request: Request) {
   const supabase = await createClient();
 
   try {
-    // Check admin authorization
     const isAdmin = await checkAdmin(supabase);
-
     if (!isAdmin) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const data: FighterTypeData = await request.json();
+    const body = await request.json();
+    const validated = validateGangTypePayload(body);
+    if ('error' in validated) {
+      return NextResponse.json({ error: validated.error }, { status: 400 });
+    }
 
-    // Get the gang type
-    const { data: gangType, error: gangTypeError } = await supabase
+    const refError = await assertEditionScopedRefs(supabase, validated.data);
+    if (refError) {
+      return NextResponse.json({ error: refError }, { status: 400 });
+    }
+
+    const { data: gangType, error } = await supabase
       .from('gang_types')
-      .select('gang_type')
-      .eq('gang_type_id', data.gangTypeId)
+      .insert([validated.data])
+      .select(GANG_TYPE_COLUMNS)
       .single();
 
-    if (gangTypeError) {
-      console.error('Error fetching gang type:', gangTypeError);
-      throw gangTypeError;
-    }
+    if (error) throw error;
 
-    if (!gangType) {
-      throw new Error('Gang type not found');
-    }
-
-    // Create fighter type
-    const { data: newFighterType, error: insertError } = await supabase
-      .from('fighter_types')
-      .insert([{
-        fighter_type: data.fighterType,
-        cost: data.baseCost,
-        gang_type_id: data.gangTypeId,
-        gang_type: gangType.gang_type,
-        fighter_subtypes: Array.isArray(data.fighterSubtypes) ? data.fighterSubtypes : [],
-        movement: data.movement,
-        weapon_skill: data.weapon_skill,
-        ballistic_skill: data.ballistic_skill,
-        strength: data.strength,
-        toughness: data.toughness,
-        wounds: data.wounds,
-        initiative: data.initiative,
-        leadership: data.leadership,
-        cool: data.cool,
-        willpower: data.willpower,
-        intelligence: data.intelligence,
-        attacks: data.attacks,
-        special_rules: data.special_rules,
-        free_skill: data.free_skill
-      }])
-      .select('id')
-      .single();
-
-    if (insertError) {
-      console.error('Error inserting fighter type:', insertError);
-      throw insertError;
-    }
-
-    // Create equipment defaults with proper typing
-    if (data.default_equipment && data.default_equipment.length > 0) {
-      const equipmentDefaults = data.default_equipment.map((equipmentId: string) => ({
-        fighter_type_id: newFighterType.id,
-        equipment_id: equipmentId
-      }));
-
-      const { error: equipmentError } = await supabase
-        .from('fighter_defaults')
-        .insert(equipmentDefaults);
-
-      if (equipmentError) {
-        console.error('Error inserting equipment defaults:', equipmentError);
-        throw equipmentError;
-      }
-    }
-
-    return NextResponse.json({ success: true });
+    return NextResponse.json(gangType);
   } catch (error) {
-    console.error('Detailed error in POST:', error);
-    
-    return NextResponse.json({ 
-      error: 'Error creating fighter type',
-      details: error instanceof Error ? error.message : 'Unknown error',
-      name: error instanceof Error ? error.name : 'Unknown'
-    }, { status: 500 });
+    console.error('Error creating gang type:', error);
+    return NextResponse.json(
+      { error: 'Failed to create gang type' },
+      { status: 500 }
+    );
   }
-} 
+}
 
-// Admin edits change global reference data that is cached app-wide; fire the
-// matching tags once per successful mutation (previously nothing was fired,
-// so admin edits never showed up until caches expired).
-function withReferenceInvalidation(
-  handler: (...args: any[]) => Promise<Response>
-) {
-  return async (...args: any[]) => {
-    const response = await handler(...args);
-    if (response.ok) {
-      revalidateTag(TAGS.globalGangTypes(), { expire: 0 });
+async function _PATCH(request: Request) {
+  const supabase = await createClient();
+
+  try {
+    const isAdmin = await checkAdmin(supabase);
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
-    return response;
-  };
+
+    const body = await request.json();
+    const gangTypeId = emptyToNull(body.gang_type_id);
+
+    if (!gangTypeId) {
+      return NextResponse.json({ error: 'gang_type_id is required' }, { status: 400 });
+    }
+
+    const validated = validateGangTypePayload(body);
+    if ('error' in validated) {
+      return NextResponse.json({ error: validated.error }, { status: 400 });
+    }
+
+    const refError = await assertEditionScopedRefs(supabase, validated.data, gangTypeId);
+    if (refError) {
+      return NextResponse.json({ error: refError }, { status: 400 });
+    }
+
+    const { data: gangType, error } = await supabase
+      .from('gang_types')
+      .update(validated.data)
+      .eq('gang_type_id', gangTypeId)
+      .select(GANG_TYPE_COLUMNS)
+      .maybeSingle();
+
+    if (error) throw error;
+    if (!gangType) {
+      return NextResponse.json({ error: 'Gang type not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(gangType);
+  } catch (error) {
+    console.error('Error updating gang type:', error);
+    return NextResponse.json(
+      { error: 'Failed to update gang type' },
+      { status: 500 }
+    );
+  }
 }
 
 export const POST = withReferenceInvalidation(_POST);
+export const PATCH = withReferenceInvalidation(_PATCH);

--- a/app/api/admin/gang-types/route.ts
+++ b/app/api/admin/gang-types/route.ts
@@ -1,10 +1,9 @@
-import { TAGS } from '@/utils/cache-tags';
 import { NextResponse } from 'next/server';
 import { createClient } from "@/utils/supabase/server";
 import { checkAdmin } from "@/utils/auth";
-import { revalidateTag } from "next/cache";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { isValidHttpUrl } from '@/utils/http-url';
+import { invalidateGangTypesCatalog } from '@/utils/cache-tags';
 
 const GANG_TYPE_LIST_COLUMNS = 'gang_type_id, gang_type, edition_id';
 
@@ -634,7 +633,11 @@ function withReferenceInvalidation(
   return async (request: Request) => {
     const response = await handler(request);
     if (response.ok) {
-      revalidateTag(TAGS.globalGangTypes(), { expire: 0 });
+      const body = await response.clone().json().catch(() => null);
+      const gangTypeId = body && typeof body.gang_type_id === 'string'
+        ? body.gang_type_id
+        : undefined;
+      invalidateGangTypesCatalog(gangTypeId);
     }
     return response;
   };

--- a/app/lib/get-user-gangs.ts
+++ b/app/lib/get-user-gangs.ts
@@ -27,26 +27,20 @@ export type Gang = {
 };
 
 /**
- * Cached list of the user's gang ids and types, so the list entry below can
- * carry per-gang and per-type tags (dynamic tags must be known before the
- * cached call). Busted via user-{id} whenever the list shape changes.
+ * Cached list of the user's gang ids, so the list entry below can carry
+ * per-gang tags (dynamic tags must be known before the cached call).
+ * Busted via user-{id} whenever the list shape changes (create/delete/copy).
  */
-const getUserGangIdsCached = async (
-  userId: string,
-  supabase: any
-): Promise<Array<{ id: string; gang_type_id: string | null }>> => {
+const getUserGangIdsCached = async (userId: string, supabase: any): Promise<string[]> => {
   return unstable_cache(
     async () => {
       const { data } = await supabase
         .from('gangs')
-        .select('id, gang_type_id')
+        .select('id')
         .eq('user_id', userId);
-      return (data || []).map((g: { id: string; gang_type_id: string | null }) => ({
-        id: g.id,
-        gang_type_id: g.gang_type_id,
-      }));
+      return (data || []).map((g: { id: string }) => g.id);
     },
-    [`user-gang-ids-v3-${userId}`],
+    [`user-gang-ids-v4-${userId}`],
     {
       tags: [TAGS.user(userId)],
       revalidate: false
@@ -55,11 +49,7 @@ const getUserGangIdsCached = async (
 };
 
 export const getUserGangs = async (userId: string, supabase: any): Promise<Gang[]> => {
-  const gangsForTags = await getUserGangIdsCached(userId, supabase);
-  const gangIdsForTags = gangsForTags.map((g) => g.id);
-  const gangTypeIdsForTags = [...new Set(
-    gangsForTags.map((g) => g.gang_type_id).filter((id): id is string => Boolean(id))
-  )];
+  const gangIdsForTags = await getUserGangIdsCached(userId, supabase);
 
   return unstable_cache(
     async () => {
@@ -175,16 +165,13 @@ export const getUserGangs = async (userId: string, supabase: any): Promise<Gang[
         throw error;
       }
     },
-    [`user-gangs-v4-${userId}`],
+    [`user-gangs-v5-${userId}`],
     {
       tags: [
         // List shape (create/delete/copy gang, favourites)
         TAGS.user(userId),
-        // Catalog portraits/names joined from gang_types (any type edit)
+        // Catalog portraits/names joined from gang_types (admin gang-type writes)
         TAGS.globalGangTypes(),
-        // Same copies, scoped to a type so an Escher edit does not wait on
-        // the global tag alone — admin gang-type writes fire this tag.
-        ...gangTypeIdsForTags.map(id => TAGS.gangType(id)),
         // Card fields: rating/credits/name via the financials choke point
         ...gangIdsForTags.map(id => TAGS.gangOverview(id)),
         // Campaign names on cards: join/leave (previously never invalidated)

--- a/app/lib/get-user-gangs.ts
+++ b/app/lib/get-user-gangs.ts
@@ -27,20 +27,26 @@ export type Gang = {
 };
 
 /**
- * Cached list of the user's gang ids, so the list entry below can carry
- * per-gang tags (dynamic tags must be known before the cached call).
- * Busted via user-{id} whenever the list shape changes (create/delete/copy).
+ * Cached list of the user's gang ids and types, so the list entry below can
+ * carry per-gang and per-type tags (dynamic tags must be known before the
+ * cached call). Busted via user-{id} whenever the list shape changes.
  */
-const getUserGangIdsCached = async (userId: string, supabase: any): Promise<string[]> => {
+const getUserGangIdsCached = async (
+  userId: string,
+  supabase: any
+): Promise<Array<{ id: string; gang_type_id: string | null }>> => {
   return unstable_cache(
     async () => {
       const { data } = await supabase
         .from('gangs')
-        .select('id')
+        .select('id, gang_type_id')
         .eq('user_id', userId);
-      return (data || []).map((g: any) => g.id);
+      return (data || []).map((g: { id: string; gang_type_id: string | null }) => ({
+        id: g.id,
+        gang_type_id: g.gang_type_id,
+      }));
     },
-    [`user-gang-ids-v2-${userId}`],
+    [`user-gang-ids-v3-${userId}`],
     {
       tags: [TAGS.user(userId)],
       revalidate: false
@@ -49,7 +55,11 @@ const getUserGangIdsCached = async (userId: string, supabase: any): Promise<stri
 };
 
 export const getUserGangs = async (userId: string, supabase: any): Promise<Gang[]> => {
-  const gangIdsForTags = await getUserGangIdsCached(userId, supabase);
+  const gangsForTags = await getUserGangIdsCached(userId, supabase);
+  const gangIdsForTags = gangsForTags.map((g) => g.id);
+  const gangTypeIdsForTags = [...new Set(
+    gangsForTags.map((g) => g.gang_type_id).filter((id): id is string => Boolean(id))
+  )];
 
   return unstable_cache(
     async () => {
@@ -165,13 +175,16 @@ export const getUserGangs = async (userId: string, supabase: any): Promise<Gang[
         throw error;
       }
     },
-    [`user-gangs-v3-${userId}`],
+    [`user-gangs-v4-${userId}`],
     {
       tags: [
         // List shape (create/delete/copy gang, favourites)
         TAGS.user(userId),
-        // Catalog portraits/names joined from gang_types (admin gang-type writes)
+        // Catalog portraits/names joined from gang_types (any type edit)
         TAGS.globalGangTypes(),
+        // Same copies, scoped to a type so an Escher edit does not wait on
+        // the global tag alone — admin gang-type writes fire this tag.
+        ...gangTypeIdsForTags.map(id => TAGS.gangType(id)),
         // Card fields: rating/credits/name via the financials choke point
         ...gangIdsForTags.map(id => TAGS.gangOverview(id)),
         // Campaign names on cards: join/leave (previously never invalidated)

--- a/app/lib/get-user-gangs.ts
+++ b/app/lib/get-user-gangs.ts
@@ -165,11 +165,13 @@ export const getUserGangs = async (userId: string, supabase: any): Promise<Gang[
         throw error;
       }
     },
-    [`user-gangs-v2-${userId}`],
+    [`user-gangs-v3-${userId}`],
     {
       tags: [
         // List shape (create/delete/copy gang, favourites)
         TAGS.user(userId),
+        // Catalog portraits/names joined from gang_types (admin gang-type writes)
+        TAGS.globalGangTypes(),
         // Card fields: rating/credits/name via the financials choke point
         ...gangIdsForTags.map(id => TAGS.gangOverview(id)),
         // Campaign names on cards: join/leave (previously never invalidated)

--- a/app/lib/shared/gang-data.ts
+++ b/app/lib/shared/gang-data.ts
@@ -241,9 +241,9 @@ export const getGangCore = async (gangId: string, supabase: any): Promise<GangCo
         venator_ranks_incomplete: venatorRanksIncomplete,
       };
     },
-    [`gang-core-v5-${gangId}`],
+    [`gang-core-v6-${gangId}`],
     {
-      tags: [TAGS.gang(gangId)],
+      tags: [TAGS.gang(gangId), TAGS.globalGangTypes()],
       revalidate: false
     }
   )();

--- a/components/admin/admin-gang-types.tsx
+++ b/components/admin/admin-gang-types.tsx
@@ -200,7 +200,7 @@ export function AdminGangTypesModal({ onClose }: AdminGangTypesModalProps) {
 
   const filteredGangTypes = useMemo(
     () => editionId
-      ? gangTypes.filter(gt => gt.edition_id === editionId)
+      ? gangTypes.filter(gt => !gt.edition_id || gt.edition_id === editionId)
       : gangTypes,
     [gangTypes, editionId]
   );
@@ -240,7 +240,7 @@ export function AdminGangTypesModal({ onClose }: AdminGangTypesModalProps) {
     setOriginCategoryId(gangType.gang_origin_category_id ?? '');
     setParentGangTypeId(gangType.parent_gang_type_id ?? '');
     setDefaultImages(toImageFormEntries(gangType.default_image_urls));
-    setEditionId(gangType.edition_id ?? '');
+    setEditionId(gangType.edition_id || editionId);
   };
 
   const handleEditionChange = (newEditionId: string) => {
@@ -248,7 +248,7 @@ export function AdminGangTypesModal({ onClose }: AdminGangTypesModalProps) {
 
     if (newEditionId && selectedGangTypeId) {
       const gangType = gangTypes.find(gt => gt.gang_type_id === selectedGangTypeId);
-      if (gangType && gangType.edition_id !== newEditionId) {
+      if (gangType?.edition_id && gangType.edition_id !== newEditionId) {
         setSelectedGangTypeId('');
         clearFormFields();
         setIsCreateMode(false);
@@ -414,6 +414,7 @@ export function AdminGangTypesModal({ onClose }: AdminGangTypesModalProps) {
                 {filteredGangTypes.map((gangType) => (
                   <option key={gangType.gang_type_id} value={gangType.gang_type_id}>
                     {gangType.gang_type}
+                    {!gangType.edition_id ? ' (no edition)' : ''}
                     {gangType.is_hidden ? ' (hidden)' : ''}
                     {gangType.parent_gang_type_id ? ' (variant)' : ''}
                   </option>
@@ -560,6 +561,10 @@ export function AdminGangTypesModal({ onClose }: AdminGangTypesModalProps) {
                   Add Image
                 </Button>
               </div>
+              <p className="text-xs text-muted-foreground mb-2">
+                Gangs pin a portrait by position. Removing an image remaps later
+                portraits and cannot be undone.
+              </p>
               {defaultImages.length === 0 && (
                 <p className="text-xs text-muted-foreground">No default images.</p>
               )}
@@ -573,7 +578,15 @@ export function AdminGangTypesModal({ onClose }: AdminGangTypesModalProps) {
                       <Button
                         type="button"
                         variant="outline"
-                        onClick={() => setDefaultImages((current) => current.filter((_, i) => i !== index))}
+                        onClick={() => {
+                          const hasPinnedUrl = Boolean(entry.url.trim());
+                          if (hasPinnedUrl && !window.confirm(
+                            'Remove this image? Gangs using it will lose that default portrait, and later images will shift. This cannot be undone.'
+                          )) {
+                            return;
+                          }
+                          setDefaultImages((current) => current.filter((_, i) => i !== index));
+                        }}
                         disabled={isFormDisabled}
                         className="text-xs h-7 px-2"
                       >

--- a/components/admin/admin-gang-types.tsx
+++ b/components/admin/admin-gang-types.tsx
@@ -220,6 +220,11 @@ export function AdminGangTypesModal({ onClose }: AdminGangTypesModalProps) {
     [filteredGangTypes, selectedGangTypeId]
   );
 
+  const selectedGangType = gangTypes.find(gt => gt.gang_type_id === selectedGangTypeId);
+  const willAssignEdition = Boolean(
+    !isCreateMode && selectedGangType && !selectedGangType.edition_id && editionId
+  );
+
   const clearFormFields = () => {
     setGangTypeName('');
     setAlignment('');
@@ -389,7 +394,15 @@ export function AdminGangTypesModal({ onClose }: AdminGangTypesModalProps) {
 
         <div className="px-[10px] py-4">
           <div className="space-y-4">
-            <EditionSelect value={editionId} onChange={handleEditionChange} defaultToCurrent />
+            <div>
+              <EditionSelect value={editionId} onChange={handleEditionChange} defaultToCurrent />
+              {willAssignEdition && (
+                <p className="text-xs text-amber-600 mt-1">
+                  This gang type has no edition. Saving will assign it to the
+                  edition selected above.
+                </p>
+              )}
+            </div>
 
             <div>
               <div className="flex justify-between items-center mb-1">

--- a/components/admin/admin-gang-types.tsx
+++ b/components/admin/admin-gang-types.tsx
@@ -9,6 +9,7 @@ import { toast } from 'sonner';
 import { LuPlus, LuTrash2 } from "react-icons/lu";
 import { EditionSelect } from '@/components/edition-select';
 import { normaliseDefaultImageUrls, type DefaultImageEntry } from '@/types/gang';
+import { isValidHttpUrl } from '@/utils/http-url';
 
 enum OperationType {
   POST = 'POST',
@@ -34,14 +35,6 @@ interface TradingPostType {
   edition_id?: string | null;
 }
 
-interface GangOrigin {
-  id: string;
-  origin_name: string;
-  edition_id?: string | null;
-  category_id: string | null;
-  category_name: string;
-}
-
 interface OriginCategory {
   id: string;
   category_name: string;
@@ -62,19 +55,10 @@ function emptyImageEntry(): ImageFormEntry {
   return { url: '', creditName: '', creditUrl: '', creditSuffix: '' };
 }
 
-function isPreviewableUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url.trim());
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
-  } catch {
-    return false;
-  }
-}
-
 function DefaultImagePreview({ url, className }: { url: string; className?: string }) {
   const [failed, setFailed] = useState(false);
   const trimmed = url.trim();
-  const previewable = isPreviewableUrl(trimmed);
+  const previewable = isValidHttpUrl(trimmed);
 
   useEffect(() => {
     setFailed(false);
@@ -134,12 +118,12 @@ function defaultImagesValidationError(entries: ImageFormEntry[]): string | null 
     if (!imageUrl) {
       return `Image ${index + 1}: image URL is required`;
     }
-    if (!isPreviewableUrl(imageUrl)) {
+    if (!isValidHttpUrl(imageUrl)) {
       return `Image ${index + 1}: image URL must be a valid http(s) URL`;
     }
 
     const creditUrl = entry.creditUrl.trim();
-    if (creditUrl && !isPreviewableUrl(creditUrl)) {
+    if (creditUrl && !isValidHttpUrl(creditUrl)) {
       return `Image ${index + 1}: credit URL must be a valid http(s) URL`;
     }
   }
@@ -201,32 +185,18 @@ export function AdminGangTypesModal({ onClose }: AdminGangTypesModalProps) {
     staleTime: 5 * 60 * 1000,
   });
 
-  const { data: origins = [], isLoading: isLoadingOrigins } = useQuery<GangOrigin[]>({
-    queryKey: ['admin-gang-origins'],
+  const { data: originCategories = [], isLoading: isLoadingOriginCategories } = useQuery<OriginCategory[]>({
+    queryKey: ['admin-gang-origin-categories'],
     queryFn: async () => {
-      const response = await fetch('/api/admin/gang-origins');
-      if (!response.ok) throw new Error('Failed to fetch gang origins');
+      const response = await fetch('/api/admin/gang-origin-categories');
+      if (!response.ok) throw new Error('Failed to fetch origin categories');
       return response.json();
     },
     staleTime: 5 * 60 * 1000,
   });
 
-  const isLoading = isLoadingGangTypes || isLoadingTradingPosts || isLoadingOrigins || isSubmitting;
+  const isLoading = isLoadingGangTypes || isLoadingTradingPosts || isLoadingOriginCategories || isSubmitting;
   const isFormDisabled = (!isCreateMode && !selectedGangTypeId) || isLoading;
-
-  const originCategories = useMemo<OriginCategory[]>(() => {
-    const byId = new Map<string, OriginCategory>();
-    for (const origin of origins) {
-      if (!origin.category_id) continue;
-      if (!byId.has(origin.category_id)) {
-        byId.set(origin.category_id, {
-          id: origin.category_id,
-          category_name: origin.category_name,
-        });
-      }
-    }
-    return [...byId.values()].sort((a, b) => a.category_name.localeCompare(b.category_name));
-  }, [origins]);
 
   const filteredGangTypes = useMemo(
     () => editionId

--- a/components/admin/admin-gang-types.tsx
+++ b/components/admin/admin-gang-types.tsx
@@ -1,0 +1,690 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { toast } from 'sonner';
+import { LuPlus, LuTrash2 } from "react-icons/lu";
+import { EditionSelect } from '@/components/edition-select';
+import { normaliseDefaultImageUrls, type DefaultImageEntry } from '@/types/gang';
+
+enum OperationType {
+  POST = 'POST',
+  UPDATE = 'UPDATE'
+}
+
+interface AdminGangType {
+  gang_type_id: string;
+  gang_type: string;
+  alignment: string | null;
+  is_hidden: boolean;
+  affiliation: boolean;
+  trading_post_type_id: string | null;
+  gang_origin_category_id: string | null;
+  parent_gang_type_id: string | null;
+  default_image_urls: unknown[] | null;
+  edition_id: string | null;
+}
+
+interface TradingPostType {
+  id: string;
+  trading_post_name: string;
+  edition_id?: string | null;
+}
+
+interface GangOrigin {
+  id: string;
+  origin_name: string;
+  edition_id?: string | null;
+  category_id: string | null;
+  category_name: string;
+}
+
+interface OriginCategory {
+  id: string;
+  category_name: string;
+}
+
+interface ImageFormEntry {
+  url: string;
+  creditName: string;
+  creditUrl: string;
+  creditSuffix: string;
+}
+
+interface AdminGangTypesModalProps {
+  onClose: () => void;
+}
+
+function emptyImageEntry(): ImageFormEntry {
+  return { url: '', creditName: '', creditUrl: '', creditSuffix: '' };
+}
+
+function isPreviewableUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url.trim());
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function DefaultImagePreview({ url, className }: { url: string; className?: string }) {
+  const [failed, setFailed] = useState(false);
+  const trimmed = url.trim();
+  const previewable = isPreviewableUrl(trimmed);
+
+  useEffect(() => {
+    setFailed(false);
+  }, [trimmed]);
+
+  return (
+    <div className={`overflow-hidden rounded-full border bg-muted flex items-center justify-center ${className ?? 'size-20'}`}>
+      {previewable && !failed ? (
+        // Native img: admin URLs may be hosts not listed in next/image remotePatterns.
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={trimmed}
+          alt=""
+          className="size-full object-cover"
+          onError={() => setFailed(true)}
+        />
+      ) : (
+        <span className="text-[10px] text-muted-foreground text-center px-1">
+          {trimmed ? 'No preview' : 'No image'}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function toImageFormEntries(raw: unknown[] | null | undefined): ImageFormEntry[] {
+  const normalised = normaliseDefaultImageUrls(raw) ?? [];
+  if (normalised.length === 0) return [];
+  return normalised.map((entry) => ({
+    url: entry.url ?? '',
+    creditName: entry.credit?.name ?? '',
+    creditUrl: entry.credit?.url ?? '',
+    creditSuffix: entry.credit?.suffix ?? '',
+  }));
+}
+
+function isEmptyImageRow(entry: ImageFormEntry): boolean {
+  return !entry.url.trim()
+    && !entry.creditName.trim()
+    && !entry.creditUrl.trim()
+    && !entry.creditSuffix.trim();
+}
+
+function withoutTrailingEmptyImageRows(entries: ImageFormEntry[]): ImageFormEntry[] {
+  let end = entries.length;
+  while (end > 0 && isEmptyImageRow(entries[end - 1])) {
+    end -= 1;
+  }
+  return entries.slice(0, end);
+}
+
+function defaultImagesValidationError(entries: ImageFormEntry[]): string | null {
+  const active = withoutTrailingEmptyImageRows(entries);
+  for (let index = 0; index < active.length; index++) {
+    const entry = active[index];
+    const imageUrl = entry.url.trim();
+    if (!imageUrl) {
+      return `Image ${index + 1}: image URL is required`;
+    }
+    if (!isPreviewableUrl(imageUrl)) {
+      return `Image ${index + 1}: image URL must be a valid http(s) URL`;
+    }
+
+    const creditUrl = entry.creditUrl.trim();
+    if (creditUrl && !isPreviewableUrl(creditUrl)) {
+      return `Image ${index + 1}: credit URL must be a valid http(s) URL`;
+    }
+  }
+  return null;
+}
+
+function toDefaultImagePayload(entries: ImageFormEntry[]): DefaultImageEntry[] | null {
+  const parsed = withoutTrailingEmptyImageRows(entries)
+    .map((entry) => {
+      const url = entry.url.trim();
+      const creditName = entry.creditName.trim();
+      const creditUrl = entry.creditUrl.trim();
+      const creditSuffix = entry.creditSuffix.trim();
+      const credit: DefaultImageEntry['credit'] = {
+        ...(creditName ? { name: creditName } : {}),
+        ...(creditUrl ? { url: creditUrl } : {}),
+        ...(creditSuffix ? { suffix: creditSuffix } : {}),
+      };
+
+      return Object.keys(credit).length > 0 ? { url, credit } : { url };
+    });
+
+  return parsed.length > 0 ? parsed : null;
+}
+
+export function AdminGangTypesModal({ onClose }: AdminGangTypesModalProps) {
+  const queryClient = useQueryClient();
+
+  const [selectedGangTypeId, setSelectedGangTypeId] = useState('');
+  const [gangTypeName, setGangTypeName] = useState('');
+  const [alignment, setAlignment] = useState('');
+  const [isHidden, setIsHidden] = useState(false);
+  const [affiliation, setAffiliation] = useState(false);
+  const [tradingPostTypeId, setTradingPostTypeId] = useState('');
+  const [originCategoryId, setOriginCategoryId] = useState('');
+  const [parentGangTypeId, setParentGangTypeId] = useState('');
+  const [defaultImages, setDefaultImages] = useState<ImageFormEntry[]>([]);
+  const [editionId, setEditionId] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isCreateMode, setIsCreateMode] = useState(false);
+
+  const { data: gangTypes = [], isLoading: isLoadingGangTypes } = useQuery<AdminGangType[]>({
+    queryKey: ['admin-gang-types', 'detailed'],
+    queryFn: async () => {
+      const response = await fetch('/api/admin/gang-types?detailed=1');
+      if (!response.ok) throw new Error('Failed to fetch gang types');
+      return response.json();
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const { data: tradingPostTypes = [], isLoading: isLoadingTradingPosts } = useQuery<TradingPostType[]>({
+    queryKey: ['admin-trading-post-types'],
+    queryFn: async () => {
+      const response = await fetch('/api/admin/equipment/trading-post-types');
+      if (!response.ok) throw new Error('Failed to fetch trading post types');
+      return response.json();
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const { data: origins = [], isLoading: isLoadingOrigins } = useQuery<GangOrigin[]>({
+    queryKey: ['admin-gang-origins'],
+    queryFn: async () => {
+      const response = await fetch('/api/admin/gang-origins');
+      if (!response.ok) throw new Error('Failed to fetch gang origins');
+      return response.json();
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const isLoading = isLoadingGangTypes || isLoadingTradingPosts || isLoadingOrigins || isSubmitting;
+  const isFormDisabled = (!isCreateMode && !selectedGangTypeId) || isLoading;
+
+  const originCategories = useMemo<OriginCategory[]>(() => {
+    const byId = new Map<string, OriginCategory>();
+    for (const origin of origins) {
+      if (!origin.category_id) continue;
+      if (!byId.has(origin.category_id)) {
+        byId.set(origin.category_id, {
+          id: origin.category_id,
+          category_name: origin.category_name,
+        });
+      }
+    }
+    return [...byId.values()].sort((a, b) => a.category_name.localeCompare(b.category_name));
+  }, [origins]);
+
+  const filteredGangTypes = useMemo(
+    () => editionId
+      ? gangTypes.filter(gt => gt.edition_id === editionId)
+      : gangTypes,
+    [gangTypes, editionId]
+  );
+
+  const filteredTradingPosts = useMemo(
+    () => editionId
+      ? tradingPostTypes.filter(tp => !tp.edition_id || tp.edition_id === editionId)
+      : tradingPostTypes,
+    [tradingPostTypes, editionId]
+  );
+
+  const parentOptions = useMemo(
+    () => filteredGangTypes.filter(gt =>
+      !gt.parent_gang_type_id &&
+      gt.gang_type_id !== selectedGangTypeId
+    ),
+    [filteredGangTypes, selectedGangTypeId]
+  );
+
+  const clearFormFields = () => {
+    setGangTypeName('');
+    setAlignment('');
+    setIsHidden(false);
+    setAffiliation(false);
+    setTradingPostTypeId('');
+    setOriginCategoryId('');
+    setParentGangTypeId('');
+    setDefaultImages([]);
+  };
+
+  const applyGangType = (gangType: AdminGangType) => {
+    setGangTypeName(gangType.gang_type ?? '');
+    setAlignment(gangType.alignment ?? '');
+    setIsHidden(Boolean(gangType.is_hidden));
+    setAffiliation(Boolean(gangType.affiliation));
+    setTradingPostTypeId(gangType.trading_post_type_id ?? '');
+    setOriginCategoryId(gangType.gang_origin_category_id ?? '');
+    setParentGangTypeId(gangType.parent_gang_type_id ?? '');
+    setDefaultImages(toImageFormEntries(gangType.default_image_urls));
+    setEditionId(gangType.edition_id ?? '');
+  };
+
+  const handleEditionChange = (newEditionId: string) => {
+    setEditionId(newEditionId);
+
+    if (newEditionId && selectedGangTypeId) {
+      const gangType = gangTypes.find(gt => gt.gang_type_id === selectedGangTypeId);
+      if (gangType && gangType.edition_id !== newEditionId) {
+        setSelectedGangTypeId('');
+        clearFormFields();
+        setIsCreateMode(false);
+      }
+    }
+
+    if (tradingPostTypeId) {
+      const selected = tradingPostTypes.find(tp => tp.id === tradingPostTypeId);
+      if (selected?.edition_id && selected.edition_id !== newEditionId) {
+        setTradingPostTypeId('');
+      }
+    }
+
+    if (parentGangTypeId) {
+      const selected = gangTypes.find(gt => gt.gang_type_id === parentGangTypeId);
+      if (selected && selected.edition_id !== newEditionId) {
+        setParentGangTypeId('');
+      }
+    }
+  };
+
+  const handleGangTypeSelect = (gangTypeId: string) => {
+    setSelectedGangTypeId(gangTypeId);
+    const gangType = gangTypes.find(gt => gt.gang_type_id === gangTypeId);
+    if (gangType) {
+      applyGangType(gangType);
+      setIsCreateMode(false);
+    } else {
+      clearFormFields();
+      setIsCreateMode(false);
+    }
+  };
+
+  const handleCreateNew = () => {
+    setSelectedGangTypeId('');
+    clearFormFields();
+    setIsCreateMode(true);
+  };
+
+  const updateImageEntry = (index: number, patch: Partial<ImageFormEntry>) => {
+    setDefaultImages((current) => current.map((entry, i) => (
+      i === index ? { ...entry, ...patch } : entry
+    )));
+  };
+
+  const handleSubmitGangType = async (operation: OperationType) => {
+    if (!gangTypeName.trim() || !editionId) {
+      toast.error('Please fill in all required fields');
+      return;
+    }
+
+    const imagesError = defaultImagesValidationError(defaultImages);
+    if (imagesError) {
+      toast.error(imagesError);
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const payload = {
+        gang_type: gangTypeName.trim(),
+        alignment: alignment || null,
+        is_hidden: isHidden,
+        affiliation,
+        trading_post_type_id: tradingPostTypeId || null,
+        gang_origin_category_id: originCategoryId || null,
+        parent_gang_type_id: parentGangTypeId || null,
+        default_image_urls: toDefaultImagePayload(defaultImages),
+        edition_id: editionId,
+      };
+
+      const method = operation === OperationType.POST ? 'POST' : 'PATCH';
+      const body = JSON.stringify(
+        operation === OperationType.POST
+          ? payload
+          : { gang_type_id: selectedGangTypeId, ...payload }
+      );
+
+      const response = await fetch('/api/admin/gang-types', {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body,
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(
+          errorData.error ||
+          `Failed to ${operation === OperationType.POST ? 'create' : 'update'} gang type`
+        );
+      }
+
+      const resultData = await response.json() as AdminGangType;
+
+      toast.success(
+        `Gang type ${operation === OperationType.POST ? 'created' : 'updated'} successfully`
+      );
+
+      await queryClient.invalidateQueries({ queryKey: ['admin-gang-types'] });
+
+      if (operation === OperationType.POST && resultData?.gang_type_id) {
+        setSelectedGangTypeId(resultData.gang_type_id);
+        setIsCreateMode(false);
+        applyGangType(resultData);
+      }
+    } catch (error) {
+      console.error(`Error executing ${operation} operation:`, error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : `Failed to ${operation === OperationType.POST ? 'create' : 'update'} gang type`
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 dark:bg-neutral-700/50 flex justify-center items-center z-50 px-[10px]"
+      onMouseDown={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="bg-card rounded-lg shadow-xl w-full max-w-3xl min-h-0 max-h-svh overflow-y-auto flex flex-col">
+        <div className="border-b px-[10px] py-2 flex justify-between items-center">
+          <div>
+            <h3 className="text-xl md:text-2xl font-bold text-foreground">Manage Gang Types</h3>
+            <p className="text-sm text-muted-foreground">Create or edit gang types</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-muted-foreground hover:text-muted-foreground text-xl"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="px-[10px] py-4">
+          <div className="space-y-4">
+            <EditionSelect value={editionId} onChange={handleEditionChange} defaultToCurrent />
+
+            <div>
+              <div className="flex justify-between items-center mb-1">
+                <label className="block text-sm font-medium text-muted-foreground">
+                  Select Gang Type
+                </label>
+                <Button
+                  onClick={handleCreateNew}
+                  disabled={isLoading}
+                  className="text-xs h-7 px-3"
+                >
+                  Create New
+                </Button>
+              </div>
+              <select
+                value={selectedGangTypeId}
+                onChange={(e) => handleGangTypeSelect(e.target.value)}
+                className="w-full p-2 border rounded-md"
+                disabled={isLoading}
+              >
+                <option value="">Select a gang type to edit</option>
+                {filteredGangTypes.map((gangType) => (
+                  <option key={gangType.gang_type_id} value={gangType.gang_type_id}>
+                    {gangType.gang_type}
+                    {gangType.is_hidden ? ' (hidden)' : ''}
+                    {gangType.parent_gang_type_id ? ' (variant)' : ''}
+                  </option>
+                ))}
+              </select>
+              {isCreateMode && (
+                <p className="text-xs text-amber-600 mt-1">
+                  Creating new gang type. Select from dropdown to cancel and edit existing.
+                </p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-muted-foreground mb-1">
+                Gang Type Name *
+              </label>
+              <Input
+                type="text"
+                value={gangTypeName}
+                onChange={(e) => setGangTypeName(e.target.value)}
+                placeholder="E.g. House Escher, Wyld Hunt"
+                className="w-full"
+                disabled={isFormDisabled}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-muted-foreground mb-1">
+                Alignment
+              </label>
+              <select
+                value={alignment}
+                onChange={(e) => setAlignment(e.target.value)}
+                className="w-full p-2 border rounded-md"
+                disabled={isFormDisabled}
+              >
+                <option value="">None</option>
+                <option value="Law Abiding">Law Abiding</option>
+                <option value="Outlaw">Outlaw</option>
+                <option value="Unaligned">Unaligned</option>
+              </select>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-6">
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="gang-type-hidden"
+                  checked={isHidden}
+                  onCheckedChange={(checked) => setIsHidden(checked === true)}
+                  disabled={isFormDisabled}
+                />
+                <label
+                  htmlFor="gang-type-hidden"
+                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                >
+                  Hidden
+                </label>
+              </div>
+              <div className="flex items-center space-x-2">
+                <Checkbox
+                  id="gang-type-affiliation"
+                  checked={affiliation}
+                  onCheckedChange={(checked) => setAffiliation(checked === true)}
+                  disabled={isFormDisabled}
+                />
+                <label
+                  htmlFor="gang-type-affiliation"
+                  className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+                >
+                  Uses Affiliations
+                </label>
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-muted-foreground mb-1">
+                Trading Post Type
+              </label>
+              <select
+                value={tradingPostTypeId}
+                onChange={(e) => setTradingPostTypeId(e.target.value)}
+                className="w-full p-2 border rounded-md"
+                disabled={isFormDisabled}
+              >
+                <option value="">None</option>
+                {filteredTradingPosts.map((tradingPost) => (
+                  <option key={tradingPost.id} value={tradingPost.id}>
+                    {tradingPost.trading_post_name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-muted-foreground mb-1">
+                Origin Category
+              </label>
+              <select
+                value={originCategoryId}
+                onChange={(e) => setOriginCategoryId(e.target.value)}
+                className="w-full p-2 border rounded-md"
+                disabled={isFormDisabled}
+              >
+                <option value="">None</option>
+                {originCategories.map((category) => (
+                  <option key={category.id} value={category.id}>
+                    {category.category_name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-muted-foreground mb-1">
+                Parent Gang Type
+              </label>
+              <select
+                value={parentGangTypeId}
+                onChange={(e) => setParentGangTypeId(e.target.value)}
+                className="w-full p-2 border rounded-md"
+                disabled={isFormDisabled}
+              >
+                <option value="">None (root gang type)</option>
+                {parentOptions.map((gangType) => (
+                  <option key={gangType.gang_type_id} value={gangType.gang_type_id}>
+                    {gangType.gang_type}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <div className="flex justify-between items-center mb-1">
+                <label className="block text-sm font-medium text-muted-foreground">
+                  Default Images
+                </label>
+                <Button
+                  type="button"
+                  onClick={() => setDefaultImages((current) => [...current, emptyImageEntry()])}
+                  disabled={isFormDisabled}
+                  className="text-xs h-7 px-3"
+                >
+                  <LuPlus className="h-4 w-4 mr-1" />
+                  Add Image
+                </Button>
+              </div>
+              {defaultImages.length === 0 && (
+                <p className="text-xs text-muted-foreground">No default images.</p>
+              )}
+              <div className="space-y-3">
+                {defaultImages.map((entry, index) => (
+                  <div key={index} className="border rounded-md p-3 space-y-2">
+                    <div className="flex justify-between items-center">
+                      <span className="text-xs font-medium text-muted-foreground">
+                        Image {index + 1}
+                      </span>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => setDefaultImages((current) => current.filter((_, i) => i !== index))}
+                        disabled={isFormDisabled}
+                        className="text-xs h-7 px-2"
+                      >
+                        <LuTrash2 className="h-4 w-4 mr-1" />
+                        Remove
+                      </Button>
+                    </div>
+                    <div className="flex gap-3 items-start">
+                      <DefaultImagePreview url={entry.url} className="size-24 shrink-0" />
+                      <div className="flex-1 space-y-2 min-w-0">
+                        <Input
+                          type="text"
+                          value={entry.url}
+                          onChange={(e) => updateImageEntry(index, { url: e.target.value })}
+                          placeholder="Image URL"
+                          className="w-full"
+                          disabled={isFormDisabled}
+                        />
+                        <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
+                          <Input
+                            type="text"
+                            value={entry.creditName}
+                            onChange={(e) => updateImageEntry(index, { creditName: e.target.value })}
+                            placeholder="Credit name"
+                            disabled={isFormDisabled}
+                          />
+                          <Input
+                            type="text"
+                            value={entry.creditUrl}
+                            onChange={(e) => updateImageEntry(index, { creditUrl: e.target.value })}
+                            placeholder="Credit URL"
+                            disabled={isFormDisabled}
+                          />
+                          <Input
+                            type="text"
+                            value={entry.creditSuffix}
+                            onChange={(e) => updateImageEntry(index, { creditSuffix: e.target.value })}
+                            placeholder="Credit suffix"
+                            disabled={isFormDisabled}
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="border-t px-[10px] py-2 flex flex-wrap justify-end gap-2">
+          <Button
+            variant="outline"
+            onClick={onClose}
+            disabled={isLoading}
+            className="flex-1"
+          >
+            Cancel
+          </Button>
+
+          {isCreateMode && (
+            <Button
+              onClick={() => handleSubmitGangType(OperationType.POST)}
+              disabled={!gangTypeName.trim() || !editionId || isLoading}
+              className="flex-1 bg-neutral-900 text-white rounded-sm hover:bg-gray-800"
+            >
+              {isLoading ? 'Creating...' : 'Create Gang Type'}
+            </Button>
+          )}
+
+          {!isCreateMode && selectedGangTypeId && (
+            <Button
+              onClick={() => handleSubmitGangType(OperationType.UPDATE)}
+              disabled={!gangTypeName.trim() || !editionId || isLoading}
+              className="flex-1 bg-neutral-900 text-white rounded-sm hover:bg-gray-800"
+            >
+              {isLoading ? 'Updating...' : 'Update Gang Type'}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/create-gang-modal.tsx
+++ b/components/create-gang-modal.tsx
@@ -19,6 +19,7 @@ import { useSearchParams } from "next/navigation"
 import Image from 'next/image'
 import { LuChevronLeft, LuChevronRight } from "react-icons/lu"
 import { DefaultImageEntry, normaliseDefaultImageUrls, UNKNOWN_GANG_IMAGE_URL } from '@/types/gang'
+import { DefaultImageCreditLine } from '@/components/ui/default-image-credit-line'
 import { EditionToggle } from '@/components/home/edition-toggle'
 import { useHomeEdition } from '@/hooks/use-home-edition'
 import { sameEditionForDisplay } from '@/types/edition'
@@ -802,17 +803,7 @@ export function CreateGangModal({ onClose }: CreateGangModalProps) {
                     )}
                   </div>
                 </div>
-                {displayCredit ? (
-                  <p className="text-xs italic text-center text-muted-foreground mt-1">
-                    Illustration by{' '}
-                    <a href={displayCredit.url} target="_blank" rel="noopener noreferrer" className="underline hover:text-foreground">
-                      {displayCredit.name}
-                    </a>
-                    {displayCredit.suffix && ` ${displayCredit.suffix}`}
-                  </p>
-                ) : (
-                  <p className="text-xs mt-1">&nbsp;</p>
-                )}
+                <DefaultImageCreditLine credit={displayCredit} />
               </>
             );
           })()}

--- a/components/ui/default-image-credit-line.tsx
+++ b/components/ui/default-image-credit-line.tsx
@@ -1,0 +1,39 @@
+import { hasDefaultImageCredit, type DefaultImageCredit } from '@/types/gang';
+
+export function DefaultImageCreditLine({
+  credit,
+}: {
+  credit?: DefaultImageCredit | null;
+}) {
+  if (!hasDefaultImageCredit(credit)) {
+    return <p className="text-xs mt-1">&nbsp;</p>;
+  }
+
+  const name = credit.name?.trim();
+  const href = credit.url?.trim();
+  const suffix = credit.suffix?.trim();
+  const hasByline = Boolean(name || href);
+
+  return (
+    <p className="text-xs italic text-center text-muted-foreground mt-1">
+      {hasByline && (
+        <>
+          Illustration by{' '}
+          {href ? (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:text-foreground"
+            >
+              {name || href}
+            </a>
+          ) : (
+            name
+          )}
+        </>
+      )}
+      {suffix && `${hasByline ? ' ' : ''}${suffix}`}
+    </p>
+  );
+}

--- a/components/ui/default-image-credit-line.tsx
+++ b/components/ui/default-image-credit-line.tsx
@@ -1,4 +1,5 @@
 import { hasDefaultImageCredit, type DefaultImageCredit } from '@/types/gang';
+import { isValidHttpUrl } from '@/utils/http-url';
 
 export function DefaultImageCreditLine({
   credit,
@@ -10,7 +11,8 @@ export function DefaultImageCreditLine({
   }
 
   const name = credit.name?.trim();
-  const href = credit.url?.trim();
+  const rawHref = credit.url?.trim();
+  const href = rawHref && isValidHttpUrl(rawHref) ? rawHref : undefined;
   const suffix = credit.suffix?.trim();
   const hasByline = Boolean(name || href);
 

--- a/components/ui/image-edit-modal.tsx
+++ b/components/ui/image-edit-modal.tsx
@@ -8,6 +8,7 @@ import { UseImageEditorOptions } from '@/hooks/use-image-editor';
 import { useImageEditor } from '@/hooks/use-image-editor';
 import { LuChevronLeft, LuChevronRight } from 'react-icons/lu';
 import { DefaultImageEntry, DefaultImageCredit } from '@/types/gang';
+import { DefaultImageCreditLine } from '@/components/ui/default-image-credit-line';
 
 interface ImageEditModalProps {
   isOpen: boolean;
@@ -240,17 +241,7 @@ export const ImageEditModal: React.FC<ImageEditModalProps> = ({
                 )}
               </div>
             </div>
-            {displayDefaultImageCredit ? (
-              <p className="text-xs italic text-center text-muted-foreground mt-1">
-                Illustration by{' '}
-                <a href={displayDefaultImageCredit.url} target="_blank" rel="noopener noreferrer" className="underline hover:text-foreground">
-                  {displayDefaultImageCredit.name}
-                </a>
-                {displayDefaultImageCredit.suffix && ` ${displayDefaultImageCredit.suffix}`}
-              </p>
-            ) : (
-              <p className="text-xs mt-1">&nbsp;</p>
-            )}
+            <DefaultImageCreditLine credit={displayDefaultImageCredit} />
           </div>
         )}
         <div className="mb-4">

--- a/types/gang.ts
+++ b/types/gang.ts
@@ -42,9 +42,15 @@ export interface StashItem {
 }
 
 export interface DefaultImageCredit {
-  name: string;
-  url: string;
+  name?: string;
+  url?: string;
   suffix?: string;
+}
+
+export function hasDefaultImageCredit(
+  credit?: DefaultImageCredit | null
+): credit is DefaultImageCredit {
+  return Boolean(credit?.name?.trim() || credit?.url?.trim() || credit?.suffix?.trim());
 }
 
 export interface DefaultImageEntry {

--- a/utils/cache-tags.ts
+++ b/utils/cache-tags.ts
@@ -23,9 +23,8 @@ import { revalidateTag } from 'next/cache';
  * user-{id}        profile/gang list/        | profile, list, social
  *                  campaign list/friends     | mutations
  * custom-{id}      custom content            | customise mutations
- * gang-type-{id}   home cards that join this | admin edits of that gang type
- *                  catalog type's portraits  | (also busts global-gang-types)
- * global-gang-types gang type catalog        | any admin gang-type write
+ * global-gang-types gang type catalog +      | any admin gang-type write
+ *                  home-card portraits/names |
  */
 export const TAGS = {
   gang: (id: string) => `gang-${id}`,
@@ -41,8 +40,6 @@ export const TAGS = {
   permission: (userId: string, gangId: string) => `check-permission-${userId}-${gangId}`,
   // All cached permission entries for one user, across every gang (busted on sign-in)
   userPermissions: (userId: string) => `user-permissions-${userId}`,
-  // Home-card copies of one official gang type (portraits / denormalized name)
-  gangType: (id: string) => `gang-type-${id}`,
 
   // Battle sessions keep their own namespace: live battles mutate frequently
   // and must not thrash the gang bundles.
@@ -179,12 +176,11 @@ export function invalidateCampaignCatalogLists() {
 }
 
 /**
- * Official gang-type catalog changed (name, images, flags). Busts the shared
- * catalog caches and every home-card list that joined this type.
+ * Official gang-type catalog changed (name, images, flags). Home cards join
+ * that catalog under the same tag.
  */
-export function invalidateGangTypesCatalog(gangTypeId?: string) {
+export function invalidateGangTypesCatalog() {
   bust(TAGS.globalGangTypes());
-  if (gangTypeId) bust(TAGS.gangType(gangTypeId));
 }
 
 // Global reference data

--- a/utils/cache-tags.ts
+++ b/utils/cache-tags.ts
@@ -23,6 +23,9 @@ import { revalidateTag } from 'next/cache';
  * user-{id}        profile/gang list/        | profile, list, social
  *                  campaign list/friends     | mutations
  * custom-{id}      custom content            | customise mutations
+ * gang-type-{id}   home cards that join this | admin edits of that gang type
+ *                  catalog type's portraits  | (also busts global-gang-types)
+ * global-gang-types gang type catalog        | any admin gang-type write
  */
 export const TAGS = {
   gang: (id: string) => `gang-${id}`,
@@ -38,6 +41,8 @@ export const TAGS = {
   permission: (userId: string, gangId: string) => `check-permission-${userId}-${gangId}`,
   // All cached permission entries for one user, across every gang (busted on sign-in)
   userPermissions: (userId: string) => `user-permissions-${userId}`,
+  // Home-card copies of one official gang type (portraits / denormalized name)
+  gangType: (id: string) => `gang-type-${id}`,
 
   // Battle sessions keep their own namespace: live battles mutate frequently
   // and must not thrash the gang bundles.
@@ -171,6 +176,15 @@ export const invalidateBattleSessions = (gangId: string) => {
 export function invalidateCampaignCatalogLists() {
   bust(TAGS.campaignTypes());
   bust(TAGS.globalTerritories());
+}
+
+/**
+ * Official gang-type catalog changed (name, images, flags). Busts the shared
+ * catalog caches and every home-card list that joined this type.
+ */
+export function invalidateGangTypesCatalog(gangTypeId?: string) {
+  bust(TAGS.globalGangTypes());
+  if (gangTypeId) bust(TAGS.gangType(gangTypeId));
 }
 
 // Global reference data

--- a/utils/http-url.ts
+++ b/utils/http-url.ts
@@ -1,0 +1,9 @@
+/** True when `value` is an absolute http or https URL. */
+export function isValidHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value.trim());
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Add a Gangs tile on the Admin Dashboard to create and edit official ``gang_types`` rows (name, edition, alignment, hidden, affiliations, trading post, origin, parent/variant, default images).
- Replace the unused fighter-type POST on ``/api/admin/gang-types`` with validated create/update, lean GET for other admin screens, and ``?detailed=1`` for this modal.
- Make default-image credits optional and share credit attribution between create-gang and the image editor.

## Type of change
- [x] Feature

## How I tested
- [x] Opened Admin Dashboard → Gangs, created a gang type, then edited it
- [x] Confirmed default-image previews, optional credit fields, and that blanking a middle image URL is refused
- [x] Confirmed create-gang still lists types and shows credit lines

## Database
Not applicable — no migration.

## Risk / rollout
Low — admin-only catalog UI. Deletes are not exposed. ``global-gang-types`` cache is revalidated on create/update.
