### PR TITLE
Removed redundant API call for exotic beast

### DIFF
--- a/app/lib/shared/gang-data.ts
+++ b/app/lib/shared/gang-data.ts
@@ -789,8 +789,8 @@ export const getGangCampaigns = async (gangId: string, supabase: any): Promise<G
  *
  * Stage 1 (parallel): fighters, ALL gang vehicles (both keyed by gang_id)
  * Stage 2 (parallel): equipment (fighter + vehicle rows in one query),
- *   skills, effects (fighter + vehicle scopes in one query), exotic beasts
- *   (both directions), loadouts (+assignments embedded), captured-by names
+ *   skills, effects (fighter + vehicle scopes in one query), exotic beasts,
+ *   loadouts (+assignments embedded), captured-by names
  */
 export const getGangFightersBundle = async (gangId: string, supabase: any): Promise<GangFightersBundle> => {
   return unstable_cache(

--- a/app/lib/shared/gang-data.ts
+++ b/app/lib/shared/gang-data.ts
@@ -909,8 +909,7 @@ export const getGangFightersBundle = async (gangId: string, supabase: any): Prom
         equipment: [],
         skills: [],
         effects: [],
-        beastsOwned: [],
-        beastsPetOf: [],
+        beastLinks: [],
         loadouts: [],
         capturedByGangs: []
       };
@@ -1042,8 +1041,7 @@ export const getGangFightersBundle = async (gangId: string, supabase: any): Prom
         equipmentRes,
         skillsRes,
         effectsRes,
-        beastsOwnedRes,
-        beastsPetOfRes,
+        beastLinksRes,
         loadoutsRes,
         capturedByGangsRes
       ] = await Promise.all([
@@ -1084,26 +1082,6 @@ export const getGangFightersBundle = async (gangId: string, supabase: any): Prom
                 fighter_owner_id,
                 fighter_pet_id,
                 fighter_equipment_id,
-                fighter_equipment!fighter_equipment_id (
-                  gang_stash,
-                  equipment!equipment_id (
-                    equipment_name
-                  ),
-                  custom_equipment!custom_equipment_id (
-                    equipment_name
-                  )
-                )
-              `)
-              .in('fighter_owner_id', fighterIds)
-          : Promise.resolve({ data: [] }),
-        fighterIds.length > 0
-          ? supabase
-              .from('fighter_exotic_beasts')
-              .select(`
-                id,
-                fighter_pet_id,
-                fighter_owner_id,
-                fighter_equipment_id,
                 fighters!fighter_owner_id (
                   fighter_name
                 ),
@@ -1111,7 +1089,7 @@ export const getGangFightersBundle = async (gangId: string, supabase: any): Prom
                   gang_stash
                 )
               `)
-              .in('fighter_pet_id', fighterIds)
+              .in('fighter_owner_id', fighterIds)
           : Promise.resolve({ data: [] }),
         fighterIds.length > 0
           ? supabase
@@ -1132,8 +1110,7 @@ export const getGangFightersBundle = async (gangId: string, supabase: any): Prom
         equipment: equipmentRes.data || [],
         skills: skillsRes.data || [],
         effects: effectsRes.data || [],
-        beastsOwned: beastsOwnedRes.data || [],
-        beastsPetOf: beastsPetOfRes.data || [],
+        beastLinks: beastLinksRes.data || [],
         loadouts: loadoutsRes.data || [],
         capturedByGangs: capturedByGangsRes.data || []
       };

--- a/types/gang.ts
+++ b/types/gang.ts
@@ -133,9 +133,7 @@ export interface GangFightersBundle {
   /** fighter_effects rows for fighters AND vehicles (superset select). */
   effects: any[];
   /** fighter_exotic_beasts where the owner is in this gang. */
-  beastsOwned: any[];
-  /** fighter_exotic_beasts where the pet is in this gang (ownership info). */
-  beastsPetOf: any[];
+  beastLinks: any[];
   /** ALL fighter_loadouts for the gang's fighters, with equipment assignments embedded. */
   loadouts: any[];
   /** {id, name} of gangs that captured this gang's fighters. */

--- a/utils/gang-assembly.ts
+++ b/utils/gang-assembly.ts
@@ -118,11 +118,11 @@ export function assembleGangFighters(
   const skillsByFighter = groupBy(bundle.skills, 'fighter_id');
   const effectsByFighter = groupBy(fighterEffectsRows, 'fighter_id');
   const vehiclesByFighter = groupBy(assignedVehicles, 'fighter_id');
-  const beastsByOwner = groupBy(bundle.beastsOwned, 'fighter_owner_id');
+  const beastsByOwner = groupBy(bundle.beastLinks, 'fighter_owner_id');
 
   // Ownership info map (petId -> ownership info)
   const ownershipInfoMap = new Map();
-  bundle.beastsPetOf.forEach((info: any) => {
+  bundle.beastLinks.forEach((info: any) => {
     ownershipInfoMap.set(info.fighter_pet_id, {
       owner_id: info.fighter_owner_id,
       owner_name: (info.fighters as any)?.fighter_name,
@@ -1273,7 +1273,7 @@ export function assembleFighterView(bundle: GangFightersBundle, fighterId: strin
     });
 
   // ---- Owned beasts: costs + display data (previous getFighterOwnedBeastsCost/Data) ----
-  const myBeastLinks = bundle.beastsOwned.filter((b: any) => b.fighter_owner_id === fighterId);
+  const myBeastLinks = bundle.beastLinks.filter((b: any) => b.fighter_owner_id === fighterId);
   const fighterById = new Map(bundle.fighters.map((f: any) => [f.id, f]));
 
   const byEquipmentId: Record<string, { equipment: number; advancements: number }> = {};
@@ -1305,7 +1305,7 @@ export function assembleFighterView(bundle: GangFightersBundle, fighterId: strin
   });
 
   // ---- Ownership info (if this fighter IS a beast) ----
-  const petRow = bundle.beastsPetOf.find((info: any) => info.fighter_pet_id === fighterId) || null;
+  const petRow = bundle.beastLinks.find((info: any) => info.fighter_pet_id === fighterId) || null;
   const ownershipInfo = petRow
     ? {
         owner_name: (petRow.fighters as any)?.fighter_name,


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? -->

-`getGangFightersBundle` queried `fighter_exotic_beasts` twice — once filtered by owner, once by pet. A beast's owner is always in the beast's own gang, so the owner-direction query already returns every row the pet-direction one did. Verified across all 23,331 links in production: zero are reachable only via the pet direction. Also drops two `equipment_name` embeds and the `id` column, none of which have a consumer since the `owned_beasts` payload was removed.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Schema / migration

## How I tested

<!-- What you tested before opening this PR. Example: Opened gang X → bought equipment → credits/rating updated -->

- Data loads as it should

## Risk / rollout

<!-- e.g. Low / Medium — any deploy notes beyond database (env vars, feature flags, etc.). -->

- None
