### PR TITLE
Add admin management for tactics card packs and cards.

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -3,6 +3,7 @@
 import { LuUsers, LuSword, LuCar, LuBookOpen, LuScrollText, LuBookUser, LuHeartCrack, LuSearch, LuBell, LuHandshake, LuHouse } from "react-icons/lu";
 import { LuChartColumn } from "react-icons/lu";
 import { PiFlagBannerFoldBold } from "react-icons/pi";
+import { TbCards } from "react-icons/tb";
 import { LuSquarePen } from 'react-icons/lu';
 import { useState } from "react";
 import { AdminCreateFighterTypeModal } from "@/components/admin/admin-create-fighter-type";
@@ -19,6 +20,7 @@ import { AdminScenariosModal } from "@/components/admin/admin-scenarios-modal";
 import { AdminInjuriesGlitchesModal } from "@/components/admin/admin-injuries";
 import { AdminAlliancesModal } from "@/components/admin/admin-alliances";
 import { AdminGangTypesModal } from "@/components/admin/admin-gang-types";
+import { AdminTacticsCardsModal } from "@/components/admin/admin-tactics-cards";
 import { AdminCampaignManagementModal } from "@/components/admin/admin-campaign-management";
 import { AdminSupportToolsModal } from "@/components/admin/admin-support-tools";
 import { AdminNotificationsModal } from "@/components/admin/admin-notifications-modal";
@@ -38,6 +40,7 @@ export default function AdminPage() {
   const [showInjuriesGlitches, setShowInjuriesGlitches] = useState(false);
   const [showAlliances, setShowAlliances] = useState(false);
   const [showGangTypes, setShowGangTypes] = useState(false);
+  const [showTacticsCards, setShowTacticsCards] = useState(false);
   const [showCampaignManagement, setShowCampaignManagement] = useState(false);
   const [showSupportTools, setShowSupportTools] = useState(false);
   const [showNotifications, setShowNotifications] = useState(false);
@@ -126,6 +129,12 @@ export default function AdminPage() {
       description: "Manage gang types",
       action: () => setShowGangTypes(true),
       icon: LuHouse
+    },
+    {
+      title: "Tactics Cards",
+      description: "Manage tactics card packs and cards",
+      action: () => setShowTacticsCards(true),
+      icon: TbCards
     }
   ];
 
@@ -300,6 +309,12 @@ export default function AdminPage() {
         {showGangTypes && (
           <AdminGangTypesModal
             onClose={() => setShowGangTypes(false)}
+          />
+        )}
+
+        {showTacticsCards && (
+          <AdminTacticsCardsModal
+            onClose={() => setShowTacticsCards(false)}
           />
         )}
 

--- a/app/api/admin/tactics-cards-packs/route.ts
+++ b/app/api/admin/tactics-cards-packs/route.ts
@@ -339,6 +339,12 @@ export async function DELETE(request: Request) {
       if (isMissingRowError(error)) {
         return NextResponse.json({ error: 'Pack not found' }, { status: 404 });
       }
+      if (postgresCode(error) === '23503') {
+        return NextResponse.json(
+          { error: 'Cannot delete pack while tactics cards still reference it' },
+          { status: 409 }
+        );
+      }
       throw error;
     }
 

--- a/app/api/admin/tactics-cards-packs/route.ts
+++ b/app/api/admin/tactics-cards-packs/route.ts
@@ -1,0 +1,353 @@
+import { createClient } from "@/utils/supabase/server";
+import { NextResponse } from "next/server";
+import { checkAdmin } from "@/utils/auth";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const PACK_COLUMNS = 'id, name, edition_id, gang_type_id';
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function emptyToNull(value: unknown): string | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed === '' ? null : trimmed;
+}
+
+function postgresCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object' || !('code' in error)) return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' ? code : undefined;
+}
+
+function errorMessage(error: unknown): string {
+  if (!error || typeof error !== 'object' || !('message' in error)) return '';
+  const message = (error as { message?: unknown }).message;
+  return typeof message === 'string' ? message : '';
+}
+
+function isMissingRowError(error: { code?: string; message?: string } | null): boolean {
+  if (!error) return false;
+  return error.code === 'PGRST116' || /0 rows/i.test(error.message ?? '');
+}
+
+function uniqueConstraintResponse(error: unknown): NextResponse | null {
+  if (postgresCode(error) !== '23505') return null;
+  const message = errorMessage(error);
+  if (message.includes('tactics_cards_packs_edition_core_uidx')) {
+    return NextResponse.json(
+      { error: 'This edition already has a core tactics pack' },
+      { status: 409 }
+    );
+  }
+  if (message.includes('tactics_cards_packs_edition_id_name_key')) {
+    return NextResponse.json(
+      { error: 'A pack with this name already exists for this edition' },
+      { status: 409 }
+    );
+  }
+  return NextResponse.json(
+    { error: 'A pack with these values already exists' },
+    { status: 409 }
+  );
+}
+
+function validatePackPayload(body: {
+  name?: unknown;
+  edition_id?: unknown;
+  gang_type_id?: unknown;
+}) {
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  const editionId = emptyToNull(body.edition_id);
+  const gangTypeId = emptyToNull(body.gang_type_id);
+
+  if (!name) {
+    return { error: 'name is required' };
+  }
+  if (name.length > 200) {
+    return { error: 'name must be 200 characters or less' };
+  }
+  if (!editionId) {
+    return { error: 'edition_id is required' };
+  }
+  if (!UUID_RE.test(editionId)) {
+    return { error: 'edition_id must be a valid UUID' };
+  }
+  if (gangTypeId && !UUID_RE.test(gangTypeId)) {
+    return { error: 'gang_type_id must be a valid UUID' };
+  }
+
+  return {
+    data: {
+      name,
+      edition_id: editionId,
+      gang_type_id: gangTypeId,
+    },
+  };
+}
+
+async function assertEditionExists(
+  supabase: SupabaseClient,
+  editionId: string
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('editions')
+    .select('id')
+    .eq('id', editionId)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) return 'edition_id not found';
+  return null;
+}
+
+async function assertGangTypeMatchesEdition(
+  supabase: SupabaseClient,
+  gangTypeId: string | null,
+  editionId: string
+): Promise<string | null> {
+  if (!gangTypeId) return null;
+
+  const { data, error } = await supabase
+    .from('gang_types')
+    .select('gang_type_id, edition_id')
+    .eq('gang_type_id', gangTypeId)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) return 'gang_type_id must reference an existing gang type';
+  if (data.edition_id !== editionId) {
+    return 'gang_type_id must be a gang type of the same edition';
+  }
+  return null;
+}
+
+async function assertEditionScopedRefs(
+  supabase: SupabaseClient,
+  gangTypeId: string | null,
+  editionId: string
+): Promise<string | null> {
+  const [editionError, gangTypeError] = await Promise.all([
+    assertEditionExists(supabase, editionId),
+    assertGangTypeMatchesEdition(supabase, gangTypeId, editionId),
+  ]);
+  return editionError ?? gangTypeError;
+}
+
+export async function GET() {
+  const supabase = await createClient();
+
+  try {
+    const isAdmin = await checkAdmin(supabase);
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { data: packs, error } = await supabase
+      .from('tactics_cards_packs')
+      .select(PACK_COLUMNS)
+      .order('name', { ascending: true });
+
+    if (error) throw error;
+
+    return NextResponse.json(packs ?? []);
+  } catch (error) {
+    console.error('Error fetching tactics card packs:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch tactics card packs' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+
+  try {
+    const isAdmin = await checkAdmin(supabase);
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const validated = validatePackPayload(body);
+    if ('error' in validated) {
+      return NextResponse.json({ error: validated.error }, { status: 400 });
+    }
+
+    const refError = await assertEditionScopedRefs(
+      supabase,
+      validated.data.gang_type_id,
+      validated.data.edition_id
+    );
+    if (refError) {
+      return NextResponse.json({ error: refError }, { status: 400 });
+    }
+
+    const { data: pack, error } = await supabase
+      .from('tactics_cards_packs')
+      .insert([validated.data])
+      .select(PACK_COLUMNS)
+      .single();
+
+    if (error) {
+      const uniqueResponse = uniqueConstraintResponse(error);
+      if (uniqueResponse) return uniqueResponse;
+      throw error;
+    }
+
+    return NextResponse.json(pack);
+  } catch (error) {
+    console.error('Error creating tactics card pack:', error);
+    return NextResponse.json(
+      { error: 'Failed to create tactics card pack' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(request: Request) {
+  const supabase = await createClient();
+
+  try {
+    const isAdmin = await checkAdmin(supabase);
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { id } = body;
+
+    if (!id || typeof id !== 'string') {
+      return NextResponse.json({ error: 'id is required' }, { status: 400 });
+    }
+
+    const validated = validatePackPayload(body);
+    if ('error' in validated) {
+      return NextResponse.json({ error: validated.error }, { status: 400 });
+    }
+
+    const refError = await assertEditionScopedRefs(
+      supabase,
+      validated.data.gang_type_id,
+      validated.data.edition_id
+    );
+    if (refError) {
+      return NextResponse.json({ error: refError }, { status: 400 });
+    }
+
+    const { data: existing, error: existingError } = await supabase
+      .from('tactics_cards_packs')
+      .select('id, edition_id')
+      .eq('id', id)
+      .maybeSingle();
+
+    if (existingError) throw existingError;
+    if (!existing) {
+      return NextResponse.json({ error: 'Pack not found' }, { status: 404 });
+    }
+
+    if (existing.edition_id !== validated.data.edition_id) {
+      const { count, error: cardCountError } = await supabase
+        .from('tactics_cards')
+        .select('id', { count: 'exact', head: true })
+        .eq('tactics_cards_pack_id', id);
+
+      if (cardCountError) throw cardCountError;
+      if ((count ?? 0) > 0) {
+        return NextResponse.json(
+          { error: 'Cannot change edition_id while this pack still has cards' },
+          { status: 409 }
+        );
+      }
+    }
+
+    const { data: pack, error } = await supabase
+      .from('tactics_cards_packs')
+      .update({
+        ...validated.data,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+      .select(PACK_COLUMNS)
+      .maybeSingle();
+
+    if (error) {
+      const uniqueResponse = uniqueConstraintResponse(error);
+      if (uniqueResponse) return uniqueResponse;
+      throw error;
+    }
+    if (!pack) {
+      return NextResponse.json({ error: 'Pack not found' }, { status: 404 });
+    }
+
+    return NextResponse.json(pack);
+  } catch (error) {
+    console.error('Error updating tactics card pack:', error);
+    return NextResponse.json(
+      { error: 'Failed to update tactics card pack' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(request: Request) {
+  const supabase = await createClient();
+
+  try {
+    const isAdmin = await checkAdmin(supabase);
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { id } = body;
+
+    if (!id || typeof id !== 'string') {
+      return NextResponse.json({ error: 'id is required' }, { status: 400 });
+    }
+
+    const { data: existing, error: existingError } = await supabase
+      .from('tactics_cards_packs')
+      .select('id')
+      .eq('id', id)
+      .maybeSingle();
+
+    if (existingError) throw existingError;
+    if (!existing) {
+      return NextResponse.json({ error: 'Pack not found' }, { status: 404 });
+    }
+
+    const { count: cardCount, error: cardCountError } = await supabase
+      .from('tactics_cards')
+      .select('id', { count: 'exact', head: true })
+      .eq('tactics_cards_pack_id', id);
+
+    if (cardCountError) throw cardCountError;
+    if ((cardCount ?? 0) > 0) {
+      return NextResponse.json(
+        { error: 'Cannot delete pack while tactics cards still reference it' },
+        { status: 409 }
+      );
+    }
+
+    const { error } = await supabase
+      .from('tactics_cards_packs')
+      .delete()
+      .eq('id', id);
+
+    if (error) {
+      if (isMissingRowError(error)) {
+        return NextResponse.json({ error: 'Pack not found' }, { status: 404 });
+      }
+      throw error;
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error deleting tactics card pack:', error);
+    return NextResponse.json(
+      { error: 'Failed to delete tactics card pack' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/tactics-cards/route.ts
+++ b/app/api/admin/tactics-cards/route.ts
@@ -1,0 +1,363 @@
+import { createClient } from "@/utils/supabase/server";
+import { NextResponse } from "next/server";
+import { checkAdmin } from "@/utils/auth";
+import { invalidateGangTacticsCards } from "@/utils/cache-tags";
+import { compareTacticsCards } from "@/types/tactics-card";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const CARD_COLUMNS = 'id, name, d66_min, d66_max, tactics_cards_pack_id, edition_id';
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function emptyToNull(value: unknown): string | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed === '' ? null : trimmed;
+}
+
+function postgresCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object' || !('code' in error)) return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' ? code : undefined;
+}
+
+function errorMessage(error: unknown): string {
+  if (!error || typeof error !== 'object' || !('message' in error)) return '';
+  const message = (error as { message?: unknown }).message;
+  return typeof message === 'string' ? message : '';
+}
+
+function isMissingRowError(error: { code?: string; message?: string } | null): boolean {
+  if (!error) return false;
+  return error.code === 'PGRST116' || /0 rows/i.test(error.message ?? '');
+}
+
+function uniqueConstraintResponse(error: unknown): NextResponse | null {
+  if (postgresCode(error) !== '23505') return null;
+  const message = errorMessage(error);
+  if (message.includes('tactics_cards_tactics_cards_pack_id_name_key')) {
+    return NextResponse.json(
+      { error: 'A card with this name already exists in this pack' },
+      { status: 409 }
+    );
+  }
+  return NextResponse.json(
+    { error: 'A card with these values already exists' },
+    { status: 409 }
+  );
+}
+
+function parseOptionalD66(value: unknown, field: string): { error: string } | { data: number | null } {
+  if (value === undefined || value === null || value === '') {
+    return { data: null };
+  }
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value)) {
+      return { error: `${field} must be an integer` };
+    }
+    return { data: value };
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed === '') return { data: null };
+    if (!/^-?\d+$/.test(trimmed)) {
+      return { error: `${field} must be an integer` };
+    }
+    return { data: Number(trimmed) };
+  }
+  return { error: `${field} must be an integer` };
+}
+
+function validateCardPayload(body: {
+  name?: unknown;
+  tactics_cards_pack_id?: unknown;
+  d66_min?: unknown;
+  d66_max?: unknown;
+}) {
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  const packId = emptyToNull(body.tactics_cards_pack_id);
+
+  if (!name) {
+    return { error: 'name is required' };
+  }
+  if (name.length > 200) {
+    return { error: 'name must be 200 characters or less' };
+  }
+  if (!packId) {
+    return { error: 'tactics_cards_pack_id is required' };
+  }
+  if (!UUID_RE.test(packId)) {
+    return { error: 'tactics_cards_pack_id must be a valid UUID' };
+  }
+
+  const parsedMin = parseOptionalD66(body.d66_min, 'd66_min');
+  if ('error' in parsedMin) return parsedMin;
+  const parsedMax = parseOptionalD66(body.d66_max, 'd66_max');
+  if ('error' in parsedMax) return parsedMax;
+
+  const d66Min = parsedMin.data;
+  const d66Max = parsedMax.data;
+
+  if ((d66Min === null) !== (d66Max === null)) {
+    return { error: 'd66_min and d66_max must both be set or both be empty' };
+  }
+  if (d66Min !== null && d66Max !== null && d66Min > d66Max) {
+    return { error: 'd66_min must be less than or equal to d66_max' };
+  }
+
+  return {
+    data: {
+      name,
+      tactics_cards_pack_id: packId,
+      d66_min: d66Min,
+      d66_max: d66Max,
+    },
+  };
+}
+
+async function loadPackEdition(
+  supabase: SupabaseClient,
+  packId: string
+): Promise<{ error: string } | { editionId: string }> {
+  const { data, error } = await supabase
+    .from('tactics_cards_packs')
+    .select('id, edition_id')
+    .eq('id', packId)
+    .maybeSingle();
+
+  if (error) throw error;
+  if (!data) return { error: 'tactics_cards_pack_id not found' };
+  return { editionId: data.edition_id };
+}
+
+async function gangIdsOwningCard(
+  supabase: SupabaseClient,
+  cardId: string
+): Promise<string[]> {
+  const { data, error } = await supabase
+    .from('gang_tactics_cards')
+    .select('gang_id')
+    .eq('tactics_cards_id', cardId);
+
+  if (error) throw error;
+  return Array.from(new Set((data ?? []).map((row) => row.gang_id).filter(Boolean)));
+}
+
+function bustGangTacticsCaches(gangIds: string[]) {
+  for (const gangId of gangIds) {
+    invalidateGangTacticsCards(gangId);
+  }
+}
+
+export async function GET() {
+  const supabase = await createClient();
+
+  try {
+    const isAdmin = await checkAdmin(supabase);
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { data: cards, error } = await supabase
+      .from('tactics_cards')
+      .select(CARD_COLUMNS);
+
+    if (error) throw error;
+
+    const sorted = [...(cards ?? [])].sort(compareTacticsCards);
+    return NextResponse.json(sorted);
+  } catch (error) {
+    console.error('Error fetching tactics cards:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch tactics cards' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+
+  try {
+    const isAdmin = await checkAdmin(supabase);
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const validated = validateCardPayload(body);
+    if ('error' in validated) {
+      return NextResponse.json({ error: validated.error }, { status: 400 });
+    }
+
+    const pack = await loadPackEdition(supabase, validated.data.tactics_cards_pack_id);
+    if ('error' in pack) {
+      return NextResponse.json({ error: pack.error }, { status: 400 });
+    }
+
+    const { data: card, error } = await supabase
+      .from('tactics_cards')
+      .insert([{
+        ...validated.data,
+        edition_id: pack.editionId,
+      }])
+      .select(CARD_COLUMNS)
+      .single();
+
+    if (error) {
+      const uniqueResponse = uniqueConstraintResponse(error);
+      if (uniqueResponse) return uniqueResponse;
+      throw error;
+    }
+
+    return NextResponse.json(card);
+  } catch (error) {
+    console.error('Error creating tactics card:', error);
+    return NextResponse.json(
+      { error: 'Failed to create tactics card' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PATCH(request: Request) {
+  const supabase = await createClient();
+
+  try {
+    const isAdmin = await checkAdmin(supabase);
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { id } = body;
+
+    if (!id || typeof id !== 'string') {
+      return NextResponse.json({ error: 'id is required' }, { status: 400 });
+    }
+
+    const validated = validateCardPayload(body);
+    if ('error' in validated) {
+      return NextResponse.json({ error: validated.error }, { status: 400 });
+    }
+
+    const pack = await loadPackEdition(supabase, validated.data.tactics_cards_pack_id);
+    if ('error' in pack) {
+      return NextResponse.json({ error: pack.error }, { status: 400 });
+    }
+
+    const { data: existing, error: existingError } = await supabase
+      .from('tactics_cards')
+      .select('id, edition_id')
+      .eq('id', id)
+      .maybeSingle();
+
+    if (existingError) throw existingError;
+    if (!existing) {
+      return NextResponse.json({ error: 'Card not found' }, { status: 404 });
+    }
+
+    const owningGangIds = await gangIdsOwningCard(supabase, id);
+    if (existing.edition_id !== pack.editionId && owningGangIds.length > 0) {
+      return NextResponse.json(
+        { error: 'Cannot change edition while gangs still reference this card' },
+        { status: 409 }
+      );
+    }
+
+    const { data: card, error } = await supabase
+      .from('tactics_cards')
+      .update({
+        ...validated.data,
+        edition_id: pack.editionId,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+      .select(CARD_COLUMNS)
+      .maybeSingle();
+
+    if (error) {
+      const uniqueResponse = uniqueConstraintResponse(error);
+      if (uniqueResponse) return uniqueResponse;
+      throw error;
+    }
+    if (!card) {
+      return NextResponse.json({ error: 'Card not found' }, { status: 404 });
+    }
+
+    bustGangTacticsCaches(owningGangIds);
+
+    return NextResponse.json(card);
+  } catch (error) {
+    console.error('Error updating tactics card:', error);
+    return NextResponse.json(
+      { error: 'Failed to update tactics card' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function DELETE(request: Request) {
+  const supabase = await createClient();
+
+  try {
+    const isAdmin = await checkAdmin(supabase);
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { id } = body;
+
+    if (!id || typeof id !== 'string') {
+      return NextResponse.json({ error: 'id is required' }, { status: 400 });
+    }
+
+    const { data: existing, error: existingError } = await supabase
+      .from('tactics_cards')
+      .select('id')
+      .eq('id', id)
+      .maybeSingle();
+
+    if (existingError) throw existingError;
+    if (!existing) {
+      return NextResponse.json({ error: 'Card not found' }, { status: 404 });
+    }
+
+    const owningGangIds = await gangIdsOwningCard(supabase, id);
+    if (owningGangIds.length > 0) {
+      return NextResponse.json(
+        { error: 'Cannot delete card while gangs still reference it' },
+        { status: 409 }
+      );
+    }
+
+    const { error } = await supabase
+      .from('tactics_cards')
+      .delete()
+      .eq('id', id);
+
+    if (error) {
+      if (isMissingRowError(error)) {
+        return NextResponse.json({ error: 'Card not found' }, { status: 404 });
+      }
+      if (postgresCode(error) === '23503') {
+        return NextResponse.json(
+          { error: 'Cannot delete card while gangs still reference it' },
+          { status: 409 }
+        );
+      }
+      throw error;
+    }
+
+    bustGangTacticsCaches(owningGangIds);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error deleting tactics card:', error);
+    return NextResponse.json(
+      { error: 'Failed to delete tactics card' },
+      { status: 500 }
+    );
+  }
+}

--- a/components/admin/admin-tactics-cards.tsx
+++ b/components/admin/admin-tactics-cards.tsx
@@ -1,0 +1,771 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Combobox } from '@/components/ui/combobox';
+import { toast } from 'sonner';
+import { EditionSelect } from '@/components/edition-select';
+import { compareTacticsCards, formatD66Range } from '@/types/tactics-card';
+
+enum OperationType {
+  POST = 'POST',
+  UPDATE = 'UPDATE',
+  DELETE = 'DELETE'
+}
+
+type CategoryType = 'packs' | 'cards';
+
+interface TacticsPack {
+  id: string;
+  name: string;
+  edition_id: string;
+  gang_type_id: string | null;
+}
+
+interface TacticsCardRow {
+  id: string;
+  name: string;
+  d66_min: number | null;
+  d66_max: number | null;
+  tactics_cards_pack_id: string;
+  edition_id: string;
+}
+
+interface GangType {
+  gang_type_id: string;
+  gang_type: string;
+  edition_id?: string | null;
+}
+
+interface AdminTacticsCardsModalProps {
+  onClose: () => void;
+}
+
+function packGangTypeName(pack: TacticsPack, gangTypes: GangType[]): string | undefined {
+  if (pack.gang_type_id == null) return undefined;
+  return gangTypes.find(gt => gt.gang_type_id === pack.gang_type_id)?.gang_type;
+}
+
+function packSelectOption(pack: TacticsPack, gangTypes: GangType[]) {
+  const gangTypeName = packGangTypeName(pack, gangTypes);
+  return {
+    value: pack.id,
+    label: gangTypeName ? (
+      <span className="inline-flex items-baseline gap-1">
+        <span>{pack.name}</span>
+        <span className="text-xs text-muted-foreground">
+          {`• ${gangTypeName}`}
+        </span>
+      </span>
+    ) : pack.name,
+    displayValue: gangTypeName ? `${pack.name} • ${gangTypeName}` : pack.name,
+  };
+}
+
+function cardLabel(card: TacticsCardRow): string {
+  const range = formatD66Range(card.d66_min, card.d66_max);
+  return range === '-' ? card.name : `${card.name} (${range})`;
+}
+
+function parseD66Input(value: string): number | null {
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+  const parsed = Number(trimmed);
+  return Number.isInteger(parsed) ? parsed : NaN;
+}
+
+export function AdminTacticsCardsModal({ onClose }: AdminTacticsCardsModalProps) {
+  const queryClient = useQueryClient();
+
+  const [selectedCategory, setSelectedCategory] = useState<CategoryType>('packs');
+  const [editionId, setEditionId] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const [selectedPackId, setSelectedPackId] = useState('');
+  const [packName, setPackName] = useState('');
+  const [packGangTypeId, setPackGangTypeId] = useState('');
+  const [isCreateModePack, setIsCreateModePack] = useState(false);
+
+  const [selectedCardId, setSelectedCardId] = useState('');
+  const [cardPackId, setCardPackId] = useState('');
+  const [cardName, setCardName] = useState('');
+  const [d66Min, setD66Min] = useState('');
+  const [d66Max, setD66Max] = useState('');
+  const [isCreateModeCard, setIsCreateModeCard] = useState(false);
+
+  const { data: packs = [], isLoading: isLoadingPacks } = useQuery<TacticsPack[]>({
+    queryKey: ['admin-tactics-cards-packs'],
+    queryFn: async () => {
+      const response = await fetch('/api/admin/tactics-cards-packs');
+      if (!response.ok) throw new Error('Failed to fetch tactics card packs');
+      return response.json();
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const { data: cards = [], isLoading: isLoadingCards } = useQuery<TacticsCardRow[]>({
+    queryKey: ['admin-tactics-cards'],
+    queryFn: async () => {
+      const response = await fetch('/api/admin/tactics-cards');
+      if (!response.ok) throw new Error('Failed to fetch tactics cards');
+      return response.json();
+    },
+    staleTime: 5 * 60 * 1000,
+    enabled: selectedCategory === 'cards',
+  });
+
+  const { data: gangTypes = [], isLoading: isLoadingGangTypes } = useQuery<GangType[]>({
+    queryKey: ['admin-gang-types'],
+    queryFn: async () => {
+      const response = await fetch('/api/admin/gang-types');
+      if (!response.ok) throw new Error('Failed to fetch gang types');
+      return response.json();
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const isLoading =
+    isLoadingPacks ||
+    isLoadingGangTypes ||
+    isSubmitting ||
+    (selectedCategory === 'cards' && isLoadingCards);
+
+  const filteredGangTypes = useMemo(
+    () => editionId
+      ? gangTypes.filter(gt => gt.edition_id === editionId)
+      : gangTypes,
+    [gangTypes, editionId]
+  );
+
+  const filteredPacks = useMemo(
+    () => editionId
+      ? packs.filter(pack => pack.edition_id === editionId)
+      : packs,
+    [packs, editionId]
+  );
+
+  const filteredCards = useMemo(() => {
+    const byEdition = editionId
+      ? cards.filter(card => card.edition_id === editionId)
+      : cards;
+    const byPack = cardPackId
+      ? byEdition.filter(card =>
+          card.tactics_cards_pack_id === cardPackId || card.id === selectedCardId
+        )
+      : byEdition;
+    return [...byPack].sort(compareTacticsCards);
+  }, [cards, editionId, cardPackId, selectedCardId]);
+
+  const packSelectOptions = useMemo(
+    () => filteredPacks.map((pack) => packSelectOption(pack, gangTypes)),
+    [filteredPacks, gangTypes]
+  );
+
+  const gangTypeSelectOptions = useMemo(
+    () => [
+      { value: '', label: 'Core (All gangs)' },
+      ...filteredGangTypes.map((gangType) => ({
+        value: gangType.gang_type_id,
+        label: gangType.gang_type,
+      })),
+    ],
+    [filteredGangTypes]
+  );
+
+  const cardSelectOptions = useMemo(
+    () => filteredCards.map((card) => ({
+      value: card.id,
+      label: cardLabel(card),
+    })),
+    [filteredCards]
+  );
+
+  const isPackFormDisabled = (!isCreateModePack && !selectedPackId) || isLoading;
+  const isCardMetaDisabled = (!isCreateModeCard && !selectedCardId) || isLoading;
+  const isCardFieldsDisabled = isCardMetaDisabled || (isCreateModeCard && !cardPackId);
+
+  const d66MinValue = parseD66Input(d66Min);
+  const d66MaxValue = parseD66Input(d66Max);
+  const d66PairValid =
+    (d66MinValue === null && d66MaxValue === null) ||
+    (
+      d66MinValue !== null &&
+      d66MaxValue !== null &&
+      !Number.isNaN(d66MinValue) &&
+      !Number.isNaN(d66MaxValue) &&
+      d66MinValue <= d66MaxValue
+    );
+
+  const canSubmitPack = Boolean(packName.trim() && editionId);
+  const canSubmitCard = Boolean(cardName.trim() && cardPackId && d66PairValid);
+
+  const clearPackFields = () => {
+    setPackName('');
+    setPackGangTypeId('');
+  };
+
+  const clearCardFields = () => {
+    setCardName('');
+    setD66Min('');
+    setD66Max('');
+  };
+
+  const resetPackSelection = () => {
+    setSelectedPackId('');
+    clearPackFields();
+    setIsCreateModePack(false);
+  };
+
+  const resetCardSelection = () => {
+    setSelectedCardId('');
+    setCardPackId('');
+    clearCardFields();
+    setIsCreateModeCard(false);
+  };
+
+  const handleCategoryChange = (category: CategoryType) => {
+    if (category === selectedCategory) return;
+    setSelectedCategory(category);
+    resetPackSelection();
+    resetCardSelection();
+  };
+
+  const handleEditionChange = (newEditionId: string) => {
+    setEditionId(newEditionId);
+
+    if (newEditionId && selectedPackId) {
+      const pack = packs.find(p => p.id === selectedPackId);
+      if (pack && pack.edition_id !== newEditionId) {
+        resetPackSelection();
+      }
+    }
+
+    if (packGangTypeId) {
+      const selectedGangType = gangTypes.find(gt => gt.gang_type_id === packGangTypeId);
+      if (selectedGangType && selectedGangType.edition_id !== newEditionId) {
+        setPackGangTypeId('');
+      }
+    }
+
+    if (newEditionId && selectedCardId) {
+      const card = cards.find(c => c.id === selectedCardId);
+      if (card && card.edition_id !== newEditionId) {
+        resetCardSelection();
+      }
+    }
+
+    if (cardPackId) {
+      const pack = packs.find(p => p.id === cardPackId);
+      if (pack && pack.edition_id !== newEditionId) {
+        setCardPackId('');
+        setSelectedCardId('');
+        clearCardFields();
+        setIsCreateModeCard(false);
+      }
+    }
+  };
+
+  const handlePackSelect = (packId: string) => {
+    setSelectedPackId(packId);
+    const pack = packs.find(p => p.id === packId);
+    if (pack) {
+      setPackName(pack.name);
+      setPackGangTypeId(pack.gang_type_id ?? '');
+      setEditionId(pack.edition_id ?? '');
+      setIsCreateModePack(false);
+    } else {
+      clearPackFields();
+      setIsCreateModePack(false);
+    }
+  };
+
+  const handleCreateNewPack = () => {
+    setSelectedPackId('');
+    clearPackFields();
+    setIsCreateModePack(true);
+  };
+
+  const handleCardSelect = (cardId: string) => {
+    setSelectedCardId(cardId);
+    const card = cards.find(c => c.id === cardId);
+    if (card) {
+      setCardPackId(card.tactics_cards_pack_id);
+      setCardName(card.name);
+      setD66Min(card.d66_min == null ? '' : String(card.d66_min));
+      setD66Max(card.d66_max == null ? '' : String(card.d66_max));
+      setEditionId(card.edition_id ?? '');
+      setIsCreateModeCard(false);
+    } else {
+      clearCardFields();
+      setIsCreateModeCard(false);
+    }
+  };
+
+  const handleCreateNewCard = () => {
+    setSelectedCardId('');
+    clearCardFields();
+    setIsCreateModeCard(true);
+  };
+
+  const invalidateTacticsQueries = () => Promise.all([
+    queryClient.invalidateQueries({ queryKey: ['admin-tactics-cards-packs'] }),
+    queryClient.invalidateQueries({ queryKey: ['admin-tactics-cards'] }),
+    queryClient.invalidateQueries({ queryKey: ['tactics-cards'] }),
+  ]);
+
+  const handleSubmitPack = async (operation: OperationType) => {
+    if (
+      (operation === OperationType.POST || operation === OperationType.UPDATE) &&
+      (!packName.trim() || !editionId)
+    ) {
+      toast.error('Please fill in all required fields');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      let method: string;
+      let body: string | undefined;
+
+      switch (operation) {
+        case OperationType.POST:
+          method = 'POST';
+          body = JSON.stringify({
+            name: packName,
+            edition_id: editionId,
+            gang_type_id: packGangTypeId || null,
+          });
+          break;
+        case OperationType.UPDATE:
+          method = 'PATCH';
+          body = JSON.stringify({
+            id: selectedPackId,
+            name: packName,
+            edition_id: editionId,
+            gang_type_id: packGangTypeId || null,
+          });
+          break;
+        case OperationType.DELETE:
+          method = 'DELETE';
+          body = JSON.stringify({
+            id: selectedPackId,
+          });
+          break;
+        default:
+          throw new Error('Invalid operation');
+      }
+
+      const response = await fetch('/api/admin/tactics-cards-packs', {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body,
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(
+          errorData.error ||
+          `Failed to ${operation === OperationType.POST ? 'create' : operation === OperationType.UPDATE ? 'update' : 'delete'} pack`
+        );
+      }
+
+      const resultData = operation === OperationType.DELETE
+        ? null
+        : await response.json();
+
+      toast.success(
+        `Pack ${operation === OperationType.POST ? 'created' : operation === OperationType.UPDATE ? 'updated' : 'deleted'} successfully`
+      );
+
+      await invalidateTacticsQueries();
+
+      if (operation === OperationType.POST && resultData?.id) {
+        setSelectedPackId(resultData.id);
+        setIsCreateModePack(false);
+        setPackName(resultData.name ?? packName);
+        setPackGangTypeId(resultData.gang_type_id ?? '');
+        setEditionId(resultData.edition_id ?? editionId);
+      } else if (operation === OperationType.DELETE) {
+        resetPackSelection();
+      }
+    } catch (error) {
+      console.error(`Error executing ${operation} pack operation:`, error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : `Failed to ${operation === OperationType.POST ? 'create' : operation === OperationType.UPDATE ? 'update' : 'delete'} pack`
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleSubmitCard = async (operation: OperationType) => {
+    if (
+      (operation === OperationType.POST || operation === OperationType.UPDATE) &&
+      (!cardName.trim() || !cardPackId || !d66PairValid)
+    ) {
+      toast.error(
+        !d66PairValid
+          ? 'D66 min and max must both be empty or both be integers with min less than or equal to max'
+          : 'Please fill in all required fields'
+      );
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      let method: string;
+      let body: string | undefined;
+
+      switch (operation) {
+        case OperationType.POST:
+          method = 'POST';
+          body = JSON.stringify({
+            name: cardName,
+            tactics_cards_pack_id: cardPackId,
+            d66_min: d66MinValue,
+            d66_max: d66MaxValue,
+          });
+          break;
+        case OperationType.UPDATE:
+          method = 'PATCH';
+          body = JSON.stringify({
+            id: selectedCardId,
+            name: cardName,
+            tactics_cards_pack_id: cardPackId,
+            d66_min: d66MinValue,
+            d66_max: d66MaxValue,
+          });
+          break;
+        case OperationType.DELETE:
+          method = 'DELETE';
+          body = JSON.stringify({
+            id: selectedCardId,
+          });
+          break;
+        default:
+          throw new Error('Invalid operation');
+      }
+
+      const response = await fetch('/api/admin/tactics-cards', {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body,
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        throw new Error(
+          errorData.error ||
+          `Failed to ${operation === OperationType.POST ? 'create' : operation === OperationType.UPDATE ? 'update' : 'delete'} card`
+        );
+      }
+
+      const resultData = operation === OperationType.DELETE
+        ? null
+        : await response.json();
+
+      toast.success(
+        `Card ${operation === OperationType.POST ? 'created' : operation === OperationType.UPDATE ? 'updated' : 'deleted'} successfully`
+      );
+
+      await invalidateTacticsQueries();
+
+      if (operation === OperationType.POST && resultData?.id) {
+        setSelectedCardId(resultData.id);
+        setIsCreateModeCard(false);
+        setCardName(resultData.name ?? cardName);
+        setCardPackId(resultData.tactics_cards_pack_id ?? cardPackId);
+        setD66Min(resultData.d66_min == null ? '' : String(resultData.d66_min));
+        setD66Max(resultData.d66_max == null ? '' : String(resultData.d66_max));
+        setEditionId(resultData.edition_id ?? editionId);
+      } else if (operation === OperationType.DELETE) {
+        setSelectedCardId('');
+        clearCardFields();
+        setIsCreateModeCard(false);
+      }
+    } catch (error) {
+      console.error(`Error executing ${operation} card operation:`, error);
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : `Failed to ${operation === OperationType.POST ? 'create' : operation === OperationType.UPDATE ? 'update' : 'delete'} card`
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const isCreateMode = selectedCategory === 'packs' ? isCreateModePack : isCreateModeCard;
+  const selectedId = selectedCategory === 'packs' ? selectedPackId : selectedCardId;
+  const canSubmit = selectedCategory === 'packs' ? canSubmitPack : canSubmitCard;
+  const handleSubmit = selectedCategory === 'packs' ? handleSubmitPack : handleSubmitCard;
+  const entityLabel = selectedCategory === 'packs' ? 'Pack' : 'Card';
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 dark:bg-neutral-700/50 flex justify-center items-center z-50 px-[10px]"
+      onMouseDown={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="bg-card rounded-lg shadow-xl w-full max-w-2xl min-h-0 max-h-svh overflow-y-auto flex flex-col">
+        <div className="border-b px-[10px] py-2 flex justify-between items-center">
+          <div>
+            <h3 className="text-xl md:text-2xl font-bold text-foreground">Manage Tactics Cards</h3>
+            <p className="text-sm text-muted-foreground">Create, edit, or delete tactics card packs and cards</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-muted-foreground hover:text-muted-foreground text-xl"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="px-[10px] py-4">
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-muted-foreground mb-1">
+                Category
+              </label>
+              <div className="grid grid-cols-2 gap-2">
+                <Button
+                  type="button"
+                  variant={selectedCategory === 'packs' ? 'default' : 'outline'}
+                  onClick={() => handleCategoryChange('packs')}
+                  disabled={isLoading}
+                  className={
+                    selectedCategory === 'packs'
+                      ? ''
+                      : 'bg-muted text-muted-foreground hover:bg-muted/80'
+                  }
+                >
+                  Packs
+                </Button>
+                <Button
+                  type="button"
+                  variant={selectedCategory === 'cards' ? 'default' : 'outline'}
+                  onClick={() => handleCategoryChange('cards')}
+                  disabled={isLoading}
+                  className={
+                    selectedCategory === 'cards'
+                      ? ''
+                      : 'bg-muted text-muted-foreground hover:bg-muted/80'
+                  }
+                >
+                  Cards
+                </Button>
+              </div>
+            </div>
+
+            <EditionSelect value={editionId} onChange={handleEditionChange} defaultToCurrent />
+
+            {selectedCategory === 'packs' && (
+              <>
+                <div>
+                  <div className="flex justify-between items-center mb-1">
+                    <label className="block text-sm font-medium text-muted-foreground">
+                      Select Pack
+                    </label>
+                    <Button
+                      onClick={handleCreateNewPack}
+                      disabled={isLoading}
+                      className="text-xs h-7 px-3"
+                    >
+                      Create New
+                    </Button>
+                  </div>
+                  <Combobox
+                    value={selectedPackId}
+                    onValueChange={handlePackSelect}
+                    options={packSelectOptions}
+                    placeholder="Select a pack to edit"
+                    clearable
+                    disabled={isLoading}
+                    showLabelWhenClosed
+                  />
+                  {isCreateModePack && (
+                    <p className="text-xs text-amber-600 mt-1">
+                      Creating new pack. Select from dropdown to cancel and edit existing.
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-muted-foreground mb-1">
+                    Pack Name *
+                  </label>
+                  <Input
+                    type="text"
+                    value={packName}
+                    onChange={(e) => setPackName(e.target.value)}
+                    placeholder="E.g. Core Gang Tactics"
+                    className="w-full"
+                    disabled={isPackFormDisabled}
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-muted-foreground mb-1">
+                    Gang Type
+                  </label>
+                  <Combobox
+                    value={packGangTypeId}
+                    onValueChange={setPackGangTypeId}
+                    options={gangTypeSelectOptions}
+                    placeholder="Core (All gangs)"
+                    disabled={isPackFormDisabled}
+                  />
+                  <p className="text-xs text-muted-foreground mt-1">
+                    Core (All gangs) is the edition default deck. House packs should use the parent gang type so alternate lists inherit them.
+                  </p>
+                </div>
+              </>
+            )}
+
+            {selectedCategory === 'cards' && (
+              <>
+                <div>
+                  <label className="block text-sm font-medium text-muted-foreground mb-1">
+                    Pack *
+                  </label>
+                  <Combobox
+                    value={cardPackId}
+                    onValueChange={setCardPackId}
+                    options={packSelectOptions}
+                    placeholder="Select a pack"
+                    clearable
+                    disabled={isLoading}
+                    showLabelWhenClosed
+                  />
+                </div>
+
+                <div>
+                  <div className="flex justify-between items-center mb-1">
+                    <label className="block text-sm font-medium text-muted-foreground">
+                      Select Card
+                    </label>
+                    <Button
+                      onClick={handleCreateNewCard}
+                      disabled={isLoading}
+                      className="text-xs h-7 px-3"
+                    >
+                      Create New
+                    </Button>
+                  </div>
+                  <Combobox
+                    value={selectedCardId}
+                    onValueChange={handleCardSelect}
+                    options={cardSelectOptions}
+                    placeholder="Select a card to edit"
+                    clearable
+                    disabled={isLoading}
+                  />
+                  {isCreateModeCard && (
+                    <p className="text-xs text-amber-600 mt-1">
+                      Creating new card. Select from dropdown to cancel and edit existing.
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-muted-foreground mb-1">
+                    Card Name *
+                  </label>
+                  <Input
+                    type="text"
+                    value={cardName}
+                    onChange={(e) => setCardName(e.target.value)}
+                    placeholder="E.g. Point-blank Shot"
+                    className="w-full"
+                    disabled={isCardFieldsDisabled}
+                  />
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-sm font-medium text-muted-foreground mb-1">
+                      D66 Min
+                    </label>
+                    <Input
+                      type="text"
+                      inputMode="numeric"
+                      value={d66Min}
+                      onChange={(e) => setD66Min(e.target.value)}
+                      placeholder="E.g. 11"
+                      className="w-full"
+                      disabled={isCardFieldsDisabled}
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-muted-foreground mb-1">
+                      D66 Max
+                    </label>
+                    <Input
+                      type="text"
+                      inputMode="numeric"
+                      value={d66Max}
+                      onChange={(e) => setD66Max(e.target.value)}
+                      placeholder="E.g. 12"
+                      className="w-full"
+                      disabled={isCardFieldsDisabled}
+                    />
+                  </div>
+                </div>
+                <p className="text-xs text-muted-foreground -mt-2">
+                  Leave both empty for unnumbered cards. If set, both are required and min must be less than or equal to max.
+                </p>
+              </>
+            )}
+          </div>
+        </div>
+
+        <div className="border-t px-[10px] py-2 flex flex-wrap justify-end gap-2">
+          <Button
+            variant="outline"
+            onClick={onClose}
+            disabled={isLoading}
+            className="flex-1"
+          >
+            Cancel
+          </Button>
+
+          {isCreateMode && (
+            <Button
+              onClick={() => handleSubmit(OperationType.POST)}
+              disabled={!canSubmit || isLoading}
+              className="flex-1 bg-neutral-900 text-white rounded-sm hover:bg-gray-800"
+            >
+              {isLoading ? 'Creating...' : `Create ${entityLabel}`}
+            </Button>
+          )}
+
+          {!isCreateMode && selectedId && (
+            <>
+              <Button
+                onClick={() => handleSubmit(OperationType.UPDATE)}
+                disabled={!canSubmit || isLoading}
+                className="flex-1 bg-neutral-900 text-white rounded-sm hover:bg-gray-800"
+              >
+                {isLoading ? 'Updating...' : `Update ${entityLabel}`}
+              </Button>
+              <Button
+                onClick={() => handleSubmit(OperationType.DELETE)}
+                disabled={isLoading}
+                className="flex-1 bg-red-600 text-white rounded-sm hover:bg-red-700"
+              >
+                {isLoading ? 'Deleting...' : `Delete ${entityLabel}`}
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/admin-tactics-cards.tsx
+++ b/components/admin/admin-tactics-cards.tsx
@@ -151,12 +151,10 @@ export function AdminTacticsCardsModal({ onClose }: AdminTacticsCardsModalProps)
       ? cards.filter(card => card.edition_id === editionId)
       : cards;
     const byPack = cardPackId
-      ? byEdition.filter(card =>
-          card.tactics_cards_pack_id === cardPackId || card.id === selectedCardId
-        )
+      ? byEdition.filter(card => card.tactics_cards_pack_id === cardPackId)
       : byEdition;
     return [...byPack].sort(compareTacticsCards);
-  }, [cards, editionId, cardPackId, selectedCardId]);
+  }, [cards, editionId, cardPackId]);
 
   const packSelectOptions = useMemo(
     () => filteredPacks.map((pack) => packSelectOption(pack, gangTypes)),
@@ -307,6 +305,14 @@ export function AdminTacticsCardsModal({ onClose }: AdminTacticsCardsModalProps)
     setSelectedCardId('');
     clearCardFields();
     setIsCreateModeCard(true);
+  };
+
+  const handleCardPackChange = (packId: string) => {
+    setCardPackId(packId);
+    if (!isCreateModeCard) {
+      setSelectedCardId('');
+      clearCardFields();
+    }
   };
 
   const invalidateTacticsQueries = () => Promise.all([
@@ -637,7 +643,7 @@ export function AdminTacticsCardsModal({ onClose }: AdminTacticsCardsModalProps)
                   </label>
                   <Combobox
                     value={cardPackId}
-                    onValueChange={setCardPackId}
+                    onValueChange={handleCardPackChange}
                     options={packSelectOptions}
                     placeholder="Select a pack"
                     clearable


### PR DESCRIPTION
## Summary

- Add a Tactics Cards tile on the Admin Dashboard (after Gangs) that opens a modal to create, edit, and delete tactics card packs and catalogue cards.
- Packs are edition-scoped decks (core vs house gang type). Cards belong to one pack; `edition_id` is copied from the pack. Deletes are blocked while cards or gangs still reference the row.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Schema / migration

## How I tested

- [x] Open Admin Dashboard → Tactics Cards → create/update/delete a pack (core and house)
- [x] Switch to Cards → add/edit/delete cards in a pack, including D66 min/max and unnumbered cards
- [x] Confirm 409 when deleting a pack that still has cards, or a card still owned by a gang
- [x] Confirm a pack rename/house assignment shows up in a gang’s Add Gang Tactics picker after refresh

## Risk / rollout

- Low — admin-only catalogue CRUD. No schema/migration. Player gang ownership (`gang_tactics_cards`) is unchanged.