### PR TITLE
Split the gang stash to not over invalidate

### DIFF
--- a/app/actions/equipment.ts
+++ b/app/actions/equipment.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { invalidateGang, invalidateFighter, invalidateGangCampaignMembership, invalidateGangStash, invalidateGangFinancials } from '@/utils/cache-tags';
+import { invalidateGang, invalidateGangRoster, invalidateFighter, invalidateGangCampaignMembership, invalidateGangStash, invalidateGangFinancials } from '@/utils/cache-tags';
 import { createClient, createServiceRoleClient } from "@/utils/supabase/server";
 
 import { updateGangFinancials, updateGangRatingSimple } from '@/utils/gang-rating-and-wealth';
@@ -909,6 +909,7 @@ export async function buyEquipmentForFighter(params: BuyEquipmentParams): Promis
       // If this fighter is a beast, invalidate the owner's cache
       await invalidateBeastOwnerCache(params.fighter_id, params.gang_id, supabase, fighterPetId);
     } else if (params.vehicle_id) {
+      invalidateGangRoster(params.gang_id);
       if (vehicleAssignedFighterId) {
         invalidateFighter(vehicleAssignedFighterId, params.gang_id); invalidateGangFinancials(params.gang_id);
       }

--- a/app/actions/sell-equipment.ts
+++ b/app/actions/sell-equipment.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { TAGS, invalidateGang, invalidateFighter, invalidateGangCampaignMembership, invalidateGangStash, invalidateGangFinancials } from '@/utils/cache-tags';
+import { TAGS, invalidateGang, invalidateGangRoster, invalidateFighter, invalidateGangCampaignMembership, invalidateGangStash, invalidateGangFinancials } from '@/utils/cache-tags';
 import { createClient } from "@/utils/supabase/server";
 import { getAuthenticatedUser } from "@/utils/auth";
 
@@ -321,6 +321,7 @@ export async function sellEquipmentFromFighter(params: SellEquipmentParams): Pro
         .eq('id', equipmentData.vehicle_id)
         .single();
       
+      invalidateGangRoster(gangId);
       if (!vehicleError && vehicleData?.fighter_id) {
         // Use equipment deletion invalidation for the fighter to ensure equipment list updates
         invalidateFighter(vehicleData.fighter_id, gangId);

--- a/app/actions/update-vehicle.ts
+++ b/app/actions/update-vehicle.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { invalidateGang, invalidateFighter, invalidateGangFinancials } from '@/utils/cache-tags';
+import { invalidateGang, invalidateGangRoster, invalidateFighter, invalidateGangFinancials } from '@/utils/cache-tags';
 import { createClient } from '@/utils/supabase/server';
 
 import { getAuthenticatedUser } from '@/utils/auth';
@@ -183,6 +183,7 @@ export async function updateVehicle(params: UpdateVehicleParams): Promise<Update
     // not the caller. Stat-adjustment effects can carry credit costs, so the
     // cross-page financial copies refresh too.
     invalidateGangFinancials(currentVehicle.gang_id);
+    invalidateGangRoster(currentVehicle.gang_id);
     if (params.assignedFighterId) {
       invalidateFighter(params.assignedFighterId, currentVehicle.gang_id);
     }

--- a/app/lib/shared/gang-data.ts
+++ b/app/lib/shared/gang-data.ts
@@ -1117,7 +1117,7 @@ export const getGangFightersBundle = async (gangId: string, supabase: any): Prom
     },
     [`gang-fighters-bundle-v4-${gangId}`],
     {
-      tags: [TAGS.gang(gangId)],
+      tags: [TAGS.gangRoster(gangId)],
       revalidate: false
     }
   )();
@@ -1248,7 +1248,7 @@ export const getGangFighterStats = async (
     },
     [`gang-fighter-stats-v3-${gangId}`],
     {
-      tags: [TAGS.gang(gangId)],
+      tags: [TAGS.gangRoster(gangId)],
       revalidate: false
     }
   )();

--- a/types/gang.ts
+++ b/types/gang.ts
@@ -117,7 +117,7 @@ export interface ResourceUpdate {
 
 /**
  * Raw, unprocessed rows for everything fighter/vehicle-shaped in a gang.
- * Fetched once (getGangFightersBundle, tag gang-{id}) and assembled into the
+ * Fetched once (getGangFightersBundle, tag gang-roster-{id}) and assembled into the
  * page-specific shapes by the pure functions in utils/gang-assembly.ts. The transform logic is
  * moved verbatim from the previous getGangFightersList/getGangVehicles
  * implementations — queries got wider, the logic did not change.

--- a/utils/cache-tags.ts
+++ b/utils/cache-tags.ts
@@ -10,7 +10,12 @@ import { revalidateTag } from 'next/cache';
  *
  * Read side                                  | Busted by
  * -------------------------------------------|------------------------------
- * gang-{id}        gang core + fighters      | any gang/fighter mutation
+ * gang-{id}        gang core, campaign        | any gang/fighter mutation
+ *                  captives                  |
+ * gang-roster-{id} fighters AND all gang     | any fighter OR vehicle
+ *                  vehicles, their equipment,| mutation — NOT
+ *                  effects, loadouts, stats  | updateGangFinancials
+ *                  (45 KB - 1 MB)            |
  * gang-overview-{id} name/rating/wealth/     | updateGangFinancials (choke
  *                  credits copies on other   | point) + gang name/reputation
  *                  pages (campaign, home)    | edits — NOT xp/image/loadouts
@@ -26,6 +31,7 @@ import { revalidateTag } from 'next/cache';
  */
 export const TAGS = {
   gang: (id: string) => `gang-${id}`,
+  gangRoster: (id: string) => `gang-roster-${id}`,
   gangOverview: (id: string) => `gang-overview-${id}`,
   gangCampaigns: (id: string) => `gang-campaigns-${id}`,
   gangPositioning: (id: string) => `gang-positioning-${id}`,
@@ -69,12 +75,22 @@ const bust = (tag: string) => revalidateTag(tag, { expire: 0 });
 /** Any gang-shaped data changed (gang core row and/or its fighters). */
 export const invalidateGang = (gangId: string) => {
   bust(TAGS.gang(gangId));
+  bust(TAGS.gangRoster(gangId));
+};
+
+/**
+ * Roster contents changed without a fighter being involved — the bundle holds ALL gang vehicles,
+ * assigned or not, with their equipment and effects.
+ */
+export const invalidateGangRoster = (gangId: string) => {
+  bust(TAGS.gangRoster(gangId));
 };
 
 /** A fighter changed. Always busts the owning gang's bundle too. */
 export const invalidateFighter = (fighterId: string, gangId: string) => {
   bust(TAGS.fighter(fighterId));
   bust(TAGS.gang(gangId));
+  bust(TAGS.gangRoster(gangId));
 };
 
 /**
@@ -91,6 +107,11 @@ export const invalidateGangOverview = (gangId: string) => {
  * Credits/rating/wealth changed: gang pages AND the cross-page copies
  * (campaign standings, home cards). updateGangFinancials calls this for
  * every financial write in the app.
+ *
+ * Deliberately does NOT bust gangRoster: rating is derived from fighters but
+ * stored on the gangs row, so money moving alters nothing the roster holds.
+ * A write that also changes roster contents must say so itself —
+ * invalidateFighter for a fighter, invalidateGangRoster for a vehicle.
  */
 export const invalidateGangFinancials = (gangId: string) => {
   bust(TAGS.gang(gangId));


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? -->

- Split of the gang id cache so that common mutations that does not effect fighters does not bust the complete gang cache.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Schema / migration

## How I tested

<!-- What you tested before opening this PR. Example: Opened gang X → bought equipment → credits/rating updated -->

- Performed some actions to check that data is not stale

## Risk / rollout

<!-- e.g. Low / Medium — any deploy notes beyond database (env vars, feature flags, etc.). -->

- Low - Risk is that this change may result in stale cache, but will in those cases be followed up with fixes.
