### PR TITLE
Fixed genestealer corruption since the name changed from infected to …

### DIFF
--- a/components/admin/admin-edit-equipment.tsx
+++ b/components/admin/admin-edit-equipment.tsx
@@ -12,7 +12,7 @@ import { WeaponProfileInput, emptyWeaponProfile, EquipmentGrants, EquipmentAvail
 import { HiX } from "react-icons/hi";
 import { getFighterSubtypeSortRank } from "@/utils/fighterSubtypeRank";
 import { gangOriginRank } from "@/utils/gangOriginRank";
-import { gangSubtypeRank } from "@/utils/gangSubtypeRank";
+import { getGangSubtypeRank } from "@/utils/gangSubtypeRank";
 import { AdminFighterEffects } from "./admin-fighter-effects";
 import { EditionSelect, useEditions, editionSlugOf } from '@/components/edition-select';
 import { hasLethalityStatline, hasTradePoints } from '@/types/edition';
@@ -86,8 +86,17 @@ function GangOriginOptions({ origins }: { origins: GangOriginOption[] }) {
   );
 }
 
-/** Gang-subtype <option>s ordered by gangSubtypeRank. */
-function GangSubtypeOptions({ subtypes }: { subtypes: Array<{ id: string; subtype: string }> }) {
+/**
+ * Gang-subtype <option>s in the edition's own order. With no edition selected the list spans
+ * editions and ranks empty, leaving them unordered rather than in one edition's order.
+ */
+function GangSubtypeOptions(
+  { subtypes, editionSlug }: {
+    subtypes: Array<{ id: string; subtype: string }>;
+    editionSlug?: string | null;
+  }
+) {
+  const gangSubtypeRank = getGangSubtypeRank(editionSlug);
   return (
     <>
       {[...subtypes]
@@ -1733,7 +1742,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                                 className="w-full p-2 border rounded-md"
                               >
                                 <option key="default" value="">Select a Gang Subtype</option>
-                                <GangSubtypeOptions subtypes={filteredGangSubtypes} />
+                                <GangSubtypeOptions subtypes={filteredGangSubtypes} editionSlug={editionSlug} />
                               </select>
                             </div>
 
@@ -1925,7 +1934,7 @@ export function AdminEditEquipmentModal({ onClose, onSubmit }: AdminEditEquipmen
                             className="w-full p-2 border rounded-md"
                           >
                             <option key="default" value="">Any Gang Subtype</option>
-                            <GangSubtypeOptions subtypes={filteredGangSubtypes} />
+                            <GangSubtypeOptions subtypes={filteredGangSubtypes} editionSlug={editionSlug} />
                           </select>
                         </div>
                       </div>

--- a/components/create-gang-modal.tsx
+++ b/components/create-gang-modal.tsx
@@ -11,7 +11,7 @@ import { createClient } from "@/utils/supabase/client"
 import { SubmitButton } from "./submit-button"
 import { toast } from 'sonner';
 import { getGangListRank } from "@/utils/gangListRank"
-import { gangSubtypeRank } from "@/utils/gangSubtypeRank"
+import { getGangSubtypeRank } from "@/utils/gangSubtypeRank"
 import { gangVariantsFor, hasParentGangType } from "@/utils/gangTypeVariants"
 import { createGang } from "@/app/actions/create-gang"
 import { useRouter } from "next/navigation"
@@ -134,6 +134,8 @@ export function CreateGangModal({ onClose }: CreateGangModalProps) {
     () => availableSubtypes.filter(subtype => sameEditionForDisplay(subtype.edition_slug, editionSlug)),
     [availableSubtypes, editionSlug]
   );
+
+  const gangSubtypeRank = useMemo(() => getGangSubtypeRank(editionSlug), [editionSlug]);
 
   const selectedRootGangType = useMemo(
     () => editionGangTypes.find(type => type.gang_type_id === gangType),

--- a/components/gang/gang-edit-modal.tsx
+++ b/components/gang/gang-edit-modal.tsx
@@ -11,7 +11,7 @@ import Modal from '@/components/ui/modal';
 import { toast } from 'sonner';
 import { HexColorPicker } from "react-colorful";
 import { groupAlliancesByType } from "@/utils/allianceRank";
-import { gangSubtypeRank } from "@/utils/gangSubtypeRank";
+import { getGangSubtypeRank } from "@/utils/gangSubtypeRank";
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { deleteGang } from '@/app/actions/delete-gang';
 import { hasAlignment, sameEditionForDisplay } from '@/types/edition';
@@ -199,6 +199,7 @@ export default function GangEditModal({
     sameEditionForDisplay(subtype.edition_slug, editionSlug)
   );
   const showGangSubtypes = editionAvailableSubtypes.length > 0;
+  const gangSubtypeRank = getGangSubtypeRank(editionSlug);
   const showAlignment = hasAlignment(editionSlug);
   // Mirror admin fighter-type forms: clear alignment when the edition lacks it
   const effectiveAlignment = showAlignment ? alignment : '';
@@ -295,23 +296,26 @@ export default function GangEditModal({
     });
   }, [unlockRankModalScroll]);
 
-  const ranksInitializedRef = useRef(false);
-  useEffect(() => {
-    if (!isOpen) {
-      ranksInitializedRef.current = false;
-      setShowRankChangeConfirm(false);
-      unlockRankModalScroll();
-      return;
-    }
-    if (ranksInitializedRef.current) return;
-    if (!existingRanksLoaded) return;
+  // Seeded once per opening, so a refetch mid-edit cannot overwrite unsaved reordering.
+  // Adjusted during render like the form state below; an effect here cascades a render.
+  const [ranksSeeded, setRanksSeeded] = useState(false);
+  if (!isOpen && ranksSeeded) {
+    setRanksSeeded(false);
+    setShowRankChangeConfirm(false);
+  }
+  if (isOpen && !ranksSeeded && existingRanksLoaded) {
+    setRanksSeeded(true);
     setRanks(
       [...existingRanks]
         .sort((a, b) => a.rank - b.rank)
         .map((r) => r.skill_type_id),
     );
-    ranksInitializedRef.current = true;
-  }, [isOpen, existingRanks, existingRanksLoaded, unlockRankModalScroll]);
+  }
+
+  // Closing mid-drag would otherwise leave the scroll parent locked.
+  useEffect(() => {
+    if (!isOpen) unlockRankModalScroll();
+  }, [isOpen, unlockRankModalScroll]);
 
   // Get campaign ID and current allegiance if gang is in a campaign
   const campaignId = campaigns?.[0]?.campaign_id;

--- a/utils/gangSubtypeRank.ts
+++ b/utils/gangSubtypeRank.ts
@@ -1,4 +1,8 @@
-export const gangSubtypeRank: { [key: string]: number } = {
+import type { EditionSlug } from '@/types/edition';
+
+// Ranks 1-9 are the "Unaffiliated" column, 10+ the "Outlaw / Corrupted" one; anything unranked is
+// hidden from both, which is how Outlaw stays out despite the gangs holding it.
+const gangSubtypeRankN23: { [key: string]: number } = {
   "aranthian-aligned": 1,
   "crusading": 2,
   "secundan incursion": 3,
@@ -10,3 +14,23 @@ export const gangSubtypeRank: { [key: string]: number } = {
   "genestealer infected": 13,
   "malstrain corrupted": 14,
 };
+
+// N26 renamed Genestealer Infected to Genestealer Corrupted, which is why these cannot share one
+// map with N23.
+const gangSubtypeRankN26: { [key: string]: number } = {
+  "chaos corrupted": 12,
+  "genestealer corrupted": 13,
+  "malstrain corrupted": 14,
+};
+
+// Keyed by EditionSlug so a new edition is a compile error until it states its own order.
+const GANG_SUBTYPE_RANK_BY_EDITION: Record<EditionSlug, { [key: string]: number }> = {
+  n23: gangSubtypeRankN23,
+  n26: gangSubtypeRankN26,
+};
+
+/** Unset or unrecognised slug gets no ranking rather than another edition's order. */
+export function getGangSubtypeRank(editionSlug?: string | null): { [key: string]: number } {
+  if (!editionSlug) return {};
+  return GANG_SUBTYPE_RANK_BY_EDITION[editionSlug as EditionSlug] ?? {};
+}


### PR DESCRIPTION
…corrupted in n26

## Summary

<!-- What does this PR change, and why? -->

- Fixed so that genestealer corruption work in n26 after name change from infected (still called infected in n23)
- Replaced the ref-plus-effect that seeded Venator skill-set ranks with the file's existing render-phase state sync, clearing the react-hooks/set-state-in-effect error while keeping the scroll-lock cleanup in an effect.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Schema / migration

## How I tested

<!-- What you tested before opening this PR. Example: Opened gang X → bought equipment → credits/rating updated -->

- Checked in the edit gang modal and all options are now displayed
- Tested in create gang and the option Genestealer Corrupted now shows up

## Risk / rollout

<!-- e.g. Low / Medium — any deploy notes beyond database (env vars, feature flags, etc.). -->

- None
