### PR TITLE
Added cron to clean up auth logs and tokens

### DIFF
--- a/supabase/migrations/20260911120000_prune_auth_audit_log_and_refresh_tokens.sql
+++ b/supabase/migrations/20260911120000_prune_auth_audit_log_and_refresh_tokens.sql
@@ -1,0 +1,56 @@
+-- Nothing prunes auth.audit_log_entries (7.1M rows, 2036 MB) or the revoked rows
+-- in auth.refresh_tokens (2.8M rows, 1167 MB): GoTrue has no statement for the
+-- former and its statement for the latter is gated behind GOTRUE_DB_CLEANUP_ENABLED,
+-- which is off on this project.
+--
+-- Deletes are batched because the first runs have ~6.5M and ~2.8M rows to clear.
+-- To drain that backlog, raise the cadence and put it back once runs stop
+-- deleting rows (~65 runs, tracked in cron.job_run_details):
+--
+--   select cron.alter_job((select jobid from cron.job where jobname = 'prune-auth-audit-log'),
+--                         schedule => '* * * * *');
+
+do $$
+begin
+  if exists (select 1 from cron.job where jobname = 'prune-auth-audit-log') then
+    perform cron.unschedule('prune-auth-audit-log');
+  end if;
+end $$;
+
+select cron.schedule(
+  'prune-auth-audit-log',
+  '20 2 * * *',
+  $job$
+    delete from auth.audit_log_entries a
+    using (
+      select id from auth.audit_log_entries
+      where created_at < now() - interval '30 days'
+      limit 100000
+    ) d
+    where a.id = d.id;
+  $job$
+);
+
+do $$
+begin
+  if exists (select 1 from cron.job where jobname = 'prune-revoked-refresh-tokens') then
+    perform cron.unschedule('prune-revoked-refresh-tokens');
+  end if;
+end $$;
+
+-- Revoked only: an unrevoked token is a live session.
+select cron.schedule(
+  'prune-revoked-refresh-tokens',
+  '40 2 * * *',
+  $job$
+    delete from auth.refresh_tokens t
+    using (
+      select id from auth.refresh_tokens
+      where revoked is true
+        and updated_at < now() - interval '7 days'
+      limit 100000
+      for update skip locked
+    ) d
+    where t.id = d.id;
+  $job$
+);


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? -->

- Cron to clean up auth logs and tokens. However, a db update is needed to return the 3GB of disk space to the OS - separate task.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Schema / migration

## How I tested

<!-- What you tested before opening this PR. Example: Opened gang X → bought equipment → credits/rating updated -->

- No test performed on local

## Database

<!-- Delete this section if not applicable. Migrations are not auto-applied — a maintainer must apply them before this PR is merged. -->

- [ ] Migration added under `supabase/migrations/`
- [ ] RPC/SQL function changed: updated both `supabase/migrations/` and the matching file under `supabase/functions/`

### Migration status

<!-- Check one. Migrations are not auto-applied. -->

- [ ] Needs maintainer to apply the migration before merge
- [ ] Migration already applied

## Risk / rollout

<!-- e.g. Low / Medium — any deploy notes beyond database (env vars, feature flags, etc.). -->

- None
