### PR TITLE
Fix missing space after "private" on the restricted gang record page

### DIFF
--- a/app/gang/[id]/forbidden.tsx
+++ b/app/gang/[id]/forbidden.tsx
@@ -11,8 +11,8 @@ export default function GangForbidden() {
         stranger — there is nothing for you here.&rdquo;
       </p>
       <p className="text-white/70 text-sm leading-relaxed">
-        This gang has been set to <strong>private</strong> by its owner. Only
-        the gang&apos;s owner and campaign arbitrators can view it.
+        This gang has been set to <strong>private</strong>{' '}
+        by its owner. Only the gang&apos;s owner and campaign arbitrators can view it.
       </p>
       <Button asChild>
         <Link href="/">Return to the Homepage</Link>


### PR DESCRIPTION
Compiler was collapsing the whitespace between </strong> and "by"; use an explicit {' '} to guarantee it survives JSX compilation.

## Summary

<!-- What does this PR change, and why? -->

-

## Type of change

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Schema / migration

## How I tested

<!-- What you tested before opening this PR. Example: Opened gang X → bought equipment → credits/rating updated -->

- [ ] 
- [ ] 

## Database

<!-- Delete this section if not applicable. Migrations are not auto-applied — a maintainer must apply them before this PR is merged. -->

- [ ] Migration added under `supabase/migrations/`
- [ ] RPC/SQL function changed: updated both `supabase/migrations/` and the matching file under `supabase/functions/`

### Migration status

<!-- Check one. Migrations are not auto-applied. -->

- [ ] Needs maintainer to apply the migration before merge
- [ ] Migration already applied

## Risk / rollout

<!-- e.g. Low / Medium — any deploy notes beyond database (env vars, feature flags, etc.). -->

-
