### PR TITLE
Show Challenge Round button to campaign owners

### DIFF
--- a/components/campaigns/[id]/campaign-page-content.tsx
+++ b/components/campaigns/[id]/campaign-page-content.tsx
@@ -998,7 +998,7 @@ export default function CampaignPageContent({
                 <div className="flex justify-between items-start mb-4">
                   <h2 className="text-xl md:text-2xl font-bold">Battles</h2>
                   <div className="flex gap-2">
-                    {(safePermissions.isOwner || safePermissions.isArbitrator || safePermissions.isAdmin) && (
+                    {safePermissions.canEditCampaign && (
                       <Button
                         variant="outline"
                         onClick={() => battleLogsRef.current?.openChallengeRoundModal()}

--- a/components/campaigns/[id]/campaign-page-content.tsx
+++ b/components/campaigns/[id]/campaign-page-content.tsx
@@ -998,7 +998,7 @@ export default function CampaignPageContent({
                 <div className="flex justify-between items-start mb-4">
                   <h2 className="text-xl md:text-2xl font-bold">Battles</h2>
                   <div className="flex gap-2">
-                    {(safePermissions.isArbitrator || safePermissions.isAdmin) && (
+                    {(safePermissions.isOwner || safePermissions.isArbitrator || safePermissions.isAdmin) && (
                       <Button
                         variant="outline"
                         onClick={() => battleLogsRef.current?.openChallengeRoundModal()}


### PR DESCRIPTION
## Summary

<!-- What does this PR change, and why? -->

- Fixed permission on Challenge Round on the campaign page.  

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Schema / migration

## How I tested

<!-- What you tested before opening this PR. Example: Opened gang X → bought equipment → credits/rating updated -->

- Checked towards existing permission used for Edit Campaign button. 

## Risk / rollout

<!-- e.g. Low / Medium — any deploy notes beyond database (env vars, feature flags, etc.). -->

- None